### PR TITLE
feat: waste-risk routing for 7d quota maximization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -842,7 +842,7 @@ fn waste_risk(util: f64, reset_epoch: Option<u64>, now_epoch: u64) -> f64 {
         Some(r) if r > now_epoch + WASTE_RISK_MIN_REMAINING => r,
         _ => return 0.0,
     };
-    let remaining_fraction = ((reset - now_epoch) as f64 / TOTAL_7D_SECS).max(0.001);
+    let remaining_fraction = (reset - now_epoch) as f64 / TOTAL_7D_SECS;
     let unused = (1.0 - util).max(0.0);
     (unused / remaining_fraction).min(10.0)
 }
@@ -1052,7 +1052,7 @@ impl AppState {
                     util
                 } else if let Some(remaining) = info.remaining_tokens {
                     let limit = info.limit_tokens.unwrap_or(1_000_000);
-                    1.0 - (remaining as f64 / limit as f64)
+                    (1.0 - (remaining as f64 / limit as f64)).clamp(0.0, 1.0)
                 } else {
                     0.5
                 }


### PR DESCRIPTION
## Summary

- Waste-risk weighted routing: `weight = waste_risk × (1 - gate_5h)` prioritizes accounts with unused 7d quota nearing reset
- Per-claim 7d utilization via `claims_7d: HashMap<String, ClaimWindowData>` for model-aware routing (sonnet vs opus sub-budgets)
- `resolve_7d_claim()` with model-family lookup and fallback to general "seven_day" claim
- `waste_risk()`: `unused_quota / remaining_time_fraction`, clamped [0, 10], zero when reset stale/missing/<60s
- Includes P1 bug fixes from expert panel review:
  - Removed `.max(0.001)` floor from `remaining_fraction` (suppressed differentiation under 10 min)
  - Added `.clamp(0.0, 1.0)` to `pick_account` legacy utilization fallback

## Test plan

- [x] 237 tests pass (207 unit + 18 config + 12 dependency)
- [x] 8 waste_risk edge case tests, 4 resolve_7d_claim tests
- [x] pick_account tests for waste-risk preference, 5h dampening, rejected claims, all-throttled degradation
- [x] fmt clean, clippy clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tightened emergency brake threshold for more responsive rate limiting control.
  * Enhanced 7-day budget resolution with model-aware logic and waste risk quantification.
  * Improved rate distribution routing with refined gating and weight-based candidate selection.
  * Added visibility metrics (gate status, waste risk, allocation weight) to logs and rate information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->