### PR TITLE
fix: Dockerfile CMD uses positional arg, not --config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY --from=builder /app/target/release/anthropic-lb /usr/local/bin/
 USER 1000
 EXPOSE 8082
 ENTRYPOINT ["anthropic-lb"]
-CMD ["--config", "/etc/anthropic-lb/config.toml"]
+CMD ["/etc/anthropic-lb/config.toml"]


### PR DESCRIPTION
## Summary
- The binary takes config path as `argv[1]` (positional), not `--config` flag
- `CMD ["--config", "/etc/anthropic-lb/config.toml"]` would fail at runtime

## Test plan
- [x] Verified `std::env::args().nth(1)` is how config is parsed (src/main.rs:3221)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container startup configuration to use direct path argument instead of flag-based configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->