### PR TITLE
fix: 429 recovery and burst rate-limit detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2405,7 +2405,11 @@ async fn proxy_handler(
                 let mut beta_flags: Vec<&str> = if existing_beta.is_empty() {
                     vec![]
                 } else {
-                    existing_beta.split(',').map(|s| s.trim()).collect()
+                    existing_beta
+                        .split(',')
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                        .collect()
                 };
                 for flag in &["oauth-2025-04-20", "claude-code-20250219"] {
                     if !beta_flags.contains(flag) {
@@ -3431,7 +3435,11 @@ async fn openai_chat_handler(
                 let mut betas: Vec<&str> = if existing_beta.is_empty() {
                     vec![]
                 } else {
-                    existing_beta.split(',').map(|s| s.trim()).collect()
+                    existing_beta
+                        .split(',')
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                        .collect()
                 };
                 for flag in &["oauth-2025-04-20", "claude-code-20250219"] {
                     if !betas.contains(flag) {
@@ -3942,7 +3950,12 @@ async fn main() {
         .parse()
         .unwrap_or_else(|e| panic!("invalid listen address: {e}"));
 
-    info!(%addr, "anthropic-lb starting");
+    info!(
+        %addr,
+        rate_limit_cooldown_secs = cooldown.as_secs(),
+        configured = ?config.rate_limit_cooldown_secs,
+        "anthropic-lb starting"
+    );
 
     let listener = tokio::net::TcpListener::bind(addr)
         .await


### PR DESCRIPTION
## Summary

- **Root cause fix**: Inject `claude-code-20250219` beta flag for OAuth tokens in proxy handler — missing flag caused Anthropic to route requests to a tighter rate-limit bucket (`org_level_disabled` overage rejection)
- **Stale-after-hard-limit recovery**: When rate-limit data was last updated before the hard limit was set, treat utilization as unknown (0.5) and ignore stale rejected claims — prevents accounts from staying permanently locked out after a 429 expires
- **Burst vs capacity 429 classification**: Detect transient burst/RPM 429s (`x-should-retry: true`, no `retry-after`, no rate headers) and apply exponential backoff (5s→10s→20s→40s→60s) instead of flat 60s lockout — prevents total blackouts when all accounts hit burst limits simultaneously
- **Hardened 429 diagnostics**: Consolidated debug logging with header redaction, body truncation, and extracted `log_429_details()` helper
- **Fix exact-match beta deduplication**: Switched from substring `.contains()` to split+trim Vec matching to prevent false positives on prefix collisions
- **Fix `last_updated` advancing on empty responses**: Only stamp `last_updated` when rate headers are actually parsed, preventing false "fresh data" after 5xx responses

## Test plan

- [x] 217 tests pass (`cargo test`)
- [x] `cargo fmt --check` clean
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` clean
- [x] 4 new unit tests: `detects_burst_429`, `capacity_429_poisons_state`, `burst_exponential_backoff`, `retry_after_overrides_default`
- [x] Deployed and verified in production — requests routing successfully across all 3 accounts