### PR TITLE
feat: support multiple operator client IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Named OpenAI-compatible upstreams configured in `[[upstreams]]` TOML sections. R
 | `client_names` | map? | {} | IP→client name mapping |
 | `client_budgets` | map? | {} | client_id→daily token limit |
 | `client_utilization_limits` | map? | {} | client_id→utilization ceiling (0.0–1.0) |
-| `operator` | string? | none | Client ID that bypasses all enforcement |
+| `operators` | string[]? | [] | Client IDs that bypass all enforcement |
 | `emergency_threshold` | f64? | 0.95 | All-accounts utilization threshold for emergency brake |
 | `redis_url` | string? | none | Redis/Valkey URL for distributed state (`redis://` or `rediss://`) |
 | `accounts[].name` | string | required | Account display name |

--- a/config.toml.example
+++ b/config.toml.example
@@ -13,9 +13,9 @@ probe_interval_secs = 300
 # Supports individual IPs and CIDR ranges. Omit or leave empty to allow all.
 # allowed_ips = ["100.64.0.0/10", "10.0.0.0/8", "1.2.3.4"]
 
-# Operator: this client_id is never throttled by utilization limits, budget limits,
-# or the emergency brake. Identity resolved via client_names IP map (not spoofable via header).
-# operator = "ray"
+# Operators: these client_ids are never throttled by utilization limits, budget limits,
+# or the emergency brake. Identity resolved via x-client-id header or client_names IP map.
+# operators = ["ray", "openclaw", "claude"]
 
 # Per-client utilization limits: clients are 429'd when ALL model-compatible accounts
 # exceed their configured limit. Values must be 0.0-1.0.


### PR DESCRIPTION
## Summary

- `operator: Option<String>` → `operators: Vec<String>` — multiple client IDs can now bypass budget/utilization/emergency enforcement
- Emergency brake at 0.88 previously locked out ALL sessions except one operator. Now openclaw, claude, and ray can all be operators while gastown gets braked
- Documents known limitations in README Security section (client ID spoofing within trust boundary, model-blind emergency brake)

**BREAKING**: Config field renamed from `operator` to `operators` (array).

## Test plan

- [x] New `is_operator_supports_multiple_operators` test verifies 3 operators + negative cases
- [x] All 218 tests pass, fmt clean, clippy clean
- [x] Config deser test updated for array syntax


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now supports multiple operator IDs for enforcement bypass, replacing single operator ID support.
  * Added new per-account configuration options for authentication tokens and model allowlists.

* **Documentation**
  * Updated guides to reflect multi-operator bypass functionality.
  * Added known limitations notes regarding client ID identification and traffic management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->