### PR TITLE
debug: log SSE head on no-usage to diagnose token counting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2808,7 +2808,9 @@ async fn finalize_stream(
         } else {
             "no_usage_event"
         };
-        info!(
+        let head_len = sse_buf.len().min(500);
+        let sse_head = String::from_utf8_lossy(&sse_buf[..head_len]);
+        warn!(
             req_id,
             client_id,
             model,
@@ -2816,6 +2818,7 @@ async fn finalize_stream(
             reason,
             elapsed_ms,
             sse_bytes = sse_buf.len(),
+            %sse_head,
             "stream_end_no_usage"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2808,8 +2808,12 @@ async fn finalize_stream(
         } else {
             "no_usage_event"
         };
-        let head_len = sse_buf.len().min(500);
-        let sse_head = String::from_utf8_lossy(&sse_buf[..head_len]);
+        // Log structural metadata only — SSE payloads contain user content.
+        let sse_text = String::from_utf8_lossy(sse_buf);
+        let sse_event_types: Vec<&str> = sse_text
+            .lines()
+            .filter_map(|l| l.strip_prefix("event: "))
+            .collect();
         warn!(
             req_id,
             client_id,
@@ -2818,7 +2822,7 @@ async fn finalize_stream(
             reason,
             elapsed_ms,
             sse_bytes = sse_buf.len(),
-            %sse_head,
+            sse_events = ?sse_event_types,
             "stream_end_no_usage"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2812,8 +2812,14 @@ async fn finalize_stream(
         let sse_text = String::from_utf8_lossy(sse_buf);
         let sse_event_types: Vec<&str> = sse_text
             .lines()
-            .filter_map(|l| l.strip_prefix("event: "))
+            .filter_map(|l| {
+                l.strip_prefix("event: ")
+                    .or_else(|| l.strip_prefix("event:"))
+            })
             .collect();
+        let total_events = sse_event_types.len();
+        let truncated = total_events > 5;
+        let preview: Vec<&str> = sse_event_types.into_iter().take(5).collect();
         warn!(
             req_id,
             client_id,
@@ -2822,7 +2828,9 @@ async fn finalize_stream(
             reason,
             elapsed_ms,
             sse_bytes = sse_buf.len(),
-            sse_events = ?sse_event_types,
+            sse_event_count = total_events,
+            sse_events = ?preview,
+            truncated,
             "stream_end_no_usage"
         );
     }


### PR DESCRIPTION
Bumps the stream_end_no_usage log to warn and dumps the first 500 bytes of the SSE buffer. Every streaming request from Claude Code is hitting this path — token counters never increment. Need to see what the buffer actually contains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved streaming diagnostics: when a stream ends with no token usage, the end-of-stream log is now a warning and includes a preview list of parsed SSE event types (with a note if truncated to the first five), while retaining existing correlation fields and byte-count metrics to aid investigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/27b-io/anthropic-lb/pull/54)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->