### PR TITLE
fix: skip reset_seconds emission for stale epochs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4446,30 +4446,20 @@ async fn metrics_handler(
         "Seconds until rate-limit window resets",
     );
     for s in &snaps {
-        if let Some(r) = s.reset_5h {
-            let secs = if r > now_epoch {
-                (r - now_epoch) as f64
-            } else {
-                0.0
-            };
+        if let Some(r) = s.reset_5h.filter(|&r| r > now_epoch) {
             prom_gauge(
                 &mut buf,
                 "anthropic_account_reset_seconds",
                 &[("account", &s.name), ("window", "5h")],
-                secs,
+                (r - now_epoch) as f64,
             );
         }
-        if let Some(r) = s.reset_7d {
-            let secs = if r > now_epoch {
-                (r - now_epoch) as f64
-            } else {
-                0.0
-            };
+        if let Some(r) = s.reset_7d.filter(|&r| r > now_epoch) {
             prom_gauge(
                 &mut buf,
                 "anthropic_account_reset_seconds",
                 &[("account", &s.name), ("window", "7d")],
-                secs,
+                (r - now_epoch) as f64,
             );
         }
     }


### PR DESCRIPTION
When a reset epoch passes before the next probe cleans it up, the metrics handler was emitting 0.0 for reset_seconds. This is indistinguishable from "reset is imminent" and causes transient red flashes on the dashboard stat panel. Now skips emission entirely when the epoch is in the past, letting the metric disappear (which is the honest "no data" state).

## Test plan
- cargo test passes (18 metrics tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reset timestamp metrics reporting by only emitting values for future reset dates, eliminating unnecessary zero-value metric entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->