### PR TITLE
feat: log probe weights and deduplicate probes across pods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Usage-aware load balancing proxy for Claude Code
 
-### Anthropic Rate Limit Windows (Unified Headers)
+## Anthropic Rate Limit Windows (Unified Headers)
 
 The proxy reads utilization from `anthropic-ratelimit-unified-*` response headers. These govern subscription-based access (Claude Code, Pro, Max plans) and are separate from the per-minute token bucket limits documented at platform.claude.com.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Production runs on the **mem** k8s cluster (`kubectl --context mem`), namespace 
 
 | What | Where |
 |------|-------|
-| Flux manifests | `~/code/27b.io/fleet-infra/apps/mem/anthropic-lb/` |
+| Flux manifests | `27b-io/fleet-infra` repo, `apps/mem/anthropic-lb/` |
 | Config template | `externalsecret.yaml` (ExternalSecret → 1Password tokens + redis password) |
 | Image policy | Flux `imagepolicy` auto-updates digest from `ghcr.io/27b-io/anthropic-lb:main` |
 | Replicas | 2 (RollingUpdate, maxUnavailable=0) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,14 @@
-# CLAUDE.md
+# AnthropicLB
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Usage-aware load balancing proxy for Claude Code
+
+### Anthropic Rate Limit Windows (Unified Headers)
+
+The proxy reads utilization from `anthropic-ratelimit-unified-*` response headers. These govern subscription-based access (Claude Code, Pro, Max plans) and are separate from the per-minute token bucket limits documented at platform.claude.com.
+
+**Two windows:**
+- **5h window** — Fixed-duration window. Starts when usage begins, resets at a specific time (hard reset to zero). Dashboard shows "resets in X min." NOT a smooth sliding window — utilization does not gradually decay. It stays constant or increases within a window, then drops to zero at reset.
+- **7d window** — Weekly ceiling. Per-model sub-budgets ("claims") tracked separately (e.g., `seven_day_sonnet`, `seven_day_opus`). The `representative-claim` header indicates which window currently constrains the account.
 
 ## Build & Development
 
@@ -29,6 +37,7 @@ Production runs on the **mem** k8s cluster (`kubectl --context mem`), namespace 
 | Config delivery | init container copies secret → `/data/config.toml` at pod start |
 
 **Config changes** require a pod restart after the ExternalSecret refreshes (secret is copied at init time, not watched):
+
 ```bash
 kubectl --context mem -n anthropic-lb rollout restart deployment/anthropic-lb
 ```
@@ -106,13 +115,6 @@ Named OpenAI-compatible upstreams configured in `[[upstreams]]` TOML sections. R
 | `accounts[].token` | string | required | API key, OAuth token, or `"passthrough"` |
 | `accounts[].models` | string[]? | [] (all) | Model allowlist (supports `*` suffix wildcards) |
 
-### Anthropic Rate Limit Windows (Unified Headers)
-
-The proxy reads utilization from `anthropic-ratelimit-unified-*` response headers. These govern subscription-based access (Claude Code, Pro, Max plans) and are separate from the per-minute token bucket limits documented at platform.claude.com.
-
-**Two windows:**
-- **5h window** — Fixed-duration window. Starts when usage begins, resets at a specific time (hard reset to zero). Dashboard shows "resets in X min." NOT a smooth sliding window — utilization does not gradually decay. It stays constant or increases within a window, then drops to zero at reset.
-- **7d window** — Weekly ceiling. Per-model sub-budgets ("claims") tracked separately (e.g., `seven_day_sonnet`, `seven_day_opus`). The `representative-claim` header indicates which window currently constrains the account.
 
 **Key headers parsed:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,25 @@ cargo llvm-cov                       # Coverage report (requires cargo-llvm-cov)
 
 Run the proxy: `./target/release/anthropic-lb config.toml`
 
+## Deployment
+
+Production runs on the **mem** k8s cluster (`kubectl --context mem`), namespace `anthropic-lb`, managed by **Flux** from `27b-io/fleet-infra` repo.
+
+| What | Where |
+|------|-------|
+| Flux manifests | `~/code/27b.io/fleet-infra/apps/mem/anthropic-lb/` |
+| Config template | `externalsecret.yaml` (ExternalSecret → 1Password tokens + redis password) |
+| Image policy | Flux `imagepolicy` auto-updates digest from `ghcr.io/27b-io/anthropic-lb:main` |
+| Replicas | 2 (RollingUpdate, maxUnavailable=0) |
+| Config delivery | init container copies secret → `/data/config.toml` at pod start |
+
+**Config changes** require a pod restart after the ExternalSecret refreshes (secret is copied at init time, not watched):
+```bash
+kubectl --context mem -n anthropic-lb rollout restart deployment/anthropic-lb
+```
+
+Local dev instance also runs as systemd user unit: `systemctl --user restart anthropic-lb`
+
 ## Architecture
 
 Single-file Rust binary (`src/main.rs`, ~12000 lines) with inline tests. No library crate — everything lives in one file with section markers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -746,15 +746,13 @@ impl AppState {
             }
         }
 
-        // Distributed probe lock: one pod per account+model per interval
+        // Distributed probe lock: one pod per account+model per interval.
+        // TTL = full configured interval so the lock covers the entire
+        // dedup window (no early-rollover race).
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
             let lock_key = format!("alb:probe:{}:{}", acct.name, model);
-            let lock_ttl = if self.probe_interval_secs > 10 {
-                self.probe_interval_secs - 10
-            } else {
-                self.probe_interval_secs
-            };
+            let lock_ttl = self.probe_interval_secs.max(1);
             let acquired: redis::RedisResult<bool> = redis::cmd("SET")
                 .arg(&lock_key)
                 .arg(1u8)
@@ -834,19 +832,7 @@ impl AppState {
                     // immediately so the dashboard reflects the account coming
                     // back online without waiting for the next probe cycle.
                     if recovered {
-                        // DEL Redis hard-limit key so other replicas don't re-apply it
-                        if let Some(redis) = &self.redis {
-                            let mut conn = redis.clone();
-                            let key = format!("alb:hard:{}", acct.name);
-                            tokio::spawn(async move {
-                                use redis::AsyncCommands;
-                                let result: redis::RedisResult<()> = conn.del(&key).await;
-                                if let Err(e) = result {
-                                    tracing::warn!(error = %e, "redis DEL failed for hard-limit clear");
-                                }
-                            });
-                        }
-                        self.refresh_metrics_weights().await;
+                        self.signal_hard_limit_recovery(acct).await;
                     }
                 }
                 self.save_state().await;
@@ -854,7 +840,13 @@ impl AppState {
                 let now_epoch = Self::now_epoch();
                 let (eff_util, constraint, _adj_5h, _adj_7d) =
                     effective_utilization(&info, now_epoch, model);
-                let rw = compute_routing_weight(&info, model, now_epoch, false);
+                // After a 429, the account is hard-limited — emit "-" instead of
+                // pre-429 routing weight values that no longer reflect reality.
+                let rw = if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    None
+                } else {
+                    compute_routing_weight(&info, model, now_epoch, false)
+                };
                 info!(
                     account = acct.name,
                     status = status.as_u16(),
@@ -1684,6 +1676,32 @@ impl AppState {
         }
     }
 
+    /// Distributed hard-limit recovery: notifies other replicas that the local
+    /// hard limit has been cleared. Writes a `0` sentinel to `alb:hard:{account}`
+    /// (instead of DEL) so `sync_from_redis` can proactively clear other replicas'
+    /// stale `hard_limited_until` Instants — DEL alone leaves them stuck until
+    /// their own probe sees recovery. Also refreshes metric gauges and publishes
+    /// the updated routing weights so all replicas reflect the recovery within
+    /// the next sync tick.
+    async fn signal_hard_limit_recovery(&self, acct: &Account) {
+        if let Some(redis) = &self.redis {
+            let mut conn = redis.clone();
+            let key = format!("alb:hard:{}", acct.name);
+            // Sentinel: epoch=0 means "explicitly cleared". Short TTL because
+            // sync_from_redis runs every 5s; once every replica has observed
+            // the sentinel, the key can be removed.
+            tokio::spawn(async move {
+                use redis::AsyncCommands;
+                let result: redis::RedisResult<()> = conn.set_ex(&key, 0u64, 60u64).await;
+                if let Err(e) = result {
+                    tracing::warn!(error = %e, "redis sentinel write failed for hard-limit clear");
+                }
+            });
+        }
+        self.refresh_metrics_weights().await;
+        self.publish_routing_weights().await;
+    }
+
     fn pick_weighted_bucket<'a>(
         &self,
         effective: &[&'a RoutingCandidate],
@@ -2247,7 +2265,19 @@ impl AppState {
         if let Ok(values) = conn.mget::<_, Vec<Option<u64>>>(&hard_keys).await {
             for (i, val) in values.iter().enumerate() {
                 if let Some(until_epoch) = val {
-                    if *until_epoch > now_epoch {
+                    if *until_epoch == 0 {
+                        // Recovery sentinel: another replica cleared its hard limit.
+                        // Proactively clear ours so we stop excluding the account.
+                        let mut info = self.accounts[i].rate_info.write().await;
+                        if info.hard_limited_until.is_some() {
+                            info.hard_limited_until = None;
+                            info.consecutive_burst_429s = 0;
+                            trace!(
+                                account = self.accounts[i].name,
+                                "synced hard-limit clear sentinel from redis"
+                            );
+                        }
+                    } else if *until_epoch > now_epoch {
                         let remaining = Duration::from_secs(until_epoch - now_epoch);
                         let until_instant = now_instant + remaining;
                         let mut info = self.accounts[i].rate_info.write().await;
@@ -3419,15 +3449,7 @@ async fn proxy_handler(
             state.save_state().await;
 
             if recovered {
-                if let Some(redis) = &state.redis {
-                    let mut conn = redis.clone();
-                    let key = format!("alb:hard:{}", acct.name);
-                    tokio::spawn(async move {
-                        use redis::AsyncCommands;
-                        let _: redis::RedisResult<()> = conn.del(&key).await;
-                    });
-                }
-                state.refresh_metrics_weights().await;
+                state.signal_hard_limit_recovery(acct).await;
             }
 
             // Log with capacity info + inject budget status header
@@ -5754,15 +5776,7 @@ async fn openai_chat_handler(
             state.save_state().await;
 
             if recovered {
-                if let Some(redis) = &state.redis {
-                    let mut conn = redis.clone();
-                    let key = format!("alb:hard:{}", acct.name);
-                    tokio::spawn(async move {
-                        use redis::AsyncCommands;
-                        let _: redis::RedisResult<()> = conn.del(&key).await;
-                    });
-                }
-                state.refresh_metrics_weights().await;
+                state.signal_hard_limit_recovery(acct).await;
             }
 
             // Compute budget pressure status for response header + log

--- a/src/main.rs
+++ b/src/main.rs
@@ -1319,8 +1319,8 @@ fn effective_utilization(
 
 /// Computed routing weight for a single account+model. Extracted so both
 /// `routing_candidates()` (real requests) and `probe_account()` (periodic probes)
-/// use identical logic. Returns `None` when the account's 7d claim is rejected
-/// (caller should skip it).
+/// use identical logic. Returns `None` when the account's 7d claim is actively
+/// rejected (caller should skip it).
 struct RoutingWeight {
     gate_5h: f64,
     gate_7d: f64,
@@ -1362,7 +1362,9 @@ fn compute_routing_weight(
 
     // 7d model-specific gate and waste risk
     let (gate_7d, wr, source) = if let Some(claim) = resolve_7d_claim(info, model) {
-        if claim.status.as_deref() == Some("rejected") && !stale_after_hard_limit {
+        let rejected_claim_active = claim.status.as_deref() == Some("rejected")
+            && claim.reset.is_none_or(|reset| reset > now_epoch);
+        if rejected_claim_active && !stale_after_hard_limit {
             return None; // caller should skip this account
         }
         (
@@ -1383,18 +1385,7 @@ fn compute_routing_weight(
         )
     } else {
         (
-            if stale_after_hard_limit {
-                0.5
-            } else {
-                time_adjusted_utilization(
-                    Some(0.0),
-                    info.reset_7d,
-                    info.status_7d.as_deref(),
-                    NEAR_RESET_7D_SECS,
-                    now_epoch,
-                )
-                .unwrap_or(0.0)
-            },
+            if stale_after_hard_limit { 0.5 } else { 0.0 },
             0.0,
             "headroom_only",
         )
@@ -1709,6 +1700,18 @@ impl AppState {
         }
     }
 
+    fn routing_weight_publish_ttl(probe_interval_secs: u64) -> u64 {
+        const FALLBACK_PUBLISH_INTERVAL_SECS: u64 = 60;
+
+        let effective_interval = if probe_interval_secs == 0 {
+            FALLBACK_PUBLISH_INTERVAL_SECS
+        } else {
+            probe_interval_secs
+        };
+
+        effective_interval.saturating_mul(2).max(1)
+    }
+
     /// Publish precomputed routing weights to Redis so non-probing pods
     /// can set their gauge atomics without recomputing.
     async fn publish_routing_weights(&self) {
@@ -1723,11 +1726,7 @@ impl AppState {
             let key = format!("alb:weight:{}", acct.name);
             let val = format!("{w},{s}");
             let mut conn = redis.clone();
-            // Saturating multiply + floor to 1: prevents zero TTL when probes
-            // are disabled and avoids overflow for absurd probe_interval_secs.
-            // Redis SETEX rejects TTL=0, so a zero-floor would silently drop
-            // every weight publish.
-            let ttl = self.probe_interval_secs.saturating_mul(2).max(1);
+            let ttl = Self::routing_weight_publish_ttl(self.probe_interval_secs);
             tokio::spawn(async move {
                 let result: redis::RedisResult<()> = conn.set_ex(&key, val, ttl).await;
                 if let Err(e) = result {
@@ -4161,6 +4160,7 @@ fn prom_header(buf: &mut String, name: &str, metric_type: &str, help: &str) {
     let _ = writeln!(buf, "# TYPE {name} {metric_type}");
 }
 
+#[allow(dead_code)]
 #[derive(Default, Clone)]
 struct ClaimMetricsSnap {
     key: String,
@@ -4170,6 +4170,7 @@ struct ClaimMetricsSnap {
     status: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Default, Clone)]
 struct AcctMetricsSnap {
     name: String,
@@ -4197,132 +4198,12 @@ struct AcctMetricsSnap {
     claims: Vec<ClaimMetricsSnap>,
 }
 
-#[derive(Clone, Debug)]
-struct WeightSnap {
-    name: String,
-    gate_5h: f64,
-    gate_7d: f64,
-    gate: f64,
-    wr: f64,
-    weight: f64,
-}
-
-fn compute_routing_weights(
-    snaps: &[AcctMetricsSnap],
-    now_epoch: u64,
-    soft_limit: f64,
-) -> Vec<WeightSnap> {
-    use std::cmp::Ordering;
-
-    let mut weight_snaps: Vec<WeightSnap> = Vec::with_capacity(snaps.len());
-
-    for s in snaps {
-        if s.hard_limited_active {
-            continue;
-        }
-
-        let gate_5h = if s.stale_after_hard_limit {
-            0.5
-        } else {
-            time_adjusted_utilization(
-                s.utilization_5h,
-                s.reset_5h,
-                s.status_5h.as_deref(),
-                NEAR_RESET_5H_SECS,
-                now_epoch,
-            )
-            .unwrap_or_else(|| {
-                if let Some(util) = s.utilization {
-                    util
-                } else if let Some(remaining) = s.remaining_tokens {
-                    let limit = s.limit_tokens.unwrap_or(1_000_000);
-                    (1.0 - (remaining as f64 / limit as f64)).clamp(0.0, 1.0)
-                } else {
-                    0.5
-                }
-            })
-        };
-
-        let best_claim = s.claims.iter().max_by(|a, b| {
-            a.waste_risk
-                .partial_cmp(&b.waste_risk)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| a.key.cmp(&b.key))
-        });
-
-        let (gate_7d, wr) = if let Some(claim) = best_claim {
-            (
-                if s.stale_after_hard_limit {
-                    0.5
-                } else {
-                    time_adjusted_utilization(
-                        Some(0.0),
-                        claim.reset,
-                        claim.status.as_deref(),
-                        NEAR_RESET_7D_SECS,
-                        now_epoch,
-                    )
-                    .unwrap_or(0.0)
-                },
-                claim.waste_risk,
-            )
-        } else if s.has_applicable_7d {
-            (
-                if s.stale_after_hard_limit {
-                    0.5
-                } else {
-                    time_adjusted_utilization(
-                        Some(0.0),
-                        s.reset_7d,
-                        s.status_7d.as_deref(),
-                        NEAR_RESET_7D_SECS,
-                        now_epoch,
-                    )
-                    .unwrap_or(0.0)
-                },
-                0.0,
-            )
-        } else {
-            (if s.stale_after_hard_limit { 0.5 } else { 0.0 }, 0.0)
-        };
-
-        let gate = gate_5h.max(gate_7d);
-        let headroom = (1.0 - gate).max(0.01);
-        let weight = if wr > 0.0 { wr * headroom } else { headroom };
-        let weight = if gate >= 1.0 { 0.0 } else { weight };
-
-        weight_snaps.push(WeightSnap {
-            name: s.name.clone(),
-            gate_5h,
-            gate_7d,
-            gate,
-            wr,
-            weight,
-        });
-    }
-
-    // Match pick_account(): if any account is below soft_limit, accounts at/above
-    // the soft limit are excluded from selection and should contribute zero share.
-    let has_healthy = weight_snaps.iter().any(|w| w.gate < soft_limit);
-    if has_healthy {
-        for w in &mut weight_snaps {
-            if w.gate >= soft_limit {
-                w.weight = 0.0;
-            }
-        }
-    }
-
-    weight_snaps
-}
-
+#[cfg(test)]
 fn append_routing_weight_metrics(
     buf: &mut String,
+    accounts: &[Account],
     snaps: &[AcctMetricsSnap],
-    now_epoch: u64,
-    soft_limit: f64,
 ) {
-    // Model-agnostic routing view: keep the existing "best 7d claim" selection,
-    // but compute gates with the same time-adjusted logic as routing_candidates().
     prom_header(
         buf,
         "anthropic_account_routing_weight",
@@ -4336,24 +4217,24 @@ fn append_routing_weight_metrics(
         "Per-account share of total routing weight (0.0-1.0)",
     );
 
-    let weight_snaps = compute_routing_weights(snaps, now_epoch, soft_limit);
-    let total_weight: f64 = weight_snaps.iter().map(|w| w.weight).sum();
-
-    for w in &weight_snaps {
+    for (acct, snap) in accounts.iter().zip(snaps.iter()) {
+        if snap.passthrough {
+            continue;
+        }
+        let weight = f64::from_bits(acct.last_routing_weight.load(Ordering::Relaxed));
+        let share = f64::from_bits(acct.last_routing_share.load(Ordering::Relaxed));
         prom_gauge(
             buf,
             "anthropic_account_routing_weight",
-            &[("account", &w.name)],
-            w.weight,
+            &[("account", &snap.name)],
+            weight,
         );
-        if total_weight > 0.0 {
-            prom_gauge(
-                buf,
-                "anthropic_account_routing_share",
-                &[("account", &w.name)],
-                w.weight / total_weight,
-            );
-        }
+        prom_gauge(
+            buf,
+            "anthropic_account_routing_share",
+            &[("account", &snap.name)],
+            share,
+        );
     }
 }
 
@@ -4794,7 +4675,40 @@ async fn metrics_handler(
         }
     }
 
-    append_routing_weight_metrics(&mut buf, &snaps, now_epoch, state.soft_limit);
+    // ── Routing weights (refreshed by refresh_metrics_weights per probe cycle) ─────
+
+    prom_header(
+        &mut buf,
+        "anthropic_account_routing_weight",
+        "gauge",
+        "Per-account routing weight (headroom * waste_risk, or plain headroom when no 7d claim)",
+    );
+    prom_header(
+        &mut buf,
+        "anthropic_account_routing_share",
+        "gauge",
+        "Per-account share of total routing weight (0.0-1.0)",
+    );
+
+    for (acct, s) in state.accounts.iter().zip(snaps.iter()) {
+        if s.passthrough {
+            continue;
+        }
+        let weight = f64::from_bits(acct.last_routing_weight.load(Ordering::Relaxed));
+        let share = f64::from_bits(acct.last_routing_share.load(Ordering::Relaxed));
+        prom_gauge(
+            &mut buf,
+            "anthropic_account_routing_weight",
+            &[("account", &s.name)],
+            weight,
+        );
+        prom_gauge(
+            &mut buf,
+            "anthropic_account_routing_share",
+            &[("account", &s.name)],
+            share,
+        );
+    }
 
     // ── Aggregate metrics ──────────────────────────────────────────
 
@@ -7003,6 +6917,46 @@ mod tests {
             result,
             Some(1),
             "fresh rejected claim should still skip the account"
+        );
+    }
+
+    #[tokio::test]
+    async fn pick_ignores_expired_rejected_claim_without_hard_limit() {
+        let state = test_state_with(vec![
+            make_account("recovered", "sk-ant-api-a"),
+            make_account("available", "sk-ant-api-b"),
+        ]);
+        let now_epoch = AppState::now_epoch();
+
+        {
+            let mut info = state.accounts[0].rate_info.write().await;
+            info.utilization = Some(0.30);
+            info.utilization_5h = Some(0.30);
+            info.reset_5h = Some(now_epoch + 10000);
+            info.claims_7d.insert(
+                "seven_day_sonnet".to_string(),
+                ClaimWindowData {
+                    utilization: Some(1.0),
+                    reset: Some(now_epoch.saturating_sub(1)),
+                    status: Some("rejected".to_string()),
+                    ..Default::default()
+                },
+            );
+        }
+        {
+            let mut info = state.accounts[1].rate_info.write().await;
+            info.utilization = Some(0.80);
+            info.utilization_5h = Some(0.80);
+            info.reset_5h = Some(now_epoch + 10000);
+        }
+
+        let result = state
+            .pick_account(Some("test"), "claude-sonnet-4-6", &[])
+            .await;
+        assert_eq!(
+            result,
+            Some(0),
+            "expired rejected claim should not block account selection"
         );
     }
 
@@ -10896,6 +10850,32 @@ data: {\"type\":\"message_stop\"}\n\n";
     }
 
     #[test]
+    fn routing_weight_expired_rejected_claim_returns_some() {
+        let now = 1_000_000u64;
+        let mut claims = HashMap::new();
+        claims.insert(
+            "seven_day_sonnet".to_string(),
+            ClaimWindowData {
+                utilization: Some(1.0),
+                reset: Some(now.saturating_sub(1)),
+                status: Some("rejected".to_string()),
+                last_seen: now,
+            },
+        );
+        let info = RateLimitInfo {
+            utilization_5h: Some(0.20),
+            reset_5h: Some(now + 18000),
+            status_5h: Some("allowed".to_string()),
+            claims_7d: claims,
+            ..Default::default()
+        };
+        assert!(
+            compute_routing_weight(&info, "claude-sonnet-4-6", now, false).is_some(),
+            "expired rejected claim should not return None"
+        );
+    }
+
+    #[test]
     fn routing_weight_stale_uses_fallback() {
         // stale_after_hard_limit = true → both gates fallback to 0.5
         let now = 1_000_000u64;
@@ -10937,6 +10917,16 @@ data: {\"type\":\"message_stop\"}\n\n";
             compute_routing_weight(&info, "claude-sonnet-4-6", now, true).is_some(),
             "stale rejected should still return Some (give account a chance)"
         );
+    }
+
+    #[test]
+    fn routing_weight_publish_ttl_uses_fallback_interval_when_probes_disabled() {
+        assert_eq!(AppState::routing_weight_publish_ttl(0), 120);
+    }
+
+    #[test]
+    fn routing_weight_publish_ttl_doubles_probe_interval() {
+        assert_eq!(AppState::routing_weight_publish_ttl(300), 600);
     }
 
     #[test]
@@ -14838,80 +14828,70 @@ upstream = "https://api.anthropic.com"
 
     #[test]
     fn routing_metrics_present() {
-        let now_epoch = AppState::now_epoch();
+        let acct = make_account("acct-a", "sk-ant-api-a");
+        acct.last_routing_weight
+            .store(0.4f64.to_bits(), Ordering::Relaxed);
+        acct.last_routing_share
+            .store(1.0f64.to_bits(), Ordering::Relaxed);
+
         let mut buf = String::new();
         append_routing_weight_metrics(
             &mut buf,
+            &[acct],
             &[AcctMetricsSnap {
                 name: "acct-a".to_string(),
-                utilization: Some(0.20),
-                utilization_5h: Some(0.20),
-                reset_5h: Some(now_epoch + NEAR_RESET_5H_SECS as u64 + 600),
-                status_5h: Some("allowed".to_string()),
-                claims: vec![ClaimMetricsSnap {
-                    key: "seven_day".to_string(),
-                    utilization: Some(0.50),
-                    waste_risk: 0.50,
-                    reset: Some(now_epoch + TOTAL_7D_SECS as u64),
-                    status: Some("allowed".to_string()),
-                }],
                 ..Default::default()
             }],
-            now_epoch,
-            1.0,
         );
 
         assert!(
             buf.lines()
                 .any(|line| line
                     .starts_with("anthropic_account_routing_weight{account=\"acct-a\"} 0.4")),
-            "missing routing_weight line:\n{buf}"
+            "missing routing_weight line:
+{buf}"
         );
         assert!(
             buf.lines()
                 .any(|line| line
                     .starts_with("anthropic_account_routing_share{account=\"acct-a\"} 1")),
-            "missing routing_share line:\n{buf}"
+            "missing routing_share line:
+{buf}"
         );
     }
-
     #[test]
     fn routing_metrics_zero_weight_for_rejected_claim() {
-        let now_epoch = AppState::now_epoch();
+        let acct = make_account("acct-a", "sk-ant-api-a");
+        acct.last_routing_weight
+            .store(0.0f64.to_bits(), Ordering::Relaxed);
+        acct.last_routing_share
+            .store(0.0f64.to_bits(), Ordering::Relaxed);
+
         let mut buf = String::new();
         append_routing_weight_metrics(
             &mut buf,
+            &[acct],
             &[AcctMetricsSnap {
                 name: "acct-a".to_string(),
-                utilization_5h: Some(0.20),
-                reset_5h: Some(now_epoch + NEAR_RESET_5H_SECS as u64 + 600),
-                status_5h: Some("allowed".to_string()),
-                claims: vec![ClaimMetricsSnap {
-                    key: "seven_day".to_string(),
-                    utilization: Some(0.50),
-                    waste_risk: 0.50,
-                    reset: Some(now_epoch + TOTAL_7D_SECS as u64),
-                    status: Some("rejected".to_string()),
-                }],
                 ..Default::default()
             }],
-            now_epoch,
-            1.0,
         );
 
         assert!(
             buf.lines()
                 .any(|line| line
                     .starts_with("anthropic_account_routing_weight{account=\"acct-a\"} 0")),
-            "rejected claim should zero routing_weight:\n{buf}"
+            "rejected claim should zero routing_weight:
+{buf}"
         );
         assert!(
-            !buf.lines()
-                .any(|line| line.starts_with("anthropic_account_routing_share{account=\"acct-a\"}")),
-            "zero-total routing_share should be omitted:\n{buf}"
+            buf.lines()
+                .any(|line| line
+                    .starts_with("anthropic_account_routing_share{account=\"acct-a\"} 0")),
+            "rejected claim should export zero routing_share:
+{buf}"
         );
     }
-
     #[tokio::test]
     async fn passthrough_accounts_participate_in_routing_candidates_and_metrics() {
         let mut state = test_state_with(vec![
@@ -14941,9 +14921,11 @@ upstream = "https://api.anthropic.com"
             "passthrough account should remain routable"
         );
 
+        state.refresh_metrics_weights().await;
         let mut buf = String::new();
         append_routing_weight_metrics(
             &mut buf,
+            &state.accounts,
             &[
                 AcctMetricsSnap {
                     name: "passthrough".to_string(),
@@ -14961,13 +14943,17 @@ upstream = "https://api.anthropic.com"
                     ..Default::default()
                 },
             ],
-            now_epoch,
-            state.soft_limit,
         );
 
         assert!(
-            buf.contains("anthropic_account_routing_weight{account=\"passthrough\"}"),
-            "passthrough account should appear in routing metrics:\n{buf}"
+            !buf.contains("anthropic_account_routing_weight{account=\"passthrough\"}"),
+            "passthrough account should be omitted from routing metrics:
+{buf}"
+        );
+        assert!(
+            buf.contains("anthropic_account_routing_weight{account=\"api\"}"),
+            "api account should remain in routing metrics:
+{buf}"
         );
     }
 
@@ -15850,6 +15836,7 @@ upstream = "https://api.anthropic.com"
             info.reset_5h = Some(now_epoch + NEAR_RESET_5H_SECS as u64 + 600);
             info.status_5h = Some("allowed".to_string());
         }
+        state.refresh_metrics_weights().await;
 
         let addr = serve(app).await;
         let client = Client::new();
@@ -15986,9 +15973,11 @@ upstream = "https://api.anthropic.com"
             info.status_5h = Some("allowed".to_string());
         }
 
+        state.refresh_metrics_weights().await;
         let mut buf = String::new();
         append_routing_weight_metrics(
             &mut buf,
+            &state.accounts,
             &[
                 AcctMetricsSnap {
                     name: "healthy".to_string(),
@@ -16007,21 +15996,22 @@ upstream = "https://api.anthropic.com"
                     ..Default::default()
                 },
             ],
-            now_epoch,
-            state.soft_limit,
         );
 
         assert!(
             buf.contains("anthropic_account_routing_share{account=\"healthy\"} 1"),
-            "healthy account should receive full routing share:\n{buf}"
+            "healthy account should receive full routing share:
+{buf}"
         );
         assert!(
             buf.contains("anthropic_account_routing_share{account=\"soft-limited\"} 0"),
-            "soft-limited account should have zero routing share:\n{buf}"
+            "soft-limited account should have zero routing share:
+{buf}"
         );
         assert!(
             buf.contains("anthropic_account_routing_weight{account=\"soft-limited\"} 0"),
-            "soft-limited account should have zero routing weight:\n{buf}"
+            "soft-limited account should have zero routing weight:
+{buf}"
         );
 
         for i in 0..20 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -812,9 +812,12 @@ impl AppState {
                 self.update_rate_info(idx, resp.headers()).await;
                 if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
                     self.mark_hard_limited(idx, resp.headers()).await;
-                } else {
-                    // Non-429: account is responsive, clear hard limit and burst counter
+                } else if status.is_success() {
+                    // 2xx only: account is responsive, clear hard limit and burst counter
                     // so pick_account stops treating rate data as stale.
+                    // 5xx/529 are upstream errors, not proof the account recovered —
+                    // clearing the hard limit on those would flood a saturated account
+                    // during an Anthropic incident.
                     let recovered = {
                         let mut info = acct.rate_info.write().await;
                         let was_hard_limited = info.hard_limited_until.is_some();
@@ -835,17 +838,19 @@ impl AppState {
                         self.signal_hard_limit_recovery(acct).await;
                     }
                 }
+                // else: 5xx/529 — leave account state untouched. Next probe cycle retries.
                 self.save_state().await;
                 let info = acct.rate_info.read().await;
                 let now_epoch = Self::now_epoch();
                 let (eff_util, constraint, _adj_5h, _adj_7d) =
                     effective_utilization(&info, now_epoch, model);
-                // After a 429, the account is hard-limited — emit "-" instead of
-                // pre-429 routing weight values that no longer reflect reality.
-                let rw = if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                    None
-                } else {
+                // Only compute routing weight on 2xx — non-success responses leave
+                // the account state either mutated (429 → hard-limited) or untouched
+                // (5xx), and the pre-response weight no longer reflects reality.
+                let rw = if status.is_success() {
                     compute_routing_weight(&info, model, now_epoch, false)
+                } else {
+                    None
                 };
                 info!(
                     account = acct.name,
@@ -1059,6 +1064,18 @@ const MAX_529_RETRIES: u32 = 3;
 
 /// Base delay for 529 BEBO retries. Doubles each round: 1s, 2s, 4s.
 const RETRY_529_BASE_DELAY: Duration = Duration::from_secs(1);
+
+/// Sentinel value written to `alb:hard:{account}` when a replica has observed
+/// recovery from a hard rate limit. Other replicas interpret this as an
+/// instruction to proactively clear their local `hard_limited_until`, which
+/// DEL alone could not do (sync_from_redis ignores missing keys). Distinct
+/// from "no key" (no data) and "epoch > 0" (active hard limit).
+const HARD_LIMIT_CLEARED_SENTINEL: u64 = 0;
+
+/// TTL for the recovery sentinel in Redis. Long enough for every replica to
+/// observe it via sync_from_redis (5s interval = 12 opportunities), short
+/// enough that the key does not linger past the intended recovery window.
+const HARD_LIMIT_SENTINEL_TTL_SECS: u64 = 60;
 
 /// Maximum request body size (25 MB).
 const MAX_REQUEST_BODY_BYTES: usize = 25 * 1024 * 1024;
@@ -1398,6 +1415,46 @@ fn compute_routing_weight(
     })
 }
 
+/// Classification of a remote `alb:hard:{account}` value read from Redis.
+/// Pure function output — unit-testable without a Redis client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HardLimitSync {
+    /// Remote stored the recovery sentinel (`HARD_LIMIT_CLEARED_SENTINEL`).
+    /// Another replica observed recovery — this replica should clear its
+    /// local `hard_limited_until` but must NOT reset local burst-backoff state.
+    Clear,
+    /// Remote stored a valid future epoch. Apply it as a hard limit until
+    /// the given `Instant`.
+    Update(Instant),
+    /// Missing, stale (epoch <= now that isn't the sentinel), or bogus value.
+    /// Take no action — local state is already correct or more current.
+    Ignore,
+}
+
+/// Classify a remote hard-limit value from Redis into an action.
+///
+/// Clamps `until_epoch` to at most 24h in the future to prevent a corrupt or
+/// malicious Redis value (e.g. `u64::MAX`) from producing an `Instant` that
+/// panics on arithmetic or creates a permanent undead hard limit.
+fn classify_hard_limit_sync(
+    remote: Option<u64>,
+    now_epoch: u64,
+    now_instant: Instant,
+) -> HardLimitSync {
+    const MAX_HARD_LIMIT_SECS: u64 = 86_400; // 24h ceiling — matches mark_hard_limited
+    match remote {
+        None => HardLimitSync::Ignore,
+        Some(HARD_LIMIT_CLEARED_SENTINEL) => HardLimitSync::Clear,
+        Some(epoch) if epoch > now_epoch => {
+            let delta = (epoch - now_epoch).min(MAX_HARD_LIMIT_SECS);
+            HardLimitSync::Update(now_instant + Duration::from_secs(delta))
+        }
+        // Stale (epoch <= now_epoch but non-zero) — ignore. The key is expiring
+        // naturally via TTL; local state is unaffected.
+        Some(_) => HardLimitSync::Ignore,
+    }
+}
+
 impl AppState {
     async fn routing_candidates(&self, model: &str, skip: &[usize]) -> Vec<RoutingCandidate> {
         let now = Instant::now();
@@ -1666,7 +1723,11 @@ impl AppState {
             let key = format!("alb:weight:{}", acct.name);
             let val = format!("{w},{s}");
             let mut conn = redis.clone();
-            let ttl = self.probe_interval_secs * 2;
+            // Saturating multiply + floor to 1: prevents zero TTL when probes
+            // are disabled and avoids overflow for absurd probe_interval_secs.
+            // Redis SETEX rejects TTL=0, so a zero-floor would silently drop
+            // every weight publish.
+            let ttl = self.probe_interval_secs.saturating_mul(2).max(1);
             tokio::spawn(async move {
                 let result: redis::RedisResult<()> = conn.set_ex(&key, val, ttl).await;
                 if let Err(e) = result {
@@ -1677,22 +1738,49 @@ impl AppState {
     }
 
     /// Distributed hard-limit recovery: notifies other replicas that the local
-    /// hard limit has been cleared. Writes a `0` sentinel to `alb:hard:{account}`
-    /// (instead of DEL) so `sync_from_redis` can proactively clear other replicas'
-    /// stale `hard_limited_until` Instants — DEL alone leaves them stuck until
-    /// their own probe sees recovery. Also refreshes metric gauges and publishes
-    /// the updated routing weights so all replicas reflect the recovery within
-    /// the next sync tick.
+    /// hard limit has been cleared. Writes a sentinel (`HARD_LIMIT_CLEARED_SENTINEL`)
+    /// to `alb:hard:{account}` so `sync_from_redis` can proactively clear other
+    /// replicas' stale `hard_limited_until` Instants — DEL alone leaves them stuck
+    /// until their own probe sees recovery.
+    ///
+    /// The write uses a Lua CAS script: only clears if the current value is absent
+    /// or already `<= now_epoch` (i.e. stale/expired). This prevents a TOCTOU race
+    /// where `mark_hard_limited` spawns a write of `until_epoch=now+cooldown` at
+    /// roughly the same moment, and unordered tokio::spawn tasks reach Redis in
+    /// reversed order — without CAS, the stale sentinel would clobber the fresh
+    /// hard-limit write and propagate a false "cleared" state across replicas.
+    ///
+    /// Also refreshes metric gauges and publishes updated routing weights so all
+    /// replicas reflect the recovery within the next sync tick.
     async fn signal_hard_limit_recovery(&self, acct: &Account) {
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
             let key = format!("alb:hard:{}", acct.name);
-            // Sentinel: epoch=0 means "explicitly cleared". Short TTL because
-            // sync_from_redis runs every 5s; once every replica has observed
-            // the sentinel, the key can be removed.
+            let now_epoch = Self::now_epoch();
+            // Lua CAS: only write the sentinel if the current value is absent,
+            // already the sentinel, or an expired hard-limit (epoch <= now).
+            // Rejects a concurrent mark_hard_limited write with epoch > now.
+            let script = redis::Script::new(
+                r#"
+                local current = redis.call('GET', KEYS[1])
+                if current == false then
+                    return redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+                end
+                local n = tonumber(current)
+                if n == nil or n <= tonumber(ARGV[3]) then
+                    return redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+                end
+                return 0
+                "#,
+            );
             tokio::spawn(async move {
-                use redis::AsyncCommands;
-                let result: redis::RedisResult<()> = conn.set_ex(&key, 0u64, 60u64).await;
+                let result: redis::RedisResult<redis::Value> = script
+                    .key(&key)
+                    .arg(HARD_LIMIT_CLEARED_SENTINEL)
+                    .arg(HARD_LIMIT_SENTINEL_TTL_SECS)
+                    .arg(now_epoch)
+                    .invoke_async(&mut conn)
+                    .await;
                 if let Err(e) = result {
                     tracing::warn!(error = %e, "redis sentinel write failed for hard-limit clear");
                 }
@@ -2241,6 +2329,10 @@ impl AppState {
         // metric gauges immediately so the dashboard reflects the dropped
         // account within seconds, not after the next probe cycle.
         self.refresh_metrics_weights().await;
+        // Republish weights to Redis so non-probing replicas pick up the
+        // new routing gauge immediately rather than reading a stale
+        // alb:weight:{account} until the next probe cycle.
+        self.publish_routing_weights().await;
     }
 
     /// Sync shared state from Redis: hard limits + rate info.
@@ -2263,37 +2355,39 @@ impl AppState {
             .collect();
 
         if let Ok(values) = conn.mget::<_, Vec<Option<u64>>>(&hard_keys).await {
-            for (i, val) in values.iter().enumerate() {
-                if let Some(until_epoch) = val {
-                    if *until_epoch == 0 {
-                        // Recovery sentinel: another replica cleared its hard limit.
-                        // Proactively clear ours so we stop excluding the account.
+            for (i, remote) in values.iter().enumerate() {
+                match classify_hard_limit_sync(*remote, now_epoch, now_instant) {
+                    HardLimitSync::Clear => {
+                        // Another replica observed recovery. Clear our local
+                        // `hard_limited_until` so pick_account stops excluding
+                        // the account. Do NOT reset `consecutive_burst_429s` —
+                        // that counter tracks THIS replica's burst-429 backoff
+                        // escalation, and resetting it based on another replica's
+                        // unrelated success would mask abuse patterns and thrash
+                        // the exponential backoff.
                         let mut info = self.accounts[i].rate_info.write().await;
                         if info.hard_limited_until.is_some() {
                             info.hard_limited_until = None;
-                            info.consecutive_burst_429s = 0;
                             trace!(
                                 account = self.accounts[i].name,
                                 "synced hard-limit clear sentinel from redis"
                             );
                         }
-                    } else if *until_epoch > now_epoch {
-                        let remaining = Duration::from_secs(until_epoch - now_epoch);
-                        let until_instant = now_instant + remaining;
+                    }
+                    HardLimitSync::Update(until_instant) => {
                         let mut info = self.accounts[i].rate_info.write().await;
-                        let should_update = match info.hard_limited_until {
-                            Some(local_until) => until_instant > local_until,
-                            None => true,
-                        };
+                        let should_update = info
+                            .hard_limited_until
+                            .is_none_or(|local| until_instant > local);
                         if should_update {
                             info.hard_limited_until = Some(until_instant);
                             trace!(
                                 account = self.accounts[i].name,
-                                remaining_secs = remaining.as_secs(),
                                 "synced hard-limit from redis"
                             );
                         }
                     }
+                    HardLimitSync::Ignore => {}
                 }
             }
         }
@@ -3436,17 +3530,24 @@ async fn proxy_handler(
                 continue;
             }
 
-            // Clear hard limit and burst counter — account just served a request successfully
-            let recovered = {
+            // Clear hard limit and burst counter only on a genuine 2xx success.
+            // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
+            // that the rate-limit window has drained — don't clobber state on
+            // client errors.
+            let recovered = if status.is_success() {
                 let mut info = acct.rate_info.write().await;
                 let was = info.hard_limited_until.is_some();
                 info.hard_limited_until = None;
                 info.consecutive_burst_429s = 0;
                 was
+            } else {
+                false
             };
 
             // Persist state after clearing hard limit so the saved snapshot is clean
-            state.save_state().await;
+            if status.is_success() {
+                state.save_state().await;
+            }
 
             if recovered {
                 state.signal_hard_limit_recovery(acct).await;
@@ -5763,17 +5864,24 @@ async fn openai_chat_handler(
                 continue;
             }
 
-            // Clear hard limit and burst counter — account just served a request successfully
-            let recovered = {
+            // Clear hard limit and burst counter only on a genuine 2xx success.
+            // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
+            // that the rate-limit window has drained — don't clobber state on
+            // client errors.
+            let recovered = if status.is_success() {
                 let mut info = acct.rate_info.write().await;
                 let was = info.hard_limited_until.is_some();
                 info.hard_limited_until = None;
                 info.consecutive_burst_429s = 0;
                 was
+            } else {
+                false
             };
 
             // Persist state after clearing hard limit so the saved snapshot is clean
-            state.save_state().await;
+            if status.is_success() {
+                state.save_state().await;
+            }
 
             if recovered {
                 state.signal_hard_limit_recovery(acct).await;
@@ -10869,6 +10977,107 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(rw.gate_5h, 0.5);
         assert_eq!(rw.source, "headroom_only");
         assert!(rw.weight > 0.0);
+    }
+
+    // ── classify_hard_limit_sync tests ────────────────────────────
+
+    #[test]
+    fn classify_hard_limit_none_is_ignore() {
+        let now_instant = Instant::now();
+        assert_eq!(
+            classify_hard_limit_sync(None, 1_000_000, now_instant),
+            HardLimitSync::Ignore
+        );
+    }
+
+    #[test]
+    fn classify_hard_limit_sentinel_is_clear() {
+        let now_instant = Instant::now();
+        assert_eq!(
+            classify_hard_limit_sync(Some(HARD_LIMIT_CLEARED_SENTINEL), 1_000_000, now_instant),
+            HardLimitSync::Clear
+        );
+    }
+
+    #[test]
+    fn classify_hard_limit_future_epoch_is_update() {
+        let now_instant = Instant::now();
+        let now_epoch = 1_000_000u64;
+        let future = now_epoch + 300; // 5 min from now
+        match classify_hard_limit_sync(Some(future), now_epoch, now_instant) {
+            HardLimitSync::Update(until) => {
+                let expected = now_instant + Duration::from_secs(300);
+                let delta = if until > expected {
+                    until.duration_since(expected)
+                } else {
+                    expected.duration_since(until)
+                };
+                assert!(delta < Duration::from_millis(1), "until Instant mismatch");
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_hard_limit_past_epoch_is_ignore() {
+        // Stale non-zero value — e.g. a hard limit that already expired via TTL
+        let now_instant = Instant::now();
+        let now_epoch = 1_000_000u64;
+        assert_eq!(
+            classify_hard_limit_sync(Some(now_epoch - 100), now_epoch, now_instant),
+            HardLimitSync::Ignore
+        );
+    }
+
+    #[test]
+    fn classify_hard_limit_epoch_equal_now_is_ignore() {
+        // Boundary: epoch == now means expired now, not future
+        let now_instant = Instant::now();
+        let now_epoch = 1_000_000u64;
+        assert_eq!(
+            classify_hard_limit_sync(Some(now_epoch), now_epoch, now_instant),
+            HardLimitSync::Ignore
+        );
+    }
+
+    #[test]
+    fn classify_hard_limit_clamps_far_future() {
+        // Corrupt or malicious Redis value must not create a panic-inducing Instant
+        // nor a permanent undead hard limit. Clamp to 24h.
+        let now_instant = Instant::now();
+        let now_epoch = 1_000_000u64;
+        match classify_hard_limit_sync(Some(u64::MAX), now_epoch, now_instant) {
+            HardLimitSync::Update(until) => {
+                let capped = now_instant + Duration::from_secs(86_400);
+                let delta = if until > capped {
+                    until.duration_since(capped)
+                } else {
+                    capped.duration_since(until)
+                };
+                assert!(delta < Duration::from_millis(1), "expected 24h clamp");
+            }
+            other => panic!("expected Update (clamped), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn signal_hard_limit_recovery_without_redis_is_noop() {
+        // Without Redis, the helper must still refresh metrics + publish weights
+        // locally. It must not panic and must not attempt Redis I/O.
+        let state = test_state_with(vec![make_account("a", "sk-ant-api-test")]);
+        // Pre-seed a non-zero weight so we can assert refresh_metrics_weights ran
+        state.accounts[0]
+            .last_routing_weight
+            .store(0u64, Ordering::Relaxed);
+        state.signal_hard_limit_recovery(&state.accounts[0]).await;
+        // refresh_metrics_weights always writes a value (even zero) — the point
+        // is that the method completed without Redis and without panicking.
+        let w = f64::from_bits(
+            state.accounts[0]
+                .last_routing_weight
+                .load(Ordering::Relaxed),
+        );
+        assert!(w.is_finite(), "weight atomic must remain valid: {w}");
     }
 
     // ── resolve_7d_claim tests ────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,6 +397,14 @@ struct Account {
     output_tokens: AtomicU64,
     cache_creation_tokens: AtomicU64,
     cache_read_tokens: AtomicU64,
+    /// Representative routing weight (f64 stored as u64 bits). Refreshed by
+    /// `refresh_metrics_weights()` once per probe cycle. Backs the
+    /// `anthropic_account_routing_weight` Prometheus gauge.
+    last_routing_weight: AtomicU64,
+    /// Representative routing share (weight/total, 0.0-1.0, f64 as bits).
+    /// Refreshed by `refresh_metrics_weights()` once per probe cycle. Backs
+    /// the `anthropic_account_routing_share` Prometheus gauge.
+    last_routing_share: AtomicU64,
 }
 
 struct Upstream {
@@ -748,15 +756,25 @@ impl AppState {
                 } else {
                     // Non-429: account is responsive, clear hard limit and burst counter
                     // so pick_account stops treating rate data as stale.
-                    let mut info = acct.rate_info.write().await;
-                    if info.hard_limited_until.is_some() {
-                        info.hard_limited_until = None;
-                        debug!(
-                            account = acct.name,
-                            "cleared hard limit after successful probe"
-                        );
+                    let recovered = {
+                        let mut info = acct.rate_info.write().await;
+                        let was_hard_limited = info.hard_limited_until.is_some();
+                        if was_hard_limited {
+                            info.hard_limited_until = None;
+                            debug!(
+                                account = acct.name,
+                                "cleared hard limit after successful probe"
+                            );
+                        }
+                        info.consecutive_burst_429s = 0;
+                        was_hard_limited
+                    };
+                    // Recovery is a sparse, high-impact event — refresh metrics
+                    // immediately so the dashboard reflects the account coming
+                    // back online without waiting for the next probe cycle.
+                    if recovered {
+                        self.refresh_metrics_weights().await;
                     }
-                    info.consecutive_burst_429s = 0;
                 }
                 self.save_state().await;
                 let info = acct.rate_info.read().await;
@@ -1320,6 +1338,168 @@ impl AppState {
         candidates
     }
 
+    /// Recompute and persist a representative routing weight per account for
+    /// metrics consumers. Called from the probe loop on the same cadence as
+    /// rate-limit data refreshes — never per-request, so the gauges reflect a
+    /// model-agnostic steady state instead of whichever model the last
+    /// inbound request happened to use.
+    ///
+    /// "Representative" means: 5h gate from the (model-agnostic) 5h window,
+    /// 7d gate from the convenience min-reset / max-utilization aggregates
+    /// already maintained on `RateLimitInfo`. This intentionally diverges from
+    /// `routing_candidates()` (which is model-specific) — pick decisions still
+    /// use the precise per-model claim.
+    ///
+    /// DIVERGENCE from `routing_candidates()`:
+    ///   1. Selects a representative `ClaimWindowData` model-agnostically
+    ///      (via `representative_claim` → `seven_day` general → highest
+    ///      waste_risk fallback) instead of the model-specific
+    ///      `resolve_7d_claim(model)` lookup. The chosen claim's util,
+    ///      reset, and status are read as a coherent triple — no
+    ///      Frankenstein from independently aggregated max/min.
+    ///   2. No "rejected claim → continue" branch; this is purely a metric
+    ///      snapshot, not a routing decision, so we still emit a gauge for
+    ///      such accounts (it ends up at zero via the `gate >= 1.0` clamp).
+    ///   3. Soft-limit handling matches `pick_account`'s graceful-degradation
+    ///      semantics: if at least one account is healthy, soft-limited
+    ///      accounts are zeroed; if NO account is healthy, all are kept so
+    ///      the dashboard reflects the still-routable degraded pool.
+    async fn refresh_metrics_weights(&self) {
+        let now_epoch = Self::now_epoch();
+        let now = Instant::now();
+
+        // Collect (gate, weight) per account. None = excluded entirely
+        // (passthrough or hard-limited — never weighted in any condition).
+        let mut entries: Vec<Option<(f64, f64)>> = vec![None; self.accounts.len()];
+
+        for (i, acct) in self.accounts.iter().enumerate() {
+            if acct.passthrough {
+                continue;
+            }
+
+            let info = acct.rate_info.read().await;
+
+            // Hard-limited accounts contribute zero (mirrors routing_candidates filter).
+            if let Some(until) = info.hard_limited_until {
+                if now < until {
+                    continue;
+                }
+            }
+
+            let stale_after_hard_limit = info
+                .hard_limited_until
+                .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
+
+            // 5h gate — same logic as routing_candidates
+            let gate_5h = if stale_after_hard_limit {
+                0.5
+            } else {
+                time_adjusted_utilization(
+                    info.utilization_5h,
+                    info.reset_5h,
+                    info.status_5h.as_deref(),
+                    NEAR_RESET_5H_SECS,
+                    now_epoch,
+                )
+                .unwrap_or_else(|| {
+                    if let Some(util) = info.utilization {
+                        util
+                    } else if let Some(remaining) = info.remaining_tokens {
+                        let limit = info.limit_tokens.unwrap_or(1_000_000);
+                        (1.0 - (remaining as f64 / limit as f64)).clamp(0.0, 1.0)
+                    } else {
+                        0.5
+                    }
+                })
+            };
+
+            // 7d gate + waste_risk from a SINGLE representative ClaimWindowData
+            // — utilization, reset and status are read as a coherent triple
+            // from one real claim, not Frankensteined from independently
+            // aggregated maxima/minima across claims.
+            //
+            // Selection precedence:
+            //   1. info.representative_claim if it points to a 7d entry
+            //      (this is the LB's own "binding constraint" signal)
+            //   2. The general "seven_day" claim if present
+            //   3. The model-specific claim with the highest waste_risk
+            //      (worst-case representative for the dashboard)
+            //   4. None → no 7d data, fall back to headroom-only
+            let representative: Option<&ClaimWindowData> = {
+                let rep_key = info.representative_claim.as_deref();
+                rep_key
+                    .filter(|k| k.starts_with("seven_day"))
+                    .and_then(|k| info.claims_7d.get(k))
+                    .or_else(|| info.claims_7d.get("seven_day"))
+                    .or_else(|| {
+                        info.claims_7d.values().max_by(|a, b| {
+                            let wr_a = waste_risk(a.utilization, a.reset, now_epoch);
+                            let wr_b = waste_risk(b.utilization, b.reset, now_epoch);
+                            wr_a.partial_cmp(&wr_b).unwrap_or(std::cmp::Ordering::Equal)
+                        })
+                    })
+            };
+
+            let (gate_7d, wr) = if let Some(claim) = representative {
+                let g = if stale_after_hard_limit {
+                    0.5
+                } else {
+                    time_adjusted_utilization(
+                        Some(0.0),
+                        claim.reset,
+                        claim.status.as_deref(),
+                        NEAR_RESET_7D_SECS,
+                        now_epoch,
+                    )
+                    .unwrap_or(0.0)
+                };
+                let w = waste_risk(claim.utilization, claim.reset, now_epoch);
+                (g, w)
+            } else {
+                // No 7d claim at all — headroom-only
+                let g = if stale_after_hard_limit { 0.5 } else { 0.0 };
+                (g, 0.0)
+            };
+
+            let gate = gate_5h.max(gate_7d);
+            let headroom = (1.0 - gate).max(0.01);
+            let weight = if wr > 0.0 { wr * headroom } else { headroom };
+            let weight = if gate >= 1.0 { 0.0 } else { weight };
+
+            entries[i] = Some((gate, weight));
+        }
+
+        // Mirror pick_account's graceful-degradation: only filter soft-limited
+        // accounts when at least one healthy account exists in the pool.
+        // Otherwise the entire pool is degraded and we still want the dashboard
+        // to reflect the routable accounts (pick_account would route to them).
+        let has_healthy = entries
+            .iter()
+            .any(|e| matches!(e, Some((gate, _)) if *gate < self.soft_limit));
+
+        let mut weights = vec![0f64; self.accounts.len()];
+        for (i, entry) in entries.iter().enumerate() {
+            if let Some((gate, weight)) = entry {
+                if has_healthy && *gate >= self.soft_limit {
+                    continue; // soft-limited and there's a healthy alternative
+                }
+                weights[i] = *weight;
+            }
+        }
+
+        let total: f64 = weights.iter().sum();
+        for (i, acct) in self.accounts.iter().enumerate() {
+            let w = weights[i];
+            let share = if total > 0.0 { w / total } else { 0.0 };
+            // Weight and share are independent gauges, not a joint invariant —
+            // a torn read across the pair is harmless for dashboard consumers.
+            acct.last_routing_weight
+                .store(w.to_bits(), Ordering::Relaxed);
+            acct.last_routing_share
+                .store(share.to_bits(), Ordering::Relaxed);
+        }
+    }
+
     fn pick_weighted_bucket<'a>(
         &self,
         effective: &[&'a RoutingCandidate],
@@ -1850,6 +2030,15 @@ impl AppState {
                 }
             });
         }
+
+        // Drop the write lock explicitly so refresh_metrics_weights can take
+        // its read lock without contention.
+        drop(info);
+
+        // Hard-limit transitions are sparse, high-impact events. Refresh
+        // metric gauges immediately so the dashboard reflects the dropped
+        // account within seconds, not after the next probe cycle.
+        self.refresh_metrics_weights().await;
     }
 
     /// Sync shared state from Redis: hard limits + rate info.
@@ -3011,14 +3200,20 @@ async fn proxy_handler(
             }
 
             // Clear hard limit and burst counter — account just served a request successfully
-            {
+            let recovered = {
                 let mut info = acct.rate_info.write().await;
+                let was = info.hard_limited_until.is_some();
                 info.hard_limited_until = None;
                 info.consecutive_burst_429s = 0;
-            }
+                was
+            };
 
             // Persist state after clearing hard limit so the saved snapshot is clean
             state.save_state().await;
+
+            if recovered {
+                state.refresh_metrics_weights().await;
+            }
 
             // Log with capacity info + inject budget status header
             let budget_status = {
@@ -5332,14 +5527,20 @@ async fn openai_chat_handler(
             }
 
             // Clear hard limit and burst counter — account just served a request successfully
-            {
+            let recovered = {
                 let mut info = acct.rate_info.write().await;
+                let was = info.hard_limited_until.is_some();
                 info.hard_limited_until = None;
                 info.consecutive_burst_429s = 0;
-            }
+                was
+            };
 
             // Persist state after clearing hard limit so the saved snapshot is clean
             state.save_state().await;
+
+            if recovered {
+                state.refresh_metrics_weights().await;
+            }
 
             // Compute budget pressure status for response header + log
             let budget_status = {
@@ -5708,6 +5909,8 @@ async fn main() {
                 output_tokens: AtomicU64::new(0),
                 cache_creation_tokens: AtomicU64::new(0),
                 cache_read_tokens: AtomicU64::new(0),
+                last_routing_weight: AtomicU64::new(0),
+                last_routing_share: AtomicU64::new(0),
             }
         })
         .collect();
@@ -5845,6 +6048,9 @@ async fn main() {
     // Restore persisted state (cooldowns, utilization, request counts)
     state.load_state().await;
 
+    // Seed metric weights from restored state so gauges aren't zero on cold start.
+    state.refresh_metrics_weights().await;
+
     let app = Router::new()
         .route("/_stats", axum::routing::get(stats_handler))
         .route("/metrics", axum::routing::get(metrics_handler))
@@ -5908,8 +6114,26 @@ async fn main() {
                     // Small delay between accounts to avoid burst
                     tokio::time::sleep(Duration::from_secs(2)).await;
                 }
+                // Recompute metric weights once per cycle, after all probes
+                // have refreshed rate-limit data. Keeps the gauges aligned
+                // with steady-state pool health, not per-request bias.
+                probe_state.refresh_metrics_weights().await;
                 probe_cycle = probe_cycle.wrapping_add(1);
                 tokio::time::sleep(Duration::from_secs(probe_interval)).await;
+            }
+        });
+    } else {
+        // Probes disabled — but `update_rate_info()` still refreshes data on
+        // every inbound request. Without this fallback ticker the routing
+        // weight gauges would freeze at startup values forever.
+        let metrics_state = state.clone();
+        tokio::spawn(async move {
+            const FALLBACK_INTERVAL: Duration = Duration::from_secs(60);
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            info!("probes disabled — metrics weights refresh on a 60s timer");
+            loop {
+                metrics_state.refresh_metrics_weights().await;
+                tokio::time::sleep(FALLBACK_INTERVAL).await;
             }
         });
     }
@@ -5986,6 +6210,8 @@ mod tests {
             output_tokens: AtomicU64::new(0),
             cache_creation_tokens: AtomicU64::new(0),
             cache_read_tokens: AtomicU64::new(0),
+            last_routing_weight: AtomicU64::new(0),
+            last_routing_share: AtomicU64::new(0),
         }
     }
 
@@ -6029,6 +6255,41 @@ mod tests {
 
     fn test_state_with(accounts: Vec<Account>) -> Arc<AppState> {
         test_state_with_strategy(accounts, RoutingStrategy::default())
+    }
+
+    fn test_state_with_soft_limit(accounts: Vec<Account>, soft_limit: f64) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .unwrap(),
+            upstream: "http://127.0.0.1:1".to_string(),
+            accounts,
+            robin: AtomicUsize::new(0),
+            routing_strategy: RoutingStrategy::default(),
+            cooldown: Duration::from_secs(60),
+            state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
+            proxy_key: None,
+            allowed_ips: vec![],
+            upstreams: vec![],
+            client_names: HashMap::new(),
+            auto_cache: true,
+            client_usage: Mutex::new(HashMap::new()),
+            shadow_log_tx: None,
+            shadow_log_dropped: AtomicU64::new(0),
+            client_budgets: HashMap::new(),
+            budget_usage: Mutex::new(HashMap::new()),
+            client_utilization_limits: HashMap::new(),
+            operators: vec![],
+            emergency_brake: true,
+            emergency_threshold: DEFAULT_EMERGENCY_THRESHOLD,
+            client_request_rates: Mutex::new(HashMap::new()),
+            soft_limit,
+            redis: None,
+            cluster_info_cache: Mutex::new(None),
+            next_req_id: AtomicU64::new(0),
+            instance_id: 0,
+        })
     }
 
     /// Spawn a mock upstream that returns a canned response with rate-limit headers.
@@ -14795,6 +15056,183 @@ upstream = "https://api.anthropic.com"
         );
     }
 
+    /// Unit: refresh_metrics_weights() persists routing weights and shares to
+    /// atomics on each Account, with shares normalized to sum ≈ 1.0 and zeros
+    /// for rejected accounts and accounts above soft_limit.
+    #[tokio::test]
+    async fn refresh_metrics_weights_persists_atomics() {
+        let acct_a = make_account("a", "sk-ant-api-a");
+        let acct_b = make_account("b", "sk-ant-api-b");
+        let acct_c = make_account("c", "sk-ant-api-c");
+        let state = test_state_with(vec![acct_a, acct_b, acct_c]);
+
+        let now = AppState::now_epoch();
+
+        // a: 5h=0.20 (healthy), b: 5h=0.30 (healthy)
+        for (i, util) in [(0, 0.20), (1, 0.30)].iter() {
+            let mut info = state.accounts[*i].rate_info.write().await;
+            info.utilization_5h = Some(*util);
+            info.reset_5h = Some(now + 10000);
+            info.utilization = Some(*util);
+            info.claims_7d.clear();
+        }
+        // c: status=rejected → status_to_floor → gate=1.0 → weight=0
+        {
+            let mut info = state.accounts[2].rate_info.write().await;
+            info.utilization_5h = Some(0.10);
+            info.reset_5h = Some(now + 10000);
+            info.utilization = Some(0.10);
+            info.status_5h = Some("rejected".to_string());
+            info.claims_7d.clear();
+        }
+
+        state.refresh_metrics_weights().await;
+
+        let read_weight = |i: usize| {
+            f64::from_bits(
+                state.accounts[i]
+                    .last_routing_weight
+                    .load(Ordering::Relaxed),
+            )
+        };
+        let read_share =
+            |i: usize| f64::from_bits(state.accounts[i].last_routing_share.load(Ordering::Relaxed));
+
+        // a and b are healthy: positive weight + positive share
+        assert!(read_weight(0) > 0.0, "a should have non-zero weight");
+        assert!(read_weight(1) > 0.0, "b should have non-zero weight");
+        assert!(read_share(0) > 0.0, "a should have non-zero share");
+        assert!(read_share(1) > 0.0, "b should have non-zero share");
+
+        // c was rejected (gate=1.0) → must be zeroed
+        assert_eq!(read_weight(2), 0.0, "c (rejected) must have zero weight");
+        assert_eq!(read_share(2), 0.0, "c (rejected) must have zero share");
+
+        // Shares of healthy accounts sum to ≈ 1.0
+        let total_share = read_share(0) + read_share(1) + read_share(2);
+        assert!(
+            (total_share - 1.0).abs() < 1e-9,
+            "shares should sum to 1.0, got {total_share}"
+        );
+
+        // Lower-utilization account should win the larger share (a < b)
+        assert!(
+            read_share(0) > read_share(1),
+            "a (lower 5h util) should have larger share than b: a={}, b={}",
+            read_share(0),
+            read_share(1)
+        );
+    }
+
+    /// Regression: when SOME accounts are above soft_limit but at least one
+    /// is healthy, the soft-limited ones must be zeroed (mirrors pick_account
+    /// excluding them). When ALL accounts are above soft_limit, none are
+    /// zeroed — graceful degradation, the dashboard reflects what
+    /// pick_account would actually still route to.
+    #[tokio::test]
+    async fn refresh_metrics_weights_soft_limit_graceful_degradation() {
+        let now = AppState::now_epoch();
+
+        // Scenario 1: mixed pool. a=healthy(0.20), b=soft-limited(0.95).
+        // soft_limit=0.90 → b should be zeroed, a gets all weight.
+        {
+            let state = test_state_with_soft_limit(
+                vec![
+                    make_account("a", "sk-ant-api-a"),
+                    make_account("b", "sk-ant-api-b"),
+                ],
+                0.90,
+            );
+            for (i, util) in [(0, 0.20), (1, 0.95)].iter() {
+                let mut info = state.accounts[*i].rate_info.write().await;
+                info.utilization_5h = Some(*util);
+                info.reset_5h = Some(now + 10000);
+                info.utilization = Some(*util);
+                info.claims_7d.clear();
+            }
+
+            state.refresh_metrics_weights().await;
+
+            let w_a = f64::from_bits(
+                state.accounts[0]
+                    .last_routing_weight
+                    .load(Ordering::Relaxed),
+            );
+            let w_b = f64::from_bits(
+                state.accounts[1]
+                    .last_routing_weight
+                    .load(Ordering::Relaxed),
+            );
+            let s_a = f64::from_bits(state.accounts[0].last_routing_share.load(Ordering::Relaxed));
+            let s_b = f64::from_bits(state.accounts[1].last_routing_share.load(Ordering::Relaxed));
+
+            assert!(w_a > 0.0, "healthy a should have non-zero weight");
+            assert_eq!(
+                w_b, 0.0,
+                "soft-limited b should be zeroed when a is healthy"
+            );
+            assert!(
+                (s_a - 1.0).abs() < 1e-9,
+                "a should have 100% share, got {s_a}"
+            );
+            assert_eq!(s_b, 0.0, "b should have zero share");
+        }
+
+        // Scenario 2: ENTIRE pool above soft_limit. a=0.95, b=0.92.
+        // soft_limit=0.90 → both above. Without graceful degradation the
+        // dashboard would go blank — instead BOTH should keep non-zero shares
+        // matching what pick_account would still route to.
+        {
+            let state = test_state_with_soft_limit(
+                vec![
+                    make_account("a", "sk-ant-api-a"),
+                    make_account("b", "sk-ant-api-b"),
+                ],
+                0.90,
+            );
+            for (i, util) in [(0, 0.95), (1, 0.92)].iter() {
+                let mut info = state.accounts[*i].rate_info.write().await;
+                info.utilization_5h = Some(*util);
+                info.reset_5h = Some(now + 10000);
+                info.utilization = Some(*util);
+                info.claims_7d.clear();
+            }
+
+            state.refresh_metrics_weights().await;
+
+            let w_a = f64::from_bits(
+                state.accounts[0]
+                    .last_routing_weight
+                    .load(Ordering::Relaxed),
+            );
+            let w_b = f64::from_bits(
+                state.accounts[1]
+                    .last_routing_weight
+                    .load(Ordering::Relaxed),
+            );
+            let s_a = f64::from_bits(state.accounts[0].last_routing_share.load(Ordering::Relaxed));
+            let s_b = f64::from_bits(state.accounts[1].last_routing_share.load(Ordering::Relaxed));
+
+            assert!(
+                w_a > 0.0,
+                "degraded a should still have non-zero weight (graceful degradation)"
+            );
+            assert!(
+                w_b > 0.0,
+                "degraded b should still have non-zero weight (graceful degradation)"
+            );
+            assert!(
+                (s_a + s_b - 1.0).abs() < 1e-9,
+                "shares should sum to 1.0 in degraded pool"
+            );
+            // b has lower utilization → larger share
+            assert!(
+                s_b > s_a,
+                "b (lower util) should outweigh a in degraded pool: a={s_a}, b={s_b}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn metrics_routing_weight_and_share_present() {
         let (mock_url, _handle) = spawn_mock_upstream().await;
@@ -14853,6 +15291,90 @@ upstream = "https://api.anthropic.com"
         assert!(
             body.contains("# TYPE anthropic_account_routing_share gauge"),
             "missing routing_share TYPE header:\n{body}"
+        );
+    }
+
+    /// Integration: GET /metrics emits anthropic_account_routing_weight and
+    /// anthropic_account_routing_share for non-passthrough accounts only,
+    /// with the values populated by refresh_metrics_weights().
+    #[tokio::test]
+    async fn metrics_routing_weight_and_share() {
+        let (mock_url, _handle) = spawn_mock_upstream().await;
+        let (app, state) = test_app(&mock_url, None);
+
+        // Default test_app builds 2 non-passthrough accounts: acct-a, acct-b.
+        let now = AppState::now_epoch();
+        {
+            let mut info = state.accounts[0].rate_info.write().await;
+            info.utilization_5h = Some(0.25);
+            info.reset_5h = Some(now + 10000);
+            info.utilization = Some(0.25);
+            info.claims_7d.clear();
+        }
+        {
+            let mut info = state.accounts[1].rate_info.write().await;
+            info.utilization_5h = Some(0.50);
+            info.reset_5h = Some(now + 10000);
+            info.utilization = Some(0.50);
+            info.claims_7d.clear();
+        }
+        state.refresh_metrics_weights().await;
+
+        let addr = serve(app).await;
+        let client = Client::new();
+        let resp = client
+            .get(format!("http://{}/metrics", addr))
+            .send()
+            .await
+            .unwrap();
+        let body = resp.text().await.unwrap();
+
+        // Both metric families are emitted with the right HELP/TYPE headers
+        assert!(
+            body.contains("# HELP anthropic_account_routing_weight"),
+            "missing routing_weight HELP:\n{body}"
+        );
+        assert!(
+            body.contains("# TYPE anthropic_account_routing_weight gauge"),
+            "missing routing_weight TYPE:\n{body}"
+        );
+        assert!(
+            body.contains("# HELP anthropic_account_routing_share"),
+            "missing routing_share HELP:\n{body}"
+        );
+
+        // Both accounts get a routing_weight line labeled by name
+        assert!(
+            body.contains("anthropic_account_routing_weight{account=\"acct-a\"}"),
+            "missing acct-a routing_weight:\n{body}"
+        );
+        assert!(
+            body.contains("anthropic_account_routing_weight{account=\"acct-b\"}"),
+            "missing acct-b routing_weight:\n{body}"
+        );
+
+        // Shares for the two accounts must sum to ≈ 1.0 (parsed out of the body)
+        let parse_share = |account: &str| -> f64 {
+            let needle = format!("anthropic_account_routing_share{{account=\"{account}\"}} ");
+            let line = body
+                .lines()
+                .find(|l| l.starts_with(&needle))
+                .unwrap_or_else(|| panic!("no share line for {account}"));
+            line[needle.len()..]
+                .trim()
+                .parse::<f64>()
+                .expect("parseable share")
+        };
+        let total = parse_share("acct-a") + parse_share("acct-b");
+        assert!(
+            (total - 1.0).abs() < 1e-9,
+            "shares should sum to 1.0, got {total}\n{body}"
+        );
+
+        // acct-a (lower utilization) should get the larger share
+        assert!(
+            parse_share("acct-a") > parse_share("acct-b"),
+            "acct-a should outweigh acct-b\n{body}"
         );
     }
 
@@ -14927,6 +15449,54 @@ upstream = "https://api.anthropic.com"
                 key
             );
         }
+    }
+
+    /// Integration: passthrough accounts must NOT appear in routing_weight or
+    /// routing_share output (refresh_metrics_weights skips them).
+    #[tokio::test]
+    async fn metrics_routing_weight_omits_passthrough() {
+        let acct_a = make_account("a", "sk-ant-api-a");
+        let acct_pt = make_account("pt", "passthrough");
+        let state = test_state_with(vec![acct_a, acct_pt]);
+
+        let now = AppState::now_epoch();
+        {
+            let mut info = state.accounts[0].rate_info.write().await;
+            info.utilization_5h = Some(0.25);
+            info.reset_5h = Some(now + 10000);
+            info.utilization = Some(0.25);
+            info.claims_7d.clear();
+        }
+        state.refresh_metrics_weights().await;
+
+        let app = Router::new()
+            .route("/metrics", axum::routing::get(metrics_handler))
+            .with_state(state.clone());
+        let addr = serve(app).await;
+        let client = Client::new();
+        let body = client
+            .get(format!("http://{}/metrics", addr))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        // a is present
+        assert!(
+            body.contains("anthropic_account_routing_weight{account=\"a\"}"),
+            "missing routing_weight for a:\n{body}"
+        );
+        // pt (passthrough) must be absent from BOTH families
+        assert!(
+            !body.contains("anthropic_account_routing_weight{account=\"pt\""),
+            "passthrough account must not appear in routing_weight:\n{body}"
+        );
+        assert!(
+            !body.contains("anthropic_account_routing_share{account=\"pt\""),
+            "passthrough account must not appear in routing_share:\n{body}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -722,21 +722,26 @@ impl AppState {
         }
 
         // Local freshness check: skip if this model's 7d claim was recently refreshed.
-        // Uses per-model claim.last_seen (not account-wide last_updated_epoch) so
-        // probing model A doesn't prevent probing model B in the same cycle.
+        // Looks up only the model-specific claim key (e.g. "seven_day_opus"), NOT the
+        // general "seven_day" fallback, so probing one family doesn't block another.
         let now_epoch = Self::now_epoch();
         {
             let info = acct.rate_info.read().await;
-            if let Some(claim) = resolve_7d_claim(&info, model) {
-                let age = now_epoch.saturating_sub(claim.last_seen);
-                if age < self.probe_interval_secs / 2 {
-                    trace!(
-                        account = acct.name,
-                        probe_model = model,
-                        age_secs = age,
-                        "probe skipped, model claim is fresh"
-                    );
-                    return;
+            let family = model_family(model);
+            if !family.is_empty() {
+                let claim_key = format!("seven_day_{}", family);
+                if let Some(claim) = info.claims_7d.get(&claim_key) {
+                    let age = now_epoch.saturating_sub(claim.last_seen);
+                    if age < self.probe_interval_secs / 2 {
+                        trace!(
+                            account = acct.name,
+                            probe_model = model,
+                            claim_key,
+                            age_secs = age,
+                            "probe skipped, model claim is fresh"
+                        );
+                        return;
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -745,10 +745,10 @@ impl AppState {
             }
         }
 
-        // Distributed probe lock: only one pod probes each account per interval
+        // Distributed probe lock: one pod per account+model per interval
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
-            let lock_key = format!("alb:probe:{}", acct.name);
+            let lock_key = format!("alb:probe:{}:{}", acct.name, model);
             let lock_ttl = self.probe_interval_secs.saturating_sub(10).max(1);
             let acquired: redis::RedisResult<bool> = redis::cmd("SET")
                 .arg(&lock_key)

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,12 @@ struct RedisRateInfo {
     limit_requests: Option<u64>,
     limit_tokens: Option<u64>,
     updated_at: u64,
+    /// Precomputed routing weight (from refresh_metrics_weights on the probing pod).
+    /// Non-probing pods read this to set their gauge atomics without recomputing.
+    #[serde(default)]
+    routing_weight: Option<f64>,
+    #[serde(default)]
+    routing_share: Option<f64>,
 }
 
 #[derive(Default)]
@@ -2052,6 +2058,12 @@ impl AppState {
                 limit_requests: info.limit_requests,
                 limit_tokens: info.limit_tokens,
                 updated_at: Self::now_epoch(),
+                routing_weight: Some(f64::from_bits(
+                    acct.last_routing_weight.load(Ordering::Relaxed),
+                )),
+                routing_share: Some(f64::from_bits(
+                    acct.last_routing_share.load(Ordering::Relaxed),
+                )),
             };
             // Compute TTL from earliest reset timestamp
             let now_epoch = Self::now_epoch();
@@ -2256,6 +2268,17 @@ impl AppState {
                             info.limit_tokens = remote.limit_tokens;
                             info.last_updated = Some(now_instant);
                             info.last_updated_epoch = Some(remote.updated_at);
+                            // Apply precomputed routing weights from probing pod
+                            if let Some(w) = remote.routing_weight {
+                                self.accounts[i]
+                                    .last_routing_weight
+                                    .store(w.to_bits(), Ordering::Relaxed);
+                            }
+                            if let Some(s) = remote.routing_share {
+                                self.accounts[i]
+                                    .last_routing_share
+                                    .store(s.to_bits(), Ordering::Relaxed);
+                            }
                             trace!(
                                 account = self.accounts[i].name,
                                 remote_age,
@@ -13819,6 +13842,8 @@ data: {\"type\":\"message_stop\"}\n\n";
             limit_requests: Some(200),
             limit_tokens: Some(100000),
             updated_at: 1700000000,
+            routing_weight: None,
+            routing_share: None,
         };
 
         let json = serde_json::to_string(&info).unwrap();
@@ -13853,6 +13878,8 @@ data: {\"type\":\"message_stop\"}\n\n";
             limit_requests: None,
             limit_tokens: None,
             updated_at: 0,
+            routing_weight: None,
+            routing_share: None,
         };
 
         let json = serde_json::to_string(&info).unwrap();
@@ -14113,6 +14140,8 @@ upstream = "https://api.anthropic.com"
             limit_requests: Some(200),
             limit_tokens: Some(100000),
             updated_at: now_epoch - 10, // 10s ago — newer than local
+            routing_weight: None,
+            routing_share: None,
         };
 
         // Apply same merge logic as sync_from_redis
@@ -14167,6 +14196,8 @@ upstream = "https://api.anthropic.com"
             limit_requests: None,
             limit_tokens: None,
             updated_at: now_epoch - 120, // 120s ago — older than local
+            routing_weight: None,
+            routing_share: None,
         };
 
         // Apply same merge logic as sync_from_redis
@@ -14220,6 +14251,8 @@ upstream = "https://api.anthropic.com"
             limit_requests: None,
             limit_tokens: None,
             updated_at: now_epoch - 30,
+            routing_weight: None,
+            routing_share: None,
         };
 
         // When local has no epoch, local_age = u64::MAX, so remote always wins

--- a/src/main.rs
+++ b/src/main.rs
@@ -743,7 +743,7 @@ impl AppState {
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
             let lock_key = format!("alb:probe:{}:{}", acct.name, model);
-            let lock_ttl = self.probe_interval_secs.saturating_sub(30).max(60);
+            let lock_ttl = self.probe_interval_secs.saturating_sub(10).max(1);
             let acquired: redis::RedisResult<bool> = redis::cmd("SET")
                 .arg(&lock_key)
                 .arg(1u8)
@@ -1547,18 +1547,32 @@ impl AppState {
             //   3. The model-specific claim with the highest waste_risk
             //      (worst-case representative for the dashboard)
             //   4. None → no 7d data, fall back to headroom-only
+            let claim_is_fresh = |c: &&ClaimWindowData| {
+                time_adjusted_utilization(
+                    Some(0.0),
+                    c.reset,
+                    c.status.as_deref(),
+                    NEAR_RESET_7D_SECS,
+                    now_epoch,
+                )
+                .is_some()
+            };
             let representative: Option<&ClaimWindowData> = {
                 let rep_key = info.representative_claim.as_deref();
                 rep_key
                     .filter(|k| k.starts_with("seven_day"))
                     .and_then(|k| info.claims_7d.get(k))
-                    .or_else(|| info.claims_7d.get("seven_day"))
+                    .filter(claim_is_fresh)
+                    .or_else(|| info.claims_7d.get("seven_day").filter(claim_is_fresh))
                     .or_else(|| {
-                        info.claims_7d.values().max_by(|a, b| {
-                            let wr_a = waste_risk(a.utilization, a.reset, now_epoch);
-                            let wr_b = waste_risk(b.utilization, b.reset, now_epoch);
-                            wr_a.partial_cmp(&wr_b).unwrap_or(std::cmp::Ordering::Equal)
-                        })
+                        info.claims_7d
+                            .values()
+                            .filter(claim_is_fresh)
+                            .max_by(|a, b| {
+                                let wr_a = waste_risk(a.utilization, a.reset, now_epoch);
+                                let wr_b = waste_risk(b.utilization, b.reset, now_epoch);
+                                wr_a.partial_cmp(&wr_b).unwrap_or(std::cmp::Ordering::Equal)
+                            })
                     })
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6253,33 +6253,21 @@ async fn main() {
                 interval_secs = probe_interval,
                 "starting utilization probes"
             );
-            let mut probe_cycle: usize = 0;
             loop {
                 for i in 0..n_accounts {
-                    // Rotate probe model per account per cycle
-                    let model_idx = (probe_cycle + i) % PROBE_MODELS.len();
-                    let model = PROBE_MODELS[model_idx];
-                    // Skip if account doesn't serve this model family
                     let acct = &probe_state.accounts[i];
-                    if !acct.serves_model(model) {
-                        // Try next model in rotation
-                        let alt_idx = (model_idx + 1) % PROBE_MODELS.len();
-                        let alt_model = PROBE_MODELS[alt_idx];
-                        if acct.serves_model(alt_model) {
-                            probe_state.probe_account(i, alt_model).await;
+                    // Probe all model families per account per cycle
+                    for model in PROBE_MODELS {
+                        if acct.serves_model(model) {
+                            probe_state.probe_account(i, model).await;
+                            tokio::time::sleep(Duration::from_secs(2)).await;
                         }
-                        // else: account serves none of our probe models, skip
-                    } else {
-                        probe_state.probe_account(i, model).await;
                     }
-                    // Small delay between accounts to avoid burst
-                    tokio::time::sleep(Duration::from_secs(2)).await;
                 }
                 // Recompute metric weights once per cycle, after all probes
                 // have refreshed rate-limit data. Keeps the gauges aligned
                 // with steady-state pool health, not per-request bias.
                 probe_state.refresh_metrics_weights().await;
-                probe_cycle = probe_cycle.wrapping_add(1);
                 tokio::time::sleep(Duration::from_secs(probe_interval)).await;
             }
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -739,10 +739,10 @@ impl AppState {
             }
         }
 
-        // Distributed probe lock: only one pod probes each account+model per interval
+        // Distributed probe lock: only one pod probes each account per interval
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
-            let lock_key = format!("alb:probe:{}:{}", acct.name, model);
+            let lock_key = format!("alb:probe:{}", acct.name);
             let lock_ttl = self.probe_interval_secs.saturating_sub(10).max(1);
             let acquired: redis::RedisResult<bool> = redis::cmd("SET")
                 .arg(&lock_key)
@@ -1548,14 +1548,15 @@ impl AppState {
             //      (worst-case representative for the dashboard)
             //   4. None → no 7d data, fall back to headroom-only
             let claim_is_fresh = |c: &&ClaimWindowData| {
-                time_adjusted_utilization(
-                    Some(0.0),
-                    c.reset,
-                    c.status.as_deref(),
-                    NEAR_RESET_7D_SECS,
-                    now_epoch,
-                )
-                .is_some()
+                c.reset.is_some()
+                    && time_adjusted_utilization(
+                        Some(0.0),
+                        c.reset,
+                        c.status.as_deref(),
+                        NEAR_RESET_7D_SECS,
+                        now_epoch,
+                    )
+                    .is_some()
             };
             let representative: Option<&ClaimWindowData> = {
                 let rep_key = info.representative_claim.as_deref();

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,6 +458,8 @@ struct AppState {
     next_req_id: AtomicU64,
     /// Random instance ID for cross-replica log disambiguation.
     instance_id: u16,
+    /// Probe interval in seconds. Used for freshness check and distributed lock TTL.
+    probe_interval_secs: u64,
 }
 
 impl Account {
@@ -719,6 +721,54 @@ impl AppState {
             }
         }
 
+        // Local freshness check: skip if data was recently refreshed (e.g. by Redis sync)
+        let now_epoch = Self::now_epoch();
+        {
+            let info = acct.rate_info.read().await;
+            if let Some(epoch) = info.last_updated_epoch {
+                let age = now_epoch.saturating_sub(epoch);
+                if age < self.probe_interval_secs / 2 {
+                    trace!(
+                        account = acct.name,
+                        probe_model = model,
+                        age_secs = age,
+                        "probe skipped, data is fresh"
+                    );
+                    return;
+                }
+            }
+        }
+
+        // Distributed probe lock: only one pod probes each account+model per interval
+        if let Some(redis) = &self.redis {
+            let mut conn = redis.clone();
+            let lock_key = format!("alb:probe:{}:{}", acct.name, model);
+            let lock_ttl = self.probe_interval_secs.saturating_sub(30).max(60);
+            let acquired: redis::RedisResult<bool> = redis::cmd("SET")
+                .arg(&lock_key)
+                .arg(1u8)
+                .arg("NX")
+                .arg("EX")
+                .arg(lock_ttl)
+                .query_async(&mut conn)
+                .await;
+            match acquired {
+                Ok(true) => {} // Lock acquired, proceed with probe
+                Ok(false) => {
+                    trace!(
+                        account = acct.name,
+                        probe_model = model,
+                        "probe skipped, another replica is probing"
+                    );
+                    return;
+                }
+                Err(e) => {
+                    // Fail-open: if Redis is down, probe anyway
+                    trace!(account = acct.name, error = %e, "probe lock failed, probing anyway");
+                }
+            }
+        }
+
         let url = format!("{}/v1/messages", self.upstream);
         let body = serde_json::json!({
             "model": model,
@@ -778,8 +828,10 @@ impl AppState {
                 }
                 self.save_state().await;
                 let info = acct.rate_info.read().await;
+                let now_epoch = Self::now_epoch();
                 let (eff_util, constraint, _adj_5h, _adj_7d) =
-                    effective_utilization(&info, Self::now_epoch(), model);
+                    effective_utilization(&info, now_epoch, model);
+                let rw = compute_routing_weight(&info, model, now_epoch, false);
                 info!(
                     account = acct.name,
                     status = status.as_u16(),
@@ -797,6 +849,27 @@ impl AppState {
                         .unwrap_or("-"),
                     constraint,
                     n_claims_7d = info.claims_7d.len(),
+                    gate_5h = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.gate_5h))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    gate_7d = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.gate_7d))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    waste_risk = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.wr))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    weight = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.weight))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    weight_source = rw.as_ref().map(|r| r.source).unwrap_or("-"),
                     "probe complete"
                 );
             }
@@ -1212,12 +1285,109 @@ fn effective_utilization(
     }
 }
 
+/// Computed routing weight for a single account+model. Extracted so both
+/// `routing_candidates()` (real requests) and `probe_account()` (periodic probes)
+/// use identical logic. Returns `None` when the account's 7d claim is rejected
+/// (caller should skip it).
+struct RoutingWeight {
+    gate_5h: f64,
+    gate_7d: f64,
+    gate: f64,
+    wr: f64,
+    weight: f64,
+    source: &'static str,
+}
+
+fn compute_routing_weight(
+    info: &RateLimitInfo,
+    model: &str,
+    now_epoch: u64,
+    stale_after_hard_limit: bool,
+) -> Option<RoutingWeight> {
+    // 5h gate: time-adjusted 5h utilization with status floors
+    let gate_5h = if stale_after_hard_limit {
+        0.5
+    } else {
+        time_adjusted_utilization(
+            info.utilization_5h,
+            info.reset_5h,
+            info.status_5h.as_deref(),
+            NEAR_RESET_5H_SECS,
+            now_epoch,
+        )
+        .unwrap_or_else(|| {
+            // Fallback: raw unified, legacy, or unknown
+            if let Some(util) = info.utilization {
+                util
+            } else if let Some(remaining) = info.remaining_tokens {
+                let limit = info.limit_tokens.unwrap_or(1_000_000);
+                (1.0 - (remaining as f64 / limit as f64)).clamp(0.0, 1.0)
+            } else {
+                0.5
+            }
+        })
+    };
+
+    // 7d model-specific gate and waste risk
+    let (gate_7d, wr, source) = if let Some(claim) = resolve_7d_claim(info, model) {
+        if claim.status.as_deref() == Some("rejected") && !stale_after_hard_limit {
+            return None; // caller should skip this account
+        }
+        (
+            if stale_after_hard_limit {
+                0.5
+            } else {
+                time_adjusted_utilization(
+                    Some(0.0),
+                    claim.reset,
+                    claim.status.as_deref(),
+                    NEAR_RESET_7D_SECS,
+                    now_epoch,
+                )
+                .unwrap_or(0.0)
+            },
+            waste_risk(claim.utilization, claim.reset, now_epoch),
+            "waste_risk",
+        )
+    } else {
+        (
+            if stale_after_hard_limit {
+                0.5
+            } else {
+                time_adjusted_utilization(
+                    Some(0.0),
+                    info.reset_7d,
+                    info.status_7d.as_deref(),
+                    NEAR_RESET_7D_SECS,
+                    now_epoch,
+                )
+                .unwrap_or(0.0)
+            },
+            0.0,
+            "headroom_only",
+        )
+    };
+
+    let gate = gate_5h.max(gate_7d);
+    let headroom = (1.0 - gate).max(0.01);
+    let weight = if wr > 0.0 { wr * headroom } else { headroom };
+    let weight = if gate >= 1.0 { 0.0 } else { weight };
+
+    Some(RoutingWeight {
+        gate_5h,
+        gate_7d,
+        gate,
+        wr,
+        weight,
+        source,
+    })
+}
+
 impl AppState {
     async fn routing_candidates(&self, model: &str, skip: &[usize]) -> Vec<RoutingCandidate> {
         let now = Instant::now();
         let now_epoch = Self::now_epoch();
-        let mut candidate_meta: Vec<(usize, &'static str)> = Vec::new();
-        let mut candidate_snaps: Vec<AcctMetricsSnap> = Vec::new();
+        let mut candidates: Vec<RoutingCandidate> = Vec::new();
         for (i, acct) in self.accounts.iter().enumerate() {
             if skip.contains(&i) {
                 trace!(account = acct.name, "pick: skipping, already tried");
@@ -1254,14 +1424,9 @@ impl AppState {
                 .hard_limited_until
                 .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
 
-            // 7d model-specific selection. Keep raw 7d utilization in waste_risk,
-            // and use gate_7d only for pressure/status so we do not double-count
-            // the same 7d signal in both terms.
-            let (claims, source) = if let Some(claim) = resolve_7d_claim(&info, model) {
-                // Skip if this model's 7d claim is rejected AND we have fresh data.
-                // Stale rejections from expired hard limits are ignored — the account
-                // needs a chance to prove it's recovered.
-                if claim.status.as_deref() == Some("rejected") && !stale_after_hard_limit {
+            let rw = match compute_routing_weight(&info, model, now_epoch, stale_after_hard_limit) {
+                Some(rw) => rw,
+                None => {
                     trace!(
                         account = acct.name,
                         model = model,
@@ -1269,70 +1434,27 @@ impl AppState {
                     );
                     continue;
                 }
-                (
-                    vec![ClaimMetricsSnap {
-                        key: "selected".to_string(),
-                        utilization: claim.utilization,
-                        waste_risk: waste_risk(claim.utilization, claim.reset, now_epoch),
-                        reset: claim.reset,
-                        status: claim.status.clone(),
-                    }],
-                    "waste_risk",
-                )
-            } else {
-                (Vec::new(), "headroom_only")
             };
 
-            candidate_snaps.push(AcctMetricsSnap {
-                name: acct.name.clone(),
-                passthrough: acct.passthrough,
-                has_applicable_7d: !claims.is_empty(),
-                utilization: info.utilization,
-                utilization_5h: info.utilization_5h,
-                utilization_7d: info.utilization_7d,
-                reset_5h: info.reset_5h,
-                reset_7d: info.reset_7d,
-                status_5h: info.status_5h.clone(),
-                status_7d: info.status_7d.clone(),
-                stale_after_hard_limit,
-                hard_limited_active: false,
-                burn_rate: (0.0, 0.0, 0.0),
-                headroom: None,
-                remaining_requests: info.remaining_requests,
-                remaining_tokens: info.remaining_tokens,
-                limit_requests: info.limit_requests,
-                limit_tokens: info.limit_tokens,
-                requests_total: 0,
-                hard_limited_secs: 0.0,
-                projected_throttle_secs: None,
-                token_usage: [0; 4],
-                claims,
-            });
-            candidate_meta.push((i, source));
-        }
-
-        let weight_snaps = compute_routing_weights(&candidate_snaps, now_epoch, self.soft_limit);
-        let mut candidates: Vec<RoutingCandidate> = Vec::with_capacity(weight_snaps.len());
-        for ((idx, source), snap) in candidate_meta.into_iter().zip(weight_snaps) {
             trace!(
-                account = snap.name,
-                gate_5h = format!("{:.4}", snap.gate_5h),
-                gate_7d = format!("{:.4}", snap.gate_7d),
-                gate = format!("{:.4}", snap.gate),
-                waste_risk = format!("{:.4}", snap.wr),
-                weight = format!("{:.4}", snap.weight),
-                source = source,
+                account = acct.name,
+                gate_5h = format!("{:.4}", rw.gate_5h),
+                gate_7d = format!("{:.4}", rw.gate_7d),
+                gate = format!("{:.4}", rw.gate),
+                waste_risk = format!("{:.4}", rw.wr),
+                weight = format!("{:.4}", rw.weight),
+                source = rw.source,
                 "pick: candidate"
             );
 
             candidates.push(RoutingCandidate {
-                idx,
-                gate_5h: snap.gate_5h,
-                gate_7d: snap.gate_7d,
-                gate: snap.gate,
-                wr: snap.wr,
-                weight: snap.weight,
-                source,
+                idx: i,
+                gate_5h: rw.gate_5h,
+                gate_7d: rw.gate_7d,
+                gate: rw.gate,
+                wr: rw.wr,
+                weight: rw.weight,
+                source: rw.source,
             });
         }
         candidates
@@ -6039,6 +6161,7 @@ async fn main() {
             use std::hash::{BuildHasher, Hasher};
             RandomState::new().build_hasher().finish() as u16
         },
+        probe_interval_secs: config.probe_interval_secs.unwrap_or(300),
     });
 
     if state.auto_cache {
@@ -6250,6 +6373,7 @@ mod tests {
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         })
     }
 
@@ -6289,6 +6413,7 @@ mod tests {
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         })
     }
 
@@ -6389,6 +6514,7 @@ mod tests {
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         (build_router(state.clone()), state)
@@ -6482,6 +6608,7 @@ mod tests {
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         assert!(state.is_ip_allowed(&"10.0.0.1".parse().unwrap()));
         assert!(!state.is_ip_allowed(&"10.0.0.2".parse().unwrap()));
@@ -8785,6 +8912,7 @@ mod tests {
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         let app = Router::new()
@@ -9460,6 +9588,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Try many affinity keys — all should route to healthy (idx 0)
@@ -9560,6 +9689,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Within budget
@@ -10067,6 +10197,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         {
             let mut info = state.accounts[0].rate_info.write().await;
@@ -10137,6 +10268,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         {
             let mut info = state.accounts[0].rate_info.write().await;
@@ -10503,6 +10635,138 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(wr, 0.0, "util > 1.0 should produce zero waste risk");
     }
 
+    // ── compute_routing_weight tests ──────────────────────────────
+
+    #[test]
+    fn routing_weight_basic_5h_only() {
+        // No 7d data → headroom_only, weight = headroom = 1 - gate_5h
+        let now = 1_000_000u64;
+        let info = RateLimitInfo {
+            utilization_5h: Some(0.40),
+            reset_5h: Some(now + 18000), // 5h window
+            status_5h: Some("allowed".to_string()),
+            ..Default::default()
+        };
+        let rw = compute_routing_weight(&info, "claude-sonnet-4-6", now, false)
+            .expect("should produce weight");
+        assert!(rw.gate_5h > 0.0 && rw.gate_5h < 1.0);
+        assert_eq!(rw.source, "headroom_only");
+        assert!(rw.wr == 0.0);
+        assert!(rw.weight > 0.0);
+    }
+
+    #[test]
+    fn routing_weight_with_waste_risk() {
+        // 7d claim present → waste_risk sourced weight
+        let now = 1_000_000u64;
+        let mut claims = HashMap::new();
+        claims.insert(
+            "seven_day_sonnet".to_string(),
+            ClaimWindowData {
+                utilization: Some(0.40),
+                reset: Some(now + 302400), // 3.5 days
+                status: Some("allowed".to_string()),
+                last_seen: now,
+            },
+        );
+        let info = RateLimitInfo {
+            utilization_5h: Some(0.20),
+            reset_5h: Some(now + 18000),
+            status_5h: Some("allowed".to_string()),
+            claims_7d: claims,
+            ..Default::default()
+        };
+        let rw = compute_routing_weight(&info, "claude-sonnet-4-6", now, false)
+            .expect("should produce weight");
+        assert_eq!(rw.source, "waste_risk");
+        assert!(rw.wr > 0.0, "waste_risk should be positive");
+        // weight = wr * headroom (both positive)
+        assert!(rw.weight > 0.0);
+    }
+
+    #[test]
+    fn routing_weight_rejected_returns_none() {
+        // 7d claim rejected → None (account should be skipped)
+        let now = 1_000_000u64;
+        let mut claims = HashMap::new();
+        claims.insert(
+            "seven_day_sonnet".to_string(),
+            ClaimWindowData {
+                utilization: Some(1.0),
+                reset: Some(now + 302400),
+                status: Some("rejected".to_string()),
+                last_seen: now,
+            },
+        );
+        let info = RateLimitInfo {
+            utilization_5h: Some(0.20),
+            reset_5h: Some(now + 18000),
+            status_5h: Some("allowed".to_string()),
+            claims_7d: claims,
+            ..Default::default()
+        };
+        assert!(
+            compute_routing_weight(&info, "claude-sonnet-4-6", now, false).is_none(),
+            "rejected claim should return None"
+        );
+    }
+
+    #[test]
+    fn routing_weight_stale_uses_fallback() {
+        // stale_after_hard_limit = true → both gates fallback to 0.5
+        let now = 1_000_000u64;
+        let info = RateLimitInfo {
+            utilization_5h: Some(0.95), // would be high, but stale
+            reset_5h: Some(now + 18000),
+            status_5h: Some("throttled".to_string()),
+            ..Default::default()
+        };
+        let rw = compute_routing_weight(&info, "claude-sonnet-4-6", now, true)
+            .expect("stale should still produce weight");
+        assert_eq!(rw.gate_5h, 0.5);
+        assert_eq!(rw.gate_7d, 0.5);
+        assert_eq!(rw.gate, 0.5);
+    }
+
+    #[test]
+    fn routing_weight_rejected_but_stale_still_returns_some() {
+        // Stale after hard limit + rejected claim → should NOT skip (give it a chance)
+        let now = 1_000_000u64;
+        let mut claims = HashMap::new();
+        claims.insert(
+            "seven_day_sonnet".to_string(),
+            ClaimWindowData {
+                utilization: Some(1.0),
+                reset: Some(now + 302400),
+                status: Some("rejected".to_string()),
+                last_seen: now,
+            },
+        );
+        let info = RateLimitInfo {
+            utilization_5h: Some(0.20),
+            reset_5h: Some(now + 18000),
+            status_5h: Some("allowed".to_string()),
+            claims_7d: claims,
+            ..Default::default()
+        };
+        assert!(
+            compute_routing_weight(&info, "claude-sonnet-4-6", now, true).is_some(),
+            "stale rejected should still return Some (give account a chance)"
+        );
+    }
+
+    #[test]
+    fn routing_weight_no_data_uses_defaults() {
+        // No utilization data at all → gate_5h=0.5 (unknown), headroom=0.5
+        let now = 1_000_000u64;
+        let info = RateLimitInfo::default();
+        let rw = compute_routing_weight(&info, "claude-sonnet-4-6", now, false)
+            .expect("should produce weight with defaults");
+        assert_eq!(rw.gate_5h, 0.5);
+        assert_eq!(rw.source, "headroom_only");
+        assert!(rw.weight > 0.0);
+    }
+
     // ── resolve_7d_claim tests ────────────────────────────────────
 
     #[test]
@@ -10625,6 +10889,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Header overrides IP mapping (supports multiple clients per IP)
@@ -10692,6 +10957,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         let ip: IpAddr = "10.0.0.1".parse().unwrap();
@@ -11485,6 +11751,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.50, 0.40, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.60, 0.50, now + 10000, now + 100000).await;
@@ -11533,6 +11800,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.80, 0.70, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.90, 0.80, now + 10000, now + 100000).await;
@@ -11582,6 +11850,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.90, 0.80, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.50, 0.40, now + 10000, now + 100000).await;
@@ -11633,6 +11902,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.95, 0.90, now + 10000, now + 100000).await;
         // Operator bypasses everything
@@ -11681,6 +11951,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // Request for "claude-opus" — no account serves it → should pass
         assert!(
@@ -11731,6 +12002,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // Don't set any utilization — accounts remain "unknown" (0.5)
         // With limit=0.30, unknown 0.5 would appear "above limit" without fail-open
@@ -11785,6 +12057,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // Two known accounts above limit, one unknown (no data set)
         set_account_utilization(&state, 0, 0.80, 0.70, now + 10000, now + 100000).await;
@@ -11859,6 +12132,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.98, 0.96, now + 10000, now + 100000).await;
         assert!(state.is_emergency_brake_active().await);
@@ -11935,6 +12209,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.85, 0.70, now + 10000, now + 100000).await;
         assert!(
@@ -12026,6 +12301,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // No rate data set — account returns (0.5, "unknown")
         // 0.5 >= 0.4 threshold → all_above is true
@@ -12077,6 +12353,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.60, 0.55, now + 10000, now + 100000).await;
         // Account 1: no data → (0.5, "unknown"), 0.5 >= 0.4 → all_above stays true
@@ -12175,6 +12452,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // "-" is not the operator
         assert!(!state.is_operator("-"));
@@ -12251,6 +12529,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // Operator always gets "healthy" regardless of utilization
         assert_eq!(compute_pressure_status(0.99, "ray", &state), "healthy");
@@ -12294,6 +12573,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // gastown has limit 0.85, 80% of that = 0.68
         // At 0.60, below 0.68 → no upgrade → "healthy"
@@ -12513,6 +12793,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // Set utilization above client's limit (0.80 > 0.50)
         set_account_utilization(&state, 0, 0.80, 0.70, now + 10000, now + 100000).await;
@@ -12574,6 +12855,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // Set utilization below client's limit (0.50 < 0.90)
         set_account_utilization(&state, 0, 0.50, 0.40, now + 10000, now + 100000).await;
@@ -12632,6 +12914,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // All accounts above emergency threshold. 5h=0.96 > emergency threshold (0.88).
         set_account_utilization(&state, 0, 0.96, 0.0, now + 10000, now + 100000).await;
@@ -12698,6 +12981,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         // All accounts above emergency threshold — 5h only (avoid claim penalty on 7d)
         set_account_utilization(&state, 0, 0.96, 0.0, now + 10000, now + 100000).await;
@@ -12761,6 +13045,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.80, 0.70, now + 10000, now + 100000).await;
 
@@ -12819,6 +13104,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         set_account_utilization(&state, 0, 0.96, 0.0, now + 10000, now + 100000).await;
 
@@ -12928,6 +13214,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         let ip: IpAddr = "192.168.1.100".parse().unwrap();
@@ -12999,6 +13286,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         let status = compute_pressure_status(0.99, "operator-id", &state);
@@ -13050,6 +13338,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // 0.65 is > 80% of 0.80 limit (80% * 0.80 = 0.64), so should upgrade from healthy to elevated
@@ -13368,6 +13657,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         assert!(state.is_operator("special-operator"));
@@ -13414,6 +13704,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
         assert!(state.is_operator("ray"));
         assert!(state.is_operator("openclaw"));
@@ -13474,6 +13765,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Budget check uses local path when redis is None
@@ -13607,6 +13899,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Recording 0 tokens should be a no-op
@@ -13970,6 +14263,7 @@ upstream = "https://api.anthropic.com"
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Set up some state to persist
@@ -14055,6 +14349,7 @@ upstream = "https://api.anthropic.com"
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Load state
@@ -14140,6 +14435,7 @@ upstream = "https://api.anthropic.com"
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Pre-populate with yesterday's usage (high usage that would exceed budget)
@@ -14194,6 +14490,7 @@ upstream = "https://api.anthropic.com"
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Pre-populate with yesterday's exhausted budget
@@ -14665,6 +14962,7 @@ upstream = "https://api.anthropic.com"
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         // Seed two operator clients and one regular client with token usage
@@ -14912,6 +15210,7 @@ upstream = "https://api.anthropic.com"
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         let app = build_router(state);
@@ -15649,6 +15948,7 @@ upstream = "https://api.anthropic.com"
             cluster_info_cache: Mutex::new(None),
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
+            probe_interval_secs: 300,
         });
 
         let app = Router::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -4125,7 +4125,7 @@ fn append_routing_weight_metrics(
         buf,
         "anthropic_account_routing_weight",
         "gauge",
-        "Per-account routing weight (headroom * waste_risk)",
+        "Per-account routing weight (headroom * waste_risk, or plain headroom when no 7d claim)",
     );
     prom_header(
         buf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -750,7 +750,11 @@ impl AppState {
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
             let lock_key = format!("alb:probe:{}:{}", acct.name, model);
-            let lock_ttl = self.probe_interval_secs.saturating_sub(10).max(1);
+            let lock_ttl = if self.probe_interval_secs > 10 {
+                self.probe_interval_secs - 10
+            } else {
+                self.probe_interval_secs
+            };
             let acquired: redis::RedisResult<bool> = redis::cmd("SET")
                 .arg(&lock_key)
                 .arg(1u8)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2354,9 +2354,10 @@ impl AppState {
             .map(|a| format!("alb:hard:{}", a.name))
             .collect();
 
-        if let Ok(values) = conn.mget::<_, Vec<Option<u64>>>(&hard_keys).await {
-            for (i, remote) in values.iter().enumerate() {
-                match classify_hard_limit_sync(*remote, now_epoch, now_instant) {
+        if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&hard_keys).await {
+            for (i, remote) in values.into_iter().enumerate() {
+                let remote = remote.and_then(|value| value.parse::<u64>().ok());
+                match classify_hard_limit_sync(remote, now_epoch, now_instant) {
                     HardLimitSync::Clear => {
                         // Another replica observed recovery. Clear our local
                         // `hard_limited_until` so pick_account stops excluding
@@ -3544,10 +3545,9 @@ async fn proxy_handler(
                 false
             };
 
-            // Persist state after clearing hard limit so the saved snapshot is clean
-            if status.is_success() {
-                state.save_state().await;
-            }
+            // Persist state after updating rate-limit state so completed 4xx
+            // responses and other terminal outcomes aren't dropped on restart.
+            state.save_state().await;
 
             if recovered {
                 state.signal_hard_limit_recovery(acct).await;
@@ -5878,10 +5878,9 @@ async fn openai_chat_handler(
                 false
             };
 
-            // Persist state after clearing hard limit so the saved snapshot is clean
-            if status.is_success() {
-                state.save_state().await;
-            }
+            // Persist state after updating rate-limit state so completed 4xx
+            // responses and other terminal outcomes aren't dropped on restart.
+            state.save_state().await;
 
             if recovered {
                 state.signal_hard_limit_recovery(acct).await;
@@ -6468,6 +6467,7 @@ async fn main() {
             info!("probes disabled — metrics weights refresh on a 60s timer");
             loop {
                 metrics_state.refresh_metrics_weights().await;
+                metrics_state.publish_routing_weights().await;
                 tokio::time::sleep(FALLBACK_INTERVAL).await;
             }
         });
@@ -6594,39 +6594,11 @@ mod tests {
     }
 
     fn test_state_with_soft_limit(accounts: Vec<Account>, soft_limit: f64) -> Arc<AppState> {
-        Arc::new(AppState {
-            client: Client::builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts,
-            robin: AtomicUsize::new(0),
-            routing_strategy: RoutingStrategy::default(),
-            cooldown: Duration::from_secs(60),
-            state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
-            proxy_key: None,
-            allowed_ips: vec![],
-            upstreams: vec![],
-            client_names: HashMap::new(),
-            auto_cache: true,
-            client_usage: Mutex::new(HashMap::new()),
-            shadow_log_tx: None,
-            shadow_log_dropped: AtomicU64::new(0),
-            client_budgets: HashMap::new(),
-            budget_usage: Mutex::new(HashMap::new()),
-            client_utilization_limits: HashMap::new(),
-            operators: vec![],
-            emergency_brake: true,
-            emergency_threshold: DEFAULT_EMERGENCY_THRESHOLD,
-            client_request_rates: Mutex::new(HashMap::new()),
-            soft_limit,
-            redis: None,
-            cluster_info_cache: Mutex::new(None),
-            next_req_id: AtomicU64::new(0),
-            instance_id: 0,
-            probe_interval_secs: 300,
-        })
+        let mut state = test_state_with(accounts);
+        Arc::get_mut(&mut state)
+            .expect("test fixture should be uniquely owned")
+            .soft_limit = soft_limit;
+        state
     }
 
     /// Spawn a mock upstream that returns a canned response with rate-limit headers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,12 +156,6 @@ struct RedisRateInfo {
     limit_requests: Option<u64>,
     limit_tokens: Option<u64>,
     updated_at: u64,
-    /// Precomputed routing weight (from refresh_metrics_weights on the probing pod).
-    /// Non-probing pods read this to set their gauge atomics without recomputing.
-    #[serde(default)]
-    routing_weight: Option<f64>,
-    #[serde(default)]
-    routing_share: Option<f64>,
 }
 
 #[derive(Default)]
@@ -727,18 +721,20 @@ impl AppState {
             }
         }
 
-        // Local freshness check: skip if data was recently refreshed (e.g. by Redis sync)
+        // Local freshness check: skip if this model's 7d claim was recently refreshed.
+        // Uses per-model claim.last_seen (not account-wide last_updated_epoch) so
+        // probing model A doesn't prevent probing model B in the same cycle.
         let now_epoch = Self::now_epoch();
         {
             let info = acct.rate_info.read().await;
-            if let Some(epoch) = info.last_updated_epoch {
-                let age = now_epoch.saturating_sub(epoch);
+            if let Some(claim) = resolve_7d_claim(&info, model) {
+                let age = now_epoch.saturating_sub(claim.last_seen);
                 if age < self.probe_interval_secs / 2 {
                     trace!(
                         account = acct.name,
                         probe_model = model,
                         age_secs = age,
-                        "probe skipped, data is fresh"
+                        "probe skipped, model claim is fresh"
                     );
                     return;
                 }
@@ -829,6 +825,18 @@ impl AppState {
                     // immediately so the dashboard reflects the account coming
                     // back online without waiting for the next probe cycle.
                     if recovered {
+                        // DEL Redis hard-limit key so other replicas don't re-apply it
+                        if let Some(redis) = &self.redis {
+                            let mut conn = redis.clone();
+                            let key = format!("alb:hard:{}", acct.name);
+                            tokio::spawn(async move {
+                                use redis::AsyncCommands;
+                                let result: redis::RedisResult<()> = conn.del(&key).await;
+                                if let Err(e) = result {
+                                    tracing::warn!(error = %e, "redis DEL failed for hard-limit clear");
+                                }
+                            });
+                        }
                         self.refresh_metrics_weights().await;
                     }
                 }
@@ -1643,6 +1651,30 @@ impl AppState {
         }
     }
 
+    /// Publish precomputed routing weights to Redis so non-probing pods
+    /// can set their gauge atomics without recomputing.
+    async fn publish_routing_weights(&self) {
+        let redis = match &self.redis {
+            Some(r) => r,
+            None => return,
+        };
+        use redis::AsyncCommands;
+        for acct in &self.accounts {
+            let w = f64::from_bits(acct.last_routing_weight.load(Ordering::Relaxed));
+            let s = f64::from_bits(acct.last_routing_share.load(Ordering::Relaxed));
+            let key = format!("alb:weight:{}", acct.name);
+            let val = format!("{w},{s}");
+            let mut conn = redis.clone();
+            let ttl = self.probe_interval_secs * 2;
+            tokio::spawn(async move {
+                let result: redis::RedisResult<()> = conn.set_ex(&key, val, ttl).await;
+                if let Err(e) = result {
+                    tracing::warn!(error = %e, "redis routing weight publish failed");
+                }
+            });
+        }
+    }
+
     fn pick_weighted_bucket<'a>(
         &self,
         effective: &[&'a RoutingCandidate],
@@ -2058,12 +2090,6 @@ impl AppState {
                 limit_requests: info.limit_requests,
                 limit_tokens: info.limit_tokens,
                 updated_at: Self::now_epoch(),
-                routing_weight: Some(f64::from_bits(
-                    acct.last_routing_weight.load(Ordering::Relaxed),
-                )),
-                routing_share: Some(f64::from_bits(
-                    acct.last_routing_share.load(Ordering::Relaxed),
-                )),
             };
             // Compute TTL from earliest reset timestamp
             let now_epoch = Self::now_epoch();
@@ -2268,17 +2294,6 @@ impl AppState {
                             info.limit_tokens = remote.limit_tokens;
                             info.last_updated = Some(now_instant);
                             info.last_updated_epoch = Some(remote.updated_at);
-                            // Apply precomputed routing weights from probing pod
-                            if let Some(w) = remote.routing_weight {
-                                self.accounts[i]
-                                    .last_routing_weight
-                                    .store(w.to_bits(), Ordering::Relaxed);
-                            }
-                            if let Some(s) = remote.routing_share {
-                                self.accounts[i]
-                                    .last_routing_share
-                                    .store(s.to_bits(), Ordering::Relaxed);
-                            }
                             trace!(
                                 account = self.accounts[i].name,
                                 remote_age,
@@ -2290,7 +2305,30 @@ impl AppState {
             }
         }
 
-        // 3. Refresh cluster info cache for /_stats endpoint
+        // 3. Sync precomputed routing weights (published by probing pod)
+        let weight_keys: Vec<String> = self
+            .accounts
+            .iter()
+            .map(|a| format!("alb:weight:{}", a.name))
+            .collect();
+        if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&weight_keys).await {
+            for (i, val) in values.iter().enumerate() {
+                if let Some(csv) = val {
+                    if let Some((w_str, s_str)) = csv.split_once(',') {
+                        if let (Ok(w), Ok(s)) = (w_str.parse::<f64>(), s_str.parse::<f64>()) {
+                            self.accounts[i]
+                                .last_routing_weight
+                                .store(w.to_bits(), Ordering::Relaxed);
+                            self.accounts[i]
+                                .last_routing_share
+                                .store(s.to_bits(), Ordering::Relaxed);
+                        }
+                    }
+                }
+            }
+        }
+
+        // 4. Refresh cluster info cache for /_stats endpoint
         let info = self.cluster_info().await;
         if let Ok(mut cache) = self.cluster_info_cache.lock() {
             *cache = info;
@@ -3372,6 +3410,14 @@ async fn proxy_handler(
             state.save_state().await;
 
             if recovered {
+                if let Some(redis) = &state.redis {
+                    let mut conn = redis.clone();
+                    let key = format!("alb:hard:{}", acct.name);
+                    tokio::spawn(async move {
+                        use redis::AsyncCommands;
+                        let _: redis::RedisResult<()> = conn.del(&key).await;
+                    });
+                }
                 state.refresh_metrics_weights().await;
             }
 
@@ -5699,6 +5745,14 @@ async fn openai_chat_handler(
             state.save_state().await;
 
             if recovered {
+                if let Some(redis) = &state.redis {
+                    let mut conn = redis.clone();
+                    let key = format!("alb:hard:{}", acct.name);
+                    tokio::spawn(async move {
+                        use redis::AsyncCommands;
+                        let _: redis::RedisResult<()> = conn.del(&key).await;
+                    });
+                }
                 state.refresh_metrics_weights().await;
             }
 
@@ -6268,6 +6322,7 @@ async fn main() {
                 // have refreshed rate-limit data. Keeps the gauges aligned
                 // with steady-state pool health, not per-request bias.
                 probe_state.refresh_metrics_weights().await;
+                probe_state.publish_routing_weights().await;
                 tokio::time::sleep(Duration::from_secs(probe_interval)).await;
             }
         });
@@ -13830,8 +13885,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             limit_requests: Some(200),
             limit_tokens: Some(100000),
             updated_at: 1700000000,
-            routing_weight: None,
-            routing_share: None,
         };
 
         let json = serde_json::to_string(&info).unwrap();
@@ -13866,8 +13919,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             limit_requests: None,
             limit_tokens: None,
             updated_at: 0,
-            routing_weight: None,
-            routing_share: None,
         };
 
         let json = serde_json::to_string(&info).unwrap();
@@ -14128,8 +14179,6 @@ upstream = "https://api.anthropic.com"
             limit_requests: Some(200),
             limit_tokens: Some(100000),
             updated_at: now_epoch - 10, // 10s ago — newer than local
-            routing_weight: None,
-            routing_share: None,
         };
 
         // Apply same merge logic as sync_from_redis
@@ -14184,8 +14233,6 @@ upstream = "https://api.anthropic.com"
             limit_requests: None,
             limit_tokens: None,
             updated_at: now_epoch - 120, // 120s ago — older than local
-            routing_weight: None,
-            routing_share: None,
         };
 
         // Apply same merge logic as sync_from_redis
@@ -14239,8 +14286,6 @@ upstream = "https://api.anthropic.com"
             limit_requests: None,
             limit_tokens: None,
             updated_at: now_epoch - 30,
-            routing_weight: None,
-            routing_share: None,
         };
 
         // When local has no epoch, local_age = u64::MAX, so remote always wins


### PR DESCRIPTION
## Summary

- **Probe weight logging**: Probes now log `gate_5h`, `gate_7d`, `waste_risk`, `weight`, and `weight_source` — the same routing weight components used by `pick_account()`. Makes it possible to debug routing decisions from probe output alone.
- **DRY refactor**: Extracted `compute_routing_weight()` from `routing_candidates()` so both probe logging and real routing use identical weight logic.
- **Probe deduplication**: Two-layer dedup prevents redundant API calls across pods:
  1. Local freshness check — skips if rate data was refreshed within `probe_interval/2` (e.g. via Redis sync from another pod)
  2. Redis `SET NX EX` lock on `alb:probe:{account}:{model}` — only one pod wins per interval. Fail-open on Redis errors.
- Added `probe_interval_secs` to `AppState` (was a local variable in `main()`)

## Test plan

- [x] 6 new unit tests for `compute_routing_weight` (5h-only, waste_risk, rejected, stale, stale+rejected, no-data defaults)
- [x] All 335 existing tests pass
- [x] `cargo fmt --check` clean
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` clean
- [ ] Manual: run with `RUST_LOG=info`, verify probe logs include weight fields
- [ ] Manual: with 2 replicas + Redis, verify only one pod probes each account per interval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-account routing weights/shares with coordinated probing, distributed locking, immediate recovery signalling and periodic publishing; metrics endpoint now exposes routing weight/share for monitoring.

* **Documentation**
  * Deployment guide renamed and expanded with unified headers, concrete Kubernetes deployment details, secret/config delivery workflow and explicit restart procedures.

* **Tests**
  * Added unit and integration tests covering routing-weight computation, probe/refresh behaviour, recovery signalling and metrics emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->