### PR TITLE
fix: strip accept-encoding in proxy_handler to prevent gzip SSE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3530,6 +3530,7 @@ async fn proxy_handler(
             let mut headers = parts.headers.clone();
             headers.remove("host");
             headers.remove("content-length"); // body size may change after cache injection
+            headers.remove("accept-encoding"); // need plaintext SSE to extract token usage
 
             // Default anthropic-version if client didn't set it
             if !headers.contains_key("anthropic-version") {


### PR DESCRIPTION
proxy_handler forwarded the client's `accept-encoding` header to Anthropic. When prajna sent `accept-encoding: gzip`, the upstream responded with compressed SSE. reqwest (no gzip feature) captured raw binary into `sse_buf` — `from_sse_text` found zero `event:`/`data:` lines and token counters never incremented.

Confirmed via debug logging: `sse_events=[], sse_bytes=1493` on every request through the native path. Direct curl tests (no accept-encoding) worked fine.

`openai_chat_handler` already strips `accept-encoding` (line 5902). This is the same one-line fix for `proxy_handler`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proxy handling to correctly process streaming responses by ensuring upstream data is delivered uncompressed, improving compatibility with streaming protocols.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/27b-io/anthropic-lb/pull/56)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->