### PR TITLE
ci: add code scanning via clippy SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -24,6 +26,19 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy --all-targets
+      - name: Clippy SARIF
+        if: always()
+        run: |
+          cargo install clippy-sarif sarif-fmt || true
+          cargo clippy --all-targets --message-format=json |
+            clippy-sarif | tee clippy-results.sarif | sarif-fmt
+        continue-on-error: true
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: clippy-results.sarif
+          wait-for-processing: true
 
   test:
     name: Test


### PR DESCRIPTION
## Summary

- Adds clippy SARIF output + upload to satisfy GitHub Code Scanning branch protection
- Runs alongside existing clippy lint step
- Required to unblock PR merges

## Test plan

- [x] CI workflow syntax valid
- [ ] Verify SARIF upload succeeds on first run