### PR TITLE
Add OpenAI-compatible /v1/chat/completions endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development
+
+```bash
+cargo build                          # Debug build
+cargo build --release                # Release build (~6MB binary)
+cargo test                           # Run all 32 tests
+cargo test <test_name>               # Run a single test (e.g. cargo test pick_prefers_lowest_utilization)
+cargo fmt --check                    # Format check (CI gate)
+RUSTFLAGS="-Dwarnings" cargo clippy --all-targets  # Lint (CI gate, warnings are errors)
+cargo llvm-cov                       # Coverage report (requires cargo-llvm-cov)
+```
+
+Run the proxy: `./target/release/anthropic-lb config.toml`
+
+## Architecture
+
+Single-file Rust binary (`src/main.rs`, ~2000 lines) with inline tests. No library crate — everything lives in one file with section markers.
+
+### Core Data Flow
+
+```
+Request → IP allowlist check → proxy_key auth → pick_account() → forward to upstream → parse rate-limit headers → persist state
+```
+
+### Key Sections (in source order)
+
+| Section | What it does |
+|---------|-------------|
+| **Config** (`Config`, `AccountConfig`, `UpstreamConfig`) | TOML deserialization structs |
+| **Runtime state** (`AppState`, `Account`, `RateLimitInfo`) | Shared via `Arc<AppState>`, per-account `RwLock<RateLimitInfo>`, atomic counters |
+| **Persistence** (`PersistedState`) | JSON state file at `<config_path>.state.json`, saved after every request and on shutdown |
+| **Handlers** | Four axum handlers: `proxy_handler` (main Anthropic proxy), `upstream_handler` (OpenAI-compatible passthrough), `stats_handler` (`/_stats` JSON), `openai_chat_handler` (OpenAI→Anthropic format translation) |
+| **OpenAI compatibility** (`translate_*`, `StreamContext`) | Translates `/v1/chat/completions` requests/responses between OpenAI and Anthropic formats, including streaming SSE |
+| **Tests** (`mod tests`) | Inline at bottom — unit tests for IP/account selection + integration tests using a mock upstream server |
+
+### Account Selection (`pick_account`)
+
+Two-tier strategy:
+1. **Dynamic capacity**: pick account with lowest `utilization` value (from Anthropic's `anthropic-ratelimit-unified-*` headers). Hard-limited (429) accounts are skipped.
+2. **Round-robin fallback**: when no rate-limit data exists yet.
+
+### Token Type Detection (by prefix)
+
+- `sk-ant-oat*` → `Authorization: Bearer` + injects `anthropic-beta: oauth-2025-04-20` and `anthropic-dangerous-direct-browser-access: true`. The OpenAI-compat handler additionally injects `claude-code-20250219` beta flag.
+- `sk-ant-api*` → `x-api-key` header
+- `passthrough` → forwards caller's auth headers untouched
+
+### Upstream Routing
+
+Named OpenAI-compatible upstreams configured in `[[upstreams]]` TOML sections. Requests to `/upstream/{name}/*` are forwarded with `Authorization: Bearer` API key injection.
+
+## Testing Patterns
+
+Tests use a `spawn_mock_upstream()` helper that starts a real TCP listener returning canned Anthropic-style responses with rate-limit headers. Integration tests bind to `127.0.0.1:0` (random port) and make real HTTP requests through the full axum router with `ConnectInfo<SocketAddr>`.
+
+`test_state_with()` and `test_app()` are the two test fixture builders — the former for unit tests (no HTTP), the latter for integration tests (full router + mock upstream). `test_openai_app()` builds a minimal router for OpenAI-compat handler tests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "toml",
  "tower-http",
  "tracing",
@@ -1275,6 +1276,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ tower-http = { version = "0.6", features = ["trace"] }
 bytes = "1"
 http-body-util = "0.1"
 ipnet = "2.11.0"
+tokio-stream = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::RwLock;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
 
 // ── Config ──────────────────────────────────────────────────────────
@@ -855,6 +856,509 @@ async fn stats_handler(
     .into_response()
 }
 
+// ── OpenAI compatibility ─────────────────────────────────────────────
+
+fn map_stop_reason(reason: &str) -> &'static str {
+    match reason {
+        "end_turn" => "stop",
+        "max_tokens" => "length",
+        "stop_sequence" => "stop",
+        _ => "stop",
+    }
+}
+
+struct StreamContext {
+    id: String,
+    model: String,
+    created: u64,
+}
+
+impl Default for StreamContext {
+    fn default() -> Self {
+        Self {
+            id: format!("chatcmpl-{}", AppState::now_epoch()),
+            model: String::new(),
+            created: AppState::now_epoch(),
+        }
+    }
+}
+
+fn make_openai_chunk(
+    ctx: &StreamContext,
+    delta: serde_json::Value,
+    finish_reason: Option<&str>,
+) -> String {
+    let chunk = serde_json::json!({
+        "id": ctx.id,
+        "object": "chat.completion.chunk",
+        "created": ctx.created,
+        "model": ctx.model,
+        "choices": [{
+            "index": 0,
+            "delta": delta,
+            "finish_reason": finish_reason,
+        }],
+    });
+    format!("data: {}\n\n", chunk)
+}
+
+fn translate_openai_to_anthropic(body: &serde_json::Value) -> serde_json::Value {
+    let mut out = serde_json::Map::new();
+
+    // Model
+    if let Some(model) = body.get("model") {
+        out.insert("model".to_string(), model.clone());
+    }
+
+    // Extract system messages, pass through the rest
+    let mut system_parts: Vec<String> = Vec::new();
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+
+    if let Some(msgs) = body.get("messages").and_then(|m| m.as_array()) {
+        for msg in msgs {
+            let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+            if role == "system" {
+                if let Some(content) = msg.get("content").and_then(|c| c.as_str()) {
+                    system_parts.push(content.to_string());
+                }
+            } else {
+                // Strip "name" field, keep role + content
+                let mut clean = serde_json::Map::new();
+                clean.insert(
+                    "role".to_string(),
+                    serde_json::Value::String(role.to_string()),
+                );
+                if let Some(content) = msg.get("content") {
+                    clean.insert("content".to_string(), content.clone());
+                }
+                messages.push(serde_json::Value::Object(clean));
+            }
+        }
+    }
+
+    if !system_parts.is_empty() {
+        out.insert(
+            "system".to_string(),
+            serde_json::Value::String(system_parts.join("\n\n")),
+        );
+    }
+
+    out.insert("messages".to_string(), serde_json::Value::Array(messages));
+
+    // max_tokens: try max_tokens, then max_completion_tokens, default 4096
+    let max_tokens = body
+        .get("max_tokens")
+        .or_else(|| body.get("max_completion_tokens"))
+        .cloned()
+        .unwrap_or(serde_json::json!(4096));
+    out.insert("max_tokens".to_string(), max_tokens);
+
+    // Direct passthrough params
+    for key in &["temperature", "top_p", "top_k", "stream"] {
+        if let Some(v) = body.get(*key) {
+            out.insert(key.to_string(), v.clone());
+        }
+    }
+
+    // stop -> stop_sequences
+    if let Some(stop) = body.get("stop") {
+        let sequences = if stop.is_array() {
+            stop.clone()
+        } else if let Some(s) = stop.as_str() {
+            serde_json::json!([s])
+        } else {
+            serde_json::json!([])
+        };
+        out.insert("stop_sequences".to_string(), sequences);
+    }
+
+    serde_json::Value::Object(out)
+}
+
+fn translate_anthropic_to_openai(body: &serde_json::Value) -> serde_json::Value {
+    let id = body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("msg_unknown");
+    let model = body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    // Concatenate text content blocks
+    let content = body
+        .get("content")
+        .and_then(|c| c.as_array())
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default();
+
+    let stop_reason = body
+        .get("stop_reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("end_turn");
+
+    let input_tokens = body
+        .pointer("/usage/input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let output_tokens = body
+        .pointer("/usage/output_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    serde_json::json!({
+        "id": format!("chatcmpl-{}", id),
+        "object": "chat.completion",
+        "created": AppState::now_epoch(),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": content,
+            },
+            "finish_reason": map_stop_reason(stop_reason),
+        }],
+        "usage": {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+    })
+}
+
+/// Parse a raw SSE event block and translate to OpenAI format.
+/// Returns None for events that should be skipped (ping, content_block_start, etc.).
+fn translate_sse_event(raw: &str, ctx: &mut StreamContext) -> Option<String> {
+    let mut event_type = String::new();
+    let mut data = String::new();
+
+    for line in raw.lines() {
+        if let Some(val) = line.strip_prefix("event:") {
+            event_type = val.trim().to_string();
+        } else if let Some(val) = line.strip_prefix("data:") {
+            data = val.trim().to_string();
+        }
+    }
+
+    if data.is_empty() {
+        return None;
+    }
+
+    let parsed: serde_json::Value = serde_json::from_str(&data).ok()?;
+
+    match event_type.as_str() {
+        "message_start" => {
+            if let Some(msg) = parsed.get("message") {
+                if let Some(id) = msg.get("id").and_then(|v| v.as_str()) {
+                    ctx.id = format!("chatcmpl-{}", id);
+                }
+                if let Some(model) = msg.get("model").and_then(|v| v.as_str()) {
+                    ctx.model = model.to_string();
+                }
+            }
+            Some(make_openai_chunk(
+                ctx,
+                serde_json::json!({"role": "assistant"}),
+                None,
+            ))
+        }
+        "content_block_delta" => {
+            let text = parsed
+                .pointer("/delta/text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if text.is_empty() {
+                return None;
+            }
+            Some(make_openai_chunk(
+                ctx,
+                serde_json::json!({"content": text}),
+                None,
+            ))
+        }
+        "message_delta" => {
+            let stop_reason = parsed
+                .pointer("/delta/stop_reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("end_turn");
+            Some(make_openai_chunk(
+                ctx,
+                serde_json::json!({}),
+                Some(map_stop_reason(stop_reason)),
+            ))
+        }
+        "message_stop" => Some("data: [DONE]\n\n".to_string()),
+        _ => None, // ping, content_block_start, content_block_stop
+    }
+}
+
+async fn openai_chat_handler(
+    State(state): State<Arc<AppState>>,
+    axum::extract::ConnectInfo(client_addr): axum::extract::ConnectInfo<SocketAddr>,
+    req: Request<Body>,
+) -> Response {
+    let client_ip = client_addr.ip();
+
+    // IP allowlist check
+    if !state.is_ip_allowed(&client_ip) {
+        warn!(client = %client_ip, "rejected: IP not in allowlist");
+        return (StatusCode::FORBIDDEN, "forbidden").into_response();
+    }
+
+    // Proxy auth
+    if let Some(ref key) = state.proxy_key {
+        let provided = req.headers().get("x-api-key").and_then(|v| v.to_str().ok());
+        if provided != Some(key.as_str()) {
+            warn!(client = %client_ip, "rejected: invalid or missing proxy key");
+            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+        }
+    }
+
+    let (parts, body) = req.into_parts();
+    let body_bytes = match axum::body::to_bytes(body, 10 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(e) => {
+            error!("failed to read request body: {e}");
+            return (StatusCode::BAD_REQUEST, "bad request body").into_response();
+        }
+    };
+
+    let openai_body: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("failed to parse request JSON: {e}");
+            return (StatusCode::BAD_REQUEST, "invalid JSON").into_response();
+        }
+    };
+
+    let is_streaming = openai_body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let model = openai_body
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let anthropic_body = translate_openai_to_anthropic(&openai_body);
+
+    let n = state.accounts.len();
+    for _attempt in 0..n {
+        let idx = match state.pick_account().await {
+            Some(i) => i,
+            None => {
+                warn!("all accounts rate-limited");
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "all upstream accounts rate-limited",
+                )
+                    .into_response();
+            }
+        };
+
+        let acct = &state.accounts[idx];
+        let url = format!("{}/v1/messages", state.upstream);
+
+        let mut headers = parts.headers.clone();
+        headers.remove("host");
+        headers.remove("authorization");
+        headers.remove("x-api-key");
+
+        // Inject required Anthropic headers
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+
+        // Auth injection with claude-code beta header for OAuth
+        if !acct.passthrough {
+            if acct.token.starts_with("sk-ant-api") {
+                headers.insert("x-api-key", HeaderValue::from_str(&acct.token).unwrap());
+            } else if acct.token.starts_with("sk-ant-oat") {
+                headers.insert(
+                    "authorization",
+                    HeaderValue::from_str(&format!("Bearer {}", acct.token)).unwrap(),
+                );
+                headers.insert(
+                    "anthropic-dangerous-direct-browser-access",
+                    HeaderValue::from_static("true"),
+                );
+                // OAuth tokens need both beta flags for non-Claude-Code clients
+                let existing_beta = headers
+                    .get("anthropic-beta")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                let mut betas: Vec<&str> = if existing_beta.is_empty() {
+                    vec![]
+                } else {
+                    existing_beta.split(',').collect()
+                };
+                for flag in &["oauth-2025-04-20", "claude-code-20250219"] {
+                    if !betas.iter().any(|b| b.trim() == *flag) {
+                        betas.push(flag);
+                    }
+                }
+                headers.insert(
+                    "anthropic-beta",
+                    HeaderValue::from_str(&betas.join(",")).unwrap(),
+                );
+            } else {
+                headers.insert("x-api-key", HeaderValue::from_str(&acct.token).unwrap());
+            }
+        }
+
+        let upstream_req = state
+            .client
+            .request(reqwest::Method::POST, &url)
+            .headers(reqwest_headers(&headers))
+            .body(anthropic_body.to_string());
+
+        let mut resp = match upstream_req.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                error!(account = acct.name, "upstream request failed: {e}");
+                continue;
+            }
+        };
+
+        let status = resp.status();
+        acct.requests.fetch_add(1, Ordering::Relaxed);
+        state.update_rate_info(idx, resp.headers()).await;
+
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            state.mark_hard_limited(idx, resp.headers()).await;
+            state.save_state().await;
+            info!(account = acct.name, "got 429, rotating to next account");
+            continue;
+        }
+
+        state.save_state().await;
+
+        {
+            let info = acct.rate_info.read().await;
+            info!(
+                client = %client_ip,
+                model = %model,
+                account = acct.name,
+                status = status.as_u16(),
+                utilization = ?info.utilization,
+                openai_compat = true,
+                stream = is_streaming,
+                "proxied (openai-compat)"
+            );
+        }
+
+        // Non-2xx: return error as-is (not SSE even if streaming was requested)
+        if !status.is_success() {
+            let error_body = resp.bytes().await.unwrap_or_default();
+            return Response::builder()
+                .status(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY))
+                .header("content-type", "application/json")
+                .body(Body::from(error_body))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+                });
+        }
+
+        if is_streaming {
+            let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
+
+            tokio::spawn(async move {
+                let mut buffer = String::new();
+                let mut ctx = StreamContext::default();
+
+                while let Ok(Some(chunk)) = resp.chunk().await {
+                    buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                    while let Some(pos) = buffer.find("\n\n") {
+                        let event = buffer[..pos].to_string();
+                        buffer = buffer[pos + 2..].to_string();
+
+                        if event.trim().is_empty() {
+                            continue;
+                        }
+
+                        if let Some(translated) = translate_sse_event(&event, &mut ctx) {
+                            if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {
+                                return; // client disconnected
+                            }
+                        }
+                    }
+                }
+
+                // Process any remaining data in buffer
+                if !buffer.trim().is_empty() {
+                    if let Some(translated) = translate_sse_event(&buffer, &mut ctx) {
+                        let _ = tx.send(Ok(bytes::Bytes::from(translated))).await;
+                    }
+                }
+
+                // Ensure [DONE] is always sent
+                let _ = tx.send(Ok(bytes::Bytes::from("data: [DONE]\n\n"))).await;
+            });
+
+            return Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "text/event-stream")
+                .header("cache-control", "no-cache")
+                .header("connection", "keep-alive")
+                .body(Body::from_stream(ReceiverStream::new(rx)))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+                });
+        }
+
+        // Non-streaming: buffer, translate, return
+        let resp_bytes = match resp.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                error!("failed to read upstream response: {e}");
+                return (StatusCode::BAD_GATEWAY, "failed to read upstream response")
+                    .into_response();
+            }
+        };
+
+        let anthropic_resp: serde_json::Value = match serde_json::from_slice(&resp_bytes) {
+            Ok(v) => v,
+            Err(_) => {
+                return Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "application/json")
+                    .body(Body::from(resp_bytes))
+                    .unwrap_or_else(|_| {
+                        (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+                    });
+            }
+        };
+
+        let openai_resp = translate_anthropic_to_openai(&anthropic_resp);
+        return axum::Json(openai_resp).into_response();
+    }
+
+    (StatusCode::TOO_MANY_REQUESTS, "exhausted all accounts").into_response()
+}
+
+/// Convert axum HeaderMap to reqwest HeaderMap.
+fn reqwest_headers(headers: &axum::http::HeaderMap) -> reqwest::header::HeaderMap {
+    let mut out = reqwest::header::HeaderMap::new();
+    for (k, v) in headers.iter() {
+        if let Ok(name) = reqwest::header::HeaderName::from_bytes(k.as_str().as_bytes()) {
+            if let Ok(val) = reqwest::header::HeaderValue::from_bytes(v.as_bytes()) {
+                out.insert(name, val);
+            }
+        }
+    }
+    out
+}
+
 // ── Main ────────────────────────────────────────────────────────────
 
 #[tokio::main]
@@ -963,6 +1467,10 @@ async fn main() {
 
     let app = Router::new()
         .route("/_stats", axum::routing::get(stats_handler))
+        .route(
+            "/v1/chat/completions",
+            axum::routing::post(openai_chat_handler),
+        )
         .route("/upstream/{name}/{*rest}", any(upstream_handler))
         .fallback(any(proxy_handler))
         .with_state(state.clone());
@@ -1128,6 +1636,10 @@ mod tests {
 
         let app = Router::new()
             .route("/_stats", axum::routing::get(stats_handler))
+            .route(
+                "/v1/chat/completions",
+                axum::routing::post(openai_chat_handler),
+            )
             .route("/upstream/{name}/{*rest}", any(upstream_handler))
             .fallback(any(proxy_handler))
             .with_state(state.clone());
@@ -1464,5 +1976,460 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+    }
+
+    // ── Unit: OpenAI request translation ────────────────────────────
+
+    #[test]
+    fn translate_request_extracts_system() {
+        let req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hello"}
+            ],
+            "max_tokens": 1024
+        });
+        let result = translate_openai_to_anthropic(&req);
+        assert_eq!(result["system"], "You are helpful");
+        let msgs = result["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0]["role"], "user");
+        assert_eq!(msgs[0]["content"], "Hello");
+    }
+
+    #[test]
+    fn translate_request_multi_system_concat() {
+        let req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [
+                {"role": "system", "content": "Rule 1"},
+                {"role": "system", "content": "Rule 2"},
+                {"role": "user", "content": "Hello"}
+            ],
+            "max_tokens": 100
+        });
+        let result = translate_openai_to_anthropic(&req);
+        assert_eq!(result["system"], "Rule 1\n\nRule 2");
+    }
+
+    #[test]
+    fn translate_request_no_system() {
+        let req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ],
+            "max_tokens": 100
+        });
+        let result = translate_openai_to_anthropic(&req);
+        assert!(result.get("system").is_none());
+    }
+
+    #[test]
+    fn translate_request_default_max_tokens() {
+        let req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let result = translate_openai_to_anthropic(&req);
+        assert_eq!(result["max_tokens"], 4096);
+    }
+
+    #[test]
+    fn translate_request_stop_to_stop_sequences() {
+        let req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 100,
+            "stop": ["END", "STOP"]
+        });
+        let result = translate_openai_to_anthropic(&req);
+        let seqs = result["stop_sequences"].as_array().unwrap();
+        assert_eq!(seqs.len(), 2);
+        assert_eq!(seqs[0], "END");
+        assert_eq!(seqs[1], "STOP");
+    }
+
+    #[test]
+    fn translate_request_passthrough_params() {
+        let req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 512,
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "stream": true
+        });
+        let result = translate_openai_to_anthropic(&req);
+        assert_eq!(result["model"], "claude-sonnet-4-20250514");
+        assert_eq!(result["max_tokens"], 512);
+        assert_eq!(result["temperature"], 0.7);
+        assert_eq!(result["top_p"], 0.9);
+        assert_eq!(result["stream"], true);
+    }
+
+    #[test]
+    fn translate_request_strips_name_field() {
+        let req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [
+                {"role": "user", "content": "Hello", "name": "bob"}
+            ],
+            "max_tokens": 100
+        });
+        let result = translate_openai_to_anthropic(&req);
+        let msgs = result["messages"].as_array().unwrap();
+        assert!(msgs[0].get("name").is_none());
+    }
+
+    // ── Unit: OpenAI response translation ───────────────────────────
+
+    #[test]
+    fn translate_response_basic() {
+        let resp = serde_json::json!({
+            "id": "msg_abc123",
+            "type": "message",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "model": "claude-sonnet-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        });
+        let result = translate_anthropic_to_openai(&resp);
+        assert_eq!(result["id"], "chatcmpl-msg_abc123");
+        assert_eq!(result["object"], "chat.completion");
+        assert_eq!(result["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(result["choices"][0]["message"]["content"], "Hello!");
+        assert_eq!(result["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[test]
+    fn translate_response_usage_mapping() {
+        let resp = serde_json::json!({
+            "id": "msg_x",
+            "content": [{"type": "text", "text": "ok"}],
+            "model": "claude-sonnet-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 25, "output_tokens": 15}
+        });
+        let result = translate_anthropic_to_openai(&resp);
+        assert_eq!(result["usage"]["prompt_tokens"], 25);
+        assert_eq!(result["usage"]["completion_tokens"], 15);
+        assert_eq!(result["usage"]["total_tokens"], 40);
+    }
+
+    #[test]
+    fn translate_response_stop_reason_mapping() {
+        assert_eq!(map_stop_reason("end_turn"), "stop");
+        assert_eq!(map_stop_reason("max_tokens"), "length");
+        assert_eq!(map_stop_reason("stop_sequence"), "stop");
+        assert_eq!(map_stop_reason("unknown"), "stop");
+    }
+
+    // ── Unit: SSE event translation ─────────────────────────────────
+
+    #[test]
+    fn translate_sse_message_start() {
+        let mut ctx = StreamContext::default();
+        let raw = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"model\":\"claude-sonnet-4-20250514\",\"role\":\"assistant\"}}";
+        let result = translate_sse_event(raw, &mut ctx).unwrap();
+        assert!(result.starts_with("data: "));
+        assert_eq!(ctx.id, "chatcmpl-msg_test");
+        assert_eq!(ctx.model, "claude-sonnet-4-20250514");
+        let chunk: serde_json::Value =
+            serde_json::from_str(result.strip_prefix("data: ").unwrap().trim()).unwrap();
+        assert_eq!(chunk["choices"][0]["delta"]["role"], "assistant");
+    }
+
+    #[test]
+    fn translate_sse_content_delta() {
+        let mut ctx = StreamContext {
+            id: "chatcmpl-test".to_string(),
+            model: "claude-sonnet-4-20250514".to_string(),
+            ..Default::default()
+        };
+        let raw = "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello world\"}}";
+        let result = translate_sse_event(raw, &mut ctx).unwrap();
+        let chunk: serde_json::Value =
+            serde_json::from_str(result.strip_prefix("data: ").unwrap().trim()).unwrap();
+        assert_eq!(chunk["choices"][0]["delta"]["content"], "Hello world");
+        assert!(chunk["choices"][0]["finish_reason"].is_null());
+    }
+
+    #[test]
+    fn translate_sse_message_delta() {
+        let mut ctx = StreamContext {
+            id: "chatcmpl-test".to_string(),
+            ..Default::default()
+        };
+        let raw = "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}";
+        let result = translate_sse_event(raw, &mut ctx).unwrap();
+        let chunk: serde_json::Value =
+            serde_json::from_str(result.strip_prefix("data: ").unwrap().trim()).unwrap();
+        assert_eq!(chunk["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[test]
+    fn translate_sse_message_stop() {
+        let mut ctx = StreamContext::default();
+        let raw = "event: message_stop\ndata: {\"type\":\"message_stop\"}";
+        let result = translate_sse_event(raw, &mut ctx).unwrap();
+        assert_eq!(result, "data: [DONE]\n\n");
+    }
+
+    #[test]
+    fn translate_sse_skips_ping() {
+        let mut ctx = StreamContext::default();
+        let raw = "event: ping\ndata: {\"type\":\"ping\"}";
+        assert!(translate_sse_event(raw, &mut ctx).is_none());
+    }
+
+    // ── Integration: OpenAI-compat handler ──────────────────────────
+
+    /// Mock that returns Anthropic /v1/messages format (non-streaming)
+    async fn mock_anthropic_handler(req: Request<Body>) -> Response {
+        let has_auth =
+            req.headers().contains_key("x-api-key") || req.headers().contains_key("authorization");
+        if !has_auth {
+            return (StatusCode::UNAUTHORIZED, "missing auth").into_response();
+        }
+
+        let mut resp = axum::Json(serde_json::json!({
+            "id": "msg_integration",
+            "type": "message",
+            "content": [{"type": "text", "text": "Hello from Claude"}],
+            "model": "claude-sonnet-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        }))
+        .into_response();
+
+        let headers = resp.headers_mut();
+        headers.insert(
+            "anthropic-ratelimit-unified-representative-claim",
+            HeaderValue::from_static("five_hour"),
+        );
+        headers.insert(
+            "anthropic-ratelimit-unified-5h-utilization",
+            HeaderValue::from_static("0.30"),
+        );
+        resp
+    }
+
+    /// Mock that returns Anthropic SSE streaming format
+    async fn mock_anthropic_streaming_handler(req: Request<Body>) -> Response {
+        let has_auth =
+            req.headers().contains_key("x-api-key") || req.headers().contains_key("authorization");
+        if !has_auth {
+            return (StatusCode::UNAUTHORIZED, "missing auth").into_response();
+        }
+
+        let events = [
+            "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-20250514\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n",
+            "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n\n",
+            "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n",
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+        ];
+
+        let body = events.join("");
+        Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "text/event-stream")
+            .body(Body::from(body))
+            .unwrap()
+    }
+
+    /// Build test app with separate handlers for streaming vs non-streaming
+    fn test_openai_app(upstream_url: &str, proxy_key: Option<String>) -> (Router, Arc<AppState>) {
+        let accounts = vec![
+            make_account("acct-a", "sk-ant-api-test-aaa"),
+            make_account("acct-b", "sk-ant-api-test-bbb"),
+        ];
+
+        let state = Arc::new(AppState {
+            client: Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .unwrap(),
+            upstream: upstream_url.to_string(),
+            accounts,
+            robin: AtomicUsize::new(0),
+            cooldown: Duration::from_secs(60),
+            state_path: PathBuf::from("/tmp/anthropic-lb-openai-test.state.json"),
+            proxy_key,
+            allowed_ips: vec![],
+            upstreams: vec![],
+        });
+
+        let app = Router::new()
+            .route(
+                "/v1/chat/completions",
+                axum::routing::post(openai_chat_handler),
+            )
+            .with_state(state.clone());
+
+        (app, state)
+    }
+
+    #[tokio::test]
+    async fn openai_chat_non_streaming() {
+        // Spawn a mock that serves /v1/messages with Anthropic format
+        let mock_app = Router::new().fallback(any(mock_anthropic_handler));
+        let mock_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = mock_listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(mock_listener, mock_app).await.unwrap();
+        });
+
+        let mock_url = format!("http://{}", mock_addr);
+        let (app, _state) = test_openai_app(&mock_url, None);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let client = Client::new();
+        let resp = client
+            .post(format!("http://{}/v1/chat/completions", addr))
+            .header("content-type", "application/json")
+            .body(r#"{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}],"max_tokens":100}"#)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["object"], "chat.completion");
+        assert!(body["id"].as_str().unwrap().starts_with("chatcmpl-"));
+        assert_eq!(
+            body["choices"][0]["message"]["content"],
+            "Hello from Claude"
+        );
+        assert_eq!(body["choices"][0]["finish_reason"], "stop");
+        assert_eq!(body["usage"]["prompt_tokens"], 10);
+        assert_eq!(body["usage"]["completion_tokens"], 5);
+        assert_eq!(body["usage"]["total_tokens"], 15);
+    }
+
+    #[tokio::test]
+    async fn openai_chat_streaming() {
+        let mock_app = Router::new().fallback(any(mock_anthropic_streaming_handler));
+        let mock_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = mock_listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(mock_listener, mock_app).await.unwrap();
+        });
+
+        let mock_url = format!("http://{}", mock_addr);
+        let (app, _state) = test_openai_app(&mock_url, None);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let client = Client::new();
+        let resp = client
+            .post(format!("http://{}/v1/chat/completions", addr))
+            .header("content-type", "application/json")
+            .body(r#"{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"Hello"}],"max_tokens":100,"stream":true}"#)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "text/event-stream"
+        );
+
+        let body = resp.text().await.unwrap();
+
+        // Parse SSE events from response
+        let mut chunks: Vec<serde_json::Value> = Vec::new();
+        let mut got_done = false;
+        for line in body.lines() {
+            if line == "data: [DONE]" {
+                got_done = true;
+            } else if let Some(data) = line.strip_prefix("data: ") {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
+                    chunks.push(v);
+                }
+            }
+        }
+
+        assert!(got_done, "should have [DONE] sentinel");
+        assert!(
+            chunks.len() >= 3,
+            "expected at least 3 chunks (role + content + finish), got {}",
+            chunks.len()
+        );
+
+        // First chunk: role
+        assert_eq!(chunks[0]["choices"][0]["delta"]["role"], "assistant");
+        assert_eq!(chunks[0]["object"], "chat.completion.chunk");
+        assert!(chunks[0]["id"].as_str().unwrap().starts_with("chatcmpl-"));
+
+        // Content chunks
+        let content_chunks: Vec<&str> = chunks
+            .iter()
+            .filter_map(|c| c["choices"][0]["delta"]["content"].as_str())
+            .collect();
+        assert_eq!(content_chunks.join(""), "Hello world");
+
+        // Last data chunk: finish_reason
+        let last = chunks.last().unwrap();
+        assert_eq!(last["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[tokio::test]
+    async fn openai_chat_rejects_missing_auth() {
+        let mock_app = Router::new().fallback(any(mock_anthropic_handler));
+        let mock_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = mock_listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(mock_listener, mock_app).await.unwrap();
+        });
+
+        let mock_url = format!("http://{}", mock_addr);
+        let (app, _state) = test_openai_app(&mock_url, Some("secret-key".to_string()));
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let client = Client::new();
+        let resp = client
+            .post(format!("http://{}/v1/chat/completions", addr))
+            .header("content-type", "application/json")
+            .body(r#"{"model":"test","messages":[{"role":"user","content":"hi"}],"max_tokens":1}"#)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `POST /v1/chat/completions` that translates OpenAI chat format to/from Anthropic `/v1/messages`
- Supports both streaming (SSE event-by-event translation via spawned task + mpsc channel) and non-streaming responses
- Injects `claude-code-20250219` beta header for OAuth tokens so non-Claude-Code clients (Perplexica, Open WebUI, LangChain) aren't rejected
- 18 new tests (13 unit + 5 integration), bringing total to 32

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets` passes (warnings as errors)
- [x] `cargo test` — 32/32 pass
- [x] `cargo build --release` succeeds
- [ ] Manual: point Perplexica at proxy, verify chat completions work
- [ ] Manual: verify existing native Anthropic clients still work (fallback handler unchanged)