### PR TITLE
Add release CI pipeline with cross-platform builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test
+      - name: Check packaging
+        run: cargo publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,155 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  id-token: write
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          cargo_version="${{ steps.version.outputs.version }}"
+          if [ "$tag_version" != "$cargo_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match Cargo.toml version $cargo_version"
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        env:
+          RUSTFLAGS: -Dwarnings
+        run: cargo clippy --all-targets
+
+      - name: Test
+        run: cargo test
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            cross: false
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            cross: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+          sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
+
+      - name: Build
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Strip binary
+        run: |
+          binary="target/${{ matrix.target }}/release/anthropic-lb"
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            aarch64-linux-gnu-strip "$binary"
+          else
+            strip "$binary"
+          fi
+
+      - name: Package
+        run: |
+          version="${{ needs.validate.outputs.version }}"
+          archive="anthropic-lb-v${version}-${{ matrix.target }}.tar.gz"
+          tar -czf "$archive" -C "target/${{ matrix.target }}/release" anthropic-lb
+          shasum -a 256 "$archive" > "${archive}.sha256"
+          echo "ARCHIVE=$archive" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: anthropic-lb-${{ matrix.target }}
+          path: |
+            anthropic-lb-*.tar.gz
+            anthropic-lb-*.tar.gz.sha256
+
+  release:
+    name: Release
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io
+        id: crates-io
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io.outputs.token }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.sha256


### PR DESCRIPTION
## Summary

- **New** `.github/workflows/release.yml` — tag-triggered (`v*.*.*`) release pipeline with 3 jobs:
  - **validate**: version tag ↔ Cargo.toml consistency check + full CI (fmt, clippy, tests)
  - **build**: 4-target matrix (x86_64-linux, aarch64-linux via cross, x86_64-darwin, aarch64-darwin) — stripped, archived with SHA256 checksums
  - **release**: crates.io Trusted Publishing (OIDC, no secrets) + GitHub Release with all binaries attached
- **Updated** `.github/workflows/ci.yml` — added `cargo publish --dry-run` to catch packaging issues on every PR

## Prerequisites

Trusted Publishing must be configured on crates.io for `27b-io/anthropic-lb` + `release.yml` workflow (no `CARGO_REGISTRY_TOKEN` secret needed).

## Test plan

- [ ] CI passes on this PR (the `cargo publish --dry-run` step validates packaging)
- [ ] Push a test tag like `v0.1.1-rc.1` to verify the release pipeline end-to-end
- [ ] Confirm GitHub Release appears with 4 platform binaries
- [ ] Confirm crate publishes to crates.io