### PR TITLE
feat: unified endpoints — collapse accounts + upstreams into one schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,13 +121,13 @@ When an endpoint serves via Anthropic **overage** (paid extra usage — `anthrop
 | `allowed_ips` | string[]? | none (allow all) | IP/CIDR allowlist |
 | `auto_cache` | bool? | true | Auto-inject prompt cache breakpoints |
 | `shadow_log` | string? | none | Path for JSONL audit trail |
-| `soft_limit` | f64? | 0.90 | Utilization ceiling — endpoints above excluded from routing |
+| `soft_limit` | f64? | 0.90 | Utilization ceiling — endpoints above this are deprioritized within their tier; they are considered only when no healthy candidate is available and the tier degrades to its soft-limited members |
 | `client_names` | map? | {} | IP→client name mapping |
 | `client_budgets` | map? | {} | client_id→daily token limit |
 | `client_utilization_limits` | map? | {} | client_id→utilization ceiling (0.0–1.0) |
 | `operators` | string[]? | [] | Client IDs that bypass budget, utilization, and emergency brake enforcement (trust-based, not IP-verified; does not bypass IP allowlist) |
 | `emergency_brake` | bool? | true | Enable/disable the emergency brake |
-| `emergency_threshold` | f64? | 0.88 | All-endpoints utilization threshold for emergency brake |
+| `emergency_threshold` | f64? | 0.88 | Utilization threshold for the emergency brake — applied only to `Protocol::Anthropic` endpoints; OpenAI endpoints (stub `RateLimitInfo`) are excluded so they cannot prevent the brake from firing |
 | `redis_url` | string? | none | Redis/Valkey URL for distributed state (`redis://` or `rediss://`) |
 | `overage_penalty` | u32? | 10 | Priority penalty added to an endpoint while it serves via overage |
 | `endpoints[].name` | string | required | Endpoint display name |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,85 +51,91 @@ Single-file Rust binary (`src/main.rs`, ~12000 lines) with inline tests. No libr
 ### Core Data Flow
 
 ```text
-Request → IP allowlist check → proxy_key auth → pre_request_gate(operator bypass → budget → utilization limit → emergency brake) → pick_account(affinity, model, skip) → forward to upstream → parse rate-limit headers → extract token usage → shadow log → persist state (+ Redis sync)
+Request → IP allowlist check → proxy_key auth → pre_request_gate(operator bypass → budget → utilization limit → emergency brake) → pick_endpoint(affinity, model, skip) → forward to endpoint → parse rate-limit headers → extract token usage → shadow log → persist state (+ Redis sync)
 ```
 
 ### Key Sections (in source order)
 
 | Section | What it does |
 |---------|-------------|
-| **Config** (`Config`, `AccountConfig`, `UpstreamConfig`) | TOML deserialization structs |
-| **Runtime state** (`AppState`, `Account`, `RateLimitInfo`) | Shared via `Arc<AppState>`, per-account `RwLock<RateLimitInfo>`, atomic counters, optional Redis `ConnectionManager` |
+| **Config** (`Config`, `EndpointConfig`) | TOML deserialization structs |
+| **Runtime state** (`AppState`, `Endpoint`, `RateLimitInfo`) | Shared via `Arc<AppState>`, per-endpoint `RwLock<RateLimitInfo>`, atomic counters, optional Redis `ConnectionManager` |
 | **Persistence** (`PersistedState`) | JSON state file at `<config_path>.state.json`, saved after every request and on shutdown. Redis for cross-replica state when configured. |
-| **Token usage** (`TokenUsage`, `record_usage`) | Extracts token counts from responses (streaming SSE + non-streaming JSON), tracks per-account and per-client |
+| **Token usage** (`TokenUsage`, `record_usage`) | Extracts token counts from responses (streaming SSE + non-streaming JSON), tracks per-endpoint and per-client |
 | **Auto-cache** (`inject_cache_breakpoints`) | Injects up to 3 prompt cache breakpoints (last tool, system, last user message) unless cache_control already present |
-| **Handlers** | Five axum handlers: `proxy_handler` (main Anthropic proxy), `upstream_handler` (OpenAI-compatible passthrough), `stats_handler` (`/_stats` JSON), `metrics_handler` (`/metrics` Prometheus), `openai_chat_handler` (OpenAI→Anthropic format translation) |
+| **Handlers** | Four axum handlers: `proxy_handler` (main Anthropic proxy), `stats_handler` (`/_stats` JSON), `metrics_handler` (`/metrics` Prometheus), `openai_chat_handler` (OpenAI→Anthropic format translation) |
 | **OpenAI compatibility** (`translate_*`, `StreamContext`) | Translates `/v1/chat/completions` requests/responses between OpenAI and Anthropic formats, including streaming SSE |
 | **Tests** (`mod tests`) | Inline at bottom — unit + integration tests using mock upstream servers |
 
-### Account Selection (`pick_account`)
+### Endpoint Selection (`pick_endpoint`)
 
 Headroom-proportional weighted bucket hashing:
-1. Filter by model compatibility (if account has `models` allowlist)
-2. Skip accounts in the `skip` list (already tried in this retry loop)
-3. Skip hard-limited (429) accounts
-4. Each remaining account gets a bucket proportional to `(1.0 - utilization)`
+1. Filter by model compatibility (if endpoint has `models` allowlist)
+2. Skip endpoints in the `skip` list (already tried in this retry loop)
+3. Skip hard-limited (429) endpoints
+4. Each remaining endpoint gets a bucket proportional to `(1.0 - utilization)`
 5. Affinity key (client+session hash) provides sticky routing; no-affinity uses Fibonacci scatter
-6. On 429 or 5xx/529, the failed account index is added to `skip` and `pick_account` is called again, guaranteeing a different account on retry
+6. On 429 or 5xx/529, the failed endpoint index is added to `skip` and `pick_endpoint` is called again, guaranteeing a different endpoint on retry
 
-### Token Type Detection (by prefix)
+### Token Type Detection
+
+`protocol = "anthropic"` endpoints use prefix-based auth on the configured `token`:
 
 - `sk-ant-oat*` → `Authorization: Bearer` + injects `anthropic-beta: oauth-2025-04-20` and `anthropic-dangerous-direct-browser-access: true`. The OpenAI-compat handler additionally injects `claude-code-20250219` beta flag.
 - `sk-ant-api*` → `x-api-key` header
 - `passthrough` → forwards caller's auth headers untouched
 
+`protocol = "openai"` endpoints use `Authorization: Bearer` with the configured `token`.
+
 ### OAuth System Prompt Requirement
 
 OAuth tokens (`sk-ant-oat*`) require the exact system prompt `"You are Claude Code, Anthropic's official CLI for Claude."` as the **first** system block to access sonnet/opus models. Without it, the API returns `400 invalid_request_error` with the unhelpful message `"Error"`. Haiku works without it.
 
-`inject_oauth_system_prompt()` handles this automatically for both handlers when OAuth accounts are configured. It prepends the prompt block, preserving any existing system content as subsequent blocks. Runs before auto-cache injection (which may add `cache_control` to the system block).
+`inject_oauth_system_prompt()` handles this automatically for both handlers when OAuth endpoints are configured. It prepends the prompt block, preserving any existing system content as subsequent blocks. Runs before auto-cache injection (which may add `cache_control` to the system block).
 
-### Upstream Routing
+### Unified Endpoints
 
-Named OpenAI-compatible upstreams configured in `[[upstreams]]` TOML sections. Requests to `/upstream/{name}/*` are forwarded with `Authorization: Bearer` API key injection.
+All routing targets are `[[endpoints]]` entries — there is one endpoint pool, no separate account/upstream concepts. Each endpoint has a `protocol`:
 
-### Unified Endpoint Priority
+- `protocol = "anthropic"` (default) — an Anthropic-native endpoint. `base_url` defaults to `https://api.anthropic.com`.
+- `protocol = "openai"` — an OpenAI-compatible endpoint. `base_url` is required and must be `https://`. When selected, the request is forwarded with automatic Anthropic↔OpenAI translation (`proxy_handler`) or direct passthrough (`openai_chat_handler`); streaming is supported on both paths.
 
-Accounts **and** the `fallback_upstream` share one priority space. Both `[[accounts]]` and `[[upstreams]]` have a `priority` field (u32, default 0; lower = preferred). `pick_endpoint` partitions all candidates by priority and tries tiers in ascending order.
+### Endpoint Priority
 
-Within a tier: healthy candidates (`gate < soft_limit`) are preferred; if none are healthy, the tier degrades to its soft-limited candidates. Routing only advances to the next tier when the current tier has **zero total weight** (genuinely exhausted). So `soft_limit` is intra-tier load-shedding — it never causes a tier jump. Free capacity is fully drained before any paid (overage or upstream) tier is touched.
+All endpoints (anthropic and openai) share one priority space via the `priority` field (u32, default 0; lower = preferred). `pick_endpoint` partitions all candidates by priority and tries tiers in ascending order.
 
-The `fallback_upstream` is a first-class routing candidate at its configured `priority`. Set it high (e.g. 100) so it is tried only after all account tiers; a startup `warn!` fires if its priority is not above every account's. When the upstream endpoint is selected, the request is forwarded with automatic Anthropic↔OpenAI translation (`proxy_handler`) or direct passthrough (`openai_chat_handler`); streaming is supported on both paths.
+Within a tier: healthy candidates (`gate < soft_limit`) are preferred; if none are healthy, the tier degrades to its soft-limited candidates. Routing only advances to the next tier when the current tier has **zero total weight** (genuinely exhausted). So `soft_limit` is intra-tier load-shedding — it never causes a tier jump. Free capacity is fully drained before any paid (overage or OpenAI-endpoint) tier is touched.
+
+An `openai`-protocol endpoint is a first-class routing candidate at its configured `priority` — it replaces the old `fallback_upstream`. Set it high (e.g. 100) so it is tried only after all Anthropic endpoint tiers. A startup `warn!` fires if an `openai` endpoint shares the lowest priority tier with an `anthropic` endpoint.
 
 ### Overage Awareness
 
-When an account serves via Anthropic **overage** (paid extra usage — `anthropic-ratelimit-unified-overage-in-use: true`), its exhausted 5h/7d subscription windows are superseded: the routing gate is computed from the overage window instead, so the account stays routable. Its effective priority is demoted by `overage_penalty` (default 10) so free subscription capacity is always preferred. When the overage window itself fills (`overage-utilization` → 1.0) the account's weight drops to 0 and routing moves on. The demotion auto-clears when the subscription window refills (`overage-in-use` goes absent → `false`).
+When an endpoint serves via Anthropic **overage** (paid extra usage — `anthropic-ratelimit-unified-overage-in-use: true`), its exhausted 5h/7d subscription windows are superseded: the routing gate is computed from the overage window instead, so the endpoint stays routable. Its effective priority is demoted by `overage_penalty` (default 10) so free subscription capacity is always preferred. When the overage window itself fills (`overage-utilization` → 1.0) the endpoint's weight drops to 0 and routing moves on. The demotion auto-clears when the subscription window refills (`overage-in-use` goes absent → `false`).
 
 ### Config Fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `listen` | string | required | Bind address (e.g. `"0.0.0.0:8080"`) |
-| `upstream` | string | required | Anthropic API base URL |
 | `proxy_key` | string? | none | Shared secret for `x-api-key` auth |
 | `allowed_ips` | string[]? | none (allow all) | IP/CIDR allowlist |
 | `auto_cache` | bool? | true | Auto-inject prompt cache breakpoints |
 | `shadow_log` | string? | none | Path for JSONL audit trail |
-| `soft_limit` | f64? | 0.90 | Utilization ceiling — accounts above excluded from routing |
+| `soft_limit` | f64? | 0.90 | Utilization ceiling — endpoints above excluded from routing |
 | `client_names` | map? | {} | IP→client name mapping |
 | `client_budgets` | map? | {} | client_id→daily token limit |
 | `client_utilization_limits` | map? | {} | client_id→utilization ceiling (0.0–1.0) |
 | `operators` | string[]? | [] | Client IDs that bypass budget, utilization, and emergency brake enforcement (trust-based, not IP-verified; does not bypass IP allowlist) |
 | `emergency_brake` | bool? | true | Enable/disable the emergency brake |
-| `emergency_threshold` | f64? | 0.88 | All-accounts utilization threshold for emergency brake |
+| `emergency_threshold` | f64? | 0.88 | All-endpoints utilization threshold for emergency brake |
 | `redis_url` | string? | none | Redis/Valkey URL for distributed state (`redis://` or `rediss://`) |
-| `fallback_upstream` | string? | none | Name of an `[[upstreams]]` entry to route to as a priority tier |
-| `overage_penalty` | u32? | 10 | Priority penalty added to an account while it serves via overage |
-| `accounts[].name` | string | required | Account display name |
-| `accounts[].token` | string | required | API key, OAuth token, or `"passthrough"` |
-| `accounts[].models` | string[]? | [] (all) | Model allowlist (supports `*` suffix wildcards) |
-| `accounts[].priority` | u32? | 0 | Priority tier (0 = highest). Lower tiers tried first |
-| `upstreams[].priority` | u32? | 0 | Priority tier when this upstream is the `fallback_upstream` (set high) |
+| `overage_penalty` | u32? | 10 | Priority penalty added to an endpoint while it serves via overage |
+| `endpoints[].name` | string | required | Endpoint display name |
+| `endpoints[].protocol` | string? | `"anthropic"` | `"anthropic"` (default) or `"openai"` |
+| `endpoints[].base_url` | string? | `https://api.anthropic.com` | Base URL. Defaults to the Anthropic API for `anthropic`; required (and must be `https://`) for `openai` |
+| `endpoints[].token` | string | required | API key, OAuth token, or `"passthrough"` |
+| `endpoints[].models` | string[]? | [] (all) | Model allowlist (supports `*` suffix wildcards) |
+| `endpoints[].priority` | u32? | 0 | Priority tier (0 = highest). Lower tiers tried first |
 
 
 **Key headers parsed:**
@@ -142,7 +148,7 @@ When an account serves via Anthropic **overage** (paid extra usage — `anthropi
 | `anthropic-ratelimit-unified-7d-utilization` | Raw 7d usage fraction (0.0–1.0) |
 | `anthropic-ratelimit-unified-7d-reset` | Epoch timestamp when 7d window resets |
 | `anthropic-ratelimit-unified-5h-status` / `7d-status` | API pressure signal: `allowed`, `allowed_warning`, `throttled`, `rejected` |
-| `anthropic-ratelimit-unified-overage-in-use` | Account is currently serving via paid overage (always overwritten; absent → `false`) |
+| `anthropic-ratelimit-unified-overage-in-use` | Endpoint is currently serving via paid overage (always overwritten; absent → `false`) |
 | `anthropic-ratelimit-unified-overage-status` | Overage window status — feeds the routing gate floor while overage is in use |
 | `anthropic-ratelimit-unified-overage-utilization` | Overage budget consumed (0.0–1.0) |
 | `anthropic-ratelimit-unified-overage-reset` | Epoch timestamp when the overage window resets |

--- a/config.toml.example
+++ b/config.toml.example
@@ -27,8 +27,9 @@ probe_interval_secs = 300
 # gastown = 0.85
 # openclaw = 0.95
 
-# Emergency brake: when ALL endpoints exceed this threshold, all non-operator traffic
-# is automatically blocked. Default: 0.88.
+# Emergency brake: when ALL Anthropic endpoints exceed this threshold, all non-operator
+# traffic is automatically blocked. OpenAI endpoints (stub rate-limit data) are excluded
+# from the check so they cannot prevent the brake from firing. Default: 0.88.
 # emergency_threshold = 0.88
 
 # Redis/Valkey URL for distributed state (multi-replica coordination).

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,6 +1,5 @@
 # anthropic-lb configuration
 listen = "127.0.0.1:8082"
-upstream = "https://api.anthropic.com"
 # Routing strategy:
 # - "dynamic-capacity" / "dynamic-capacity-v1": legacy weighted routing with
 #   the older 0.5 affinity override threshold
@@ -22,13 +21,13 @@ probe_interval_secs = 300
 # or the emergency brake. Identity resolved via x-client-id header or client_names IP map.
 # operators = ["ray", "openclaw", "claude"]
 
-# Per-client utilization limits: clients are 429'd when ALL model-compatible accounts
+# Per-client utilization limits: clients are 429'd when ALL model-compatible endpoints
 # exceed their configured limit. Values must be 0.0-1.0.
 # [client_utilization_limits]
 # gastown = 0.85
 # openclaw = 0.95
 
-# Emergency brake: when ALL accounts exceed this threshold, all non-operator traffic
+# Emergency brake: when ALL endpoints exceed this threshold, all non-operator traffic
 # is automatically blocked. Default: 0.88.
 # emergency_threshold = 0.88
 
@@ -38,13 +37,22 @@ probe_interval_secs = 300
 # redis_url = "redis://10.0.0.5:6379"
 
 # "passthrough" = forward caller's auth headers as-is (for OpenClaw managed tokens)
-# Any other value = inject as the account's own token
+# Any other value = inject as the endpoint's own token
 # OAuth tokens (sk-ant-oat*) are injected as Authorization: Bearer
 # Standard keys (sk-ant-api*) are injected as X-Api-Key
-[[accounts]]
+[[endpoints]]
 name = "primary"
 token = "sk-ant-oat01-YOUR_TOKEN_HERE"
 
-[[accounts]]
+[[endpoints]]
 name = "secondary"
 token = "sk-ant-oat01-YOUR_TOKEN_HERE"
+
+# OpenAI-compatible endpoint — set a high priority so it is tried only
+# after all Anthropic endpoints are exhausted.
+#[[endpoints]]
+#name = "portkey"
+#protocol = "openai"
+#base_url = "https://portkey.example.dev/v1"
+#token = "your-api-key"
+#priority = 100

--- a/docs/superpowers/plans/2026-05-21-unified-endpoints.md
+++ b/docs/superpowers/plans/2026-05-21-unified-endpoints.md
@@ -1,0 +1,2686 @@
+# Unified Endpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse `[[accounts]]` and `[[upstreams]]` into a single `[[endpoints]]` concept with a `protocol` field, delete the `fallback_upstream` and global `upstream` config keys, and concentrate endpoint-type special-casing into three named, commented call sites.
+
+**Architecture:** Single-file Rust binary (`src/main.rs`, ~19500 lines, axum + tokio). The refactor introduces a `Protocol` enum (`Anthropic` | `OpenAI`), a unified `EndpointConfig`/runtime `Endpoint` type, and a `Vec<usize>` skip list replacing the `Endpoint { Account(usize), Upstream(usize) }` routing enum. The `routing_candidates`/`is_emergency_brake_active`/probe loop are the three named sites that explicitly branch on `endpoint.protocol`. Hard break on config schema, state-file format, and the `/upstream/{name}/*` route.
+
+**Tech Stack:** Rust 2021, tokio, axum 0.7+, reqwest, redis (`ConnectionManager`), serde+serde_json, toml. Quality gates: `cargo test`, `cargo fmt --check`, `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets`.
+
+**Spec:** [docs/superpowers/specs/2026-05-21-unified-endpoints-design.md](../specs/2026-05-21-unified-endpoints-design.md)
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `src/main.rs` | Entire binary (config, runtime, handlers, tests) | Modify — all changes land here |
+| `Cargo.toml` | Dependencies | No change |
+| `config.toml` | Local dev config example | Modify — rewrite to `[[endpoints]]` schema |
+| `CLAUDE.md` | Repo-level config schema docs | Modify — update "Config Fields" table and routing sections |
+| `27b-io/fleet-infra/apps/mem/anthropic-lb/externalsecret.yaml` | Mem cluster ExternalSecret | Modify — rewrite TOML template |
+| `27b-io/lab/k8s/mcp/anthropic-lb-externalsecret.yaml` | Lab cluster ExternalSecret | Modify — rewrite TOML template |
+
+The plan touches one source file and four config/doc files. All work happens in the existing branch `feat/overage-aware-routing` unless you create a fresh worktree.
+
+## Execution Order Rationale
+
+The refactor cannot be cleanly bite-sized into independent TDD increments because the runtime type collapse ripples across ~491 call sites simultaneously. The plan therefore uses a **strangler pattern** internally:
+
+1. **Phase 1 (TDD):** Build the new types alongside the old. Each step is a normal red-green-commit cycle.
+2. **Phase 2 (compiler-driven):** Migrate consumers one structural area at a time. The compiler enumerates every site that must change; the existing test suite is the safety net. Each task ends with a green `cargo test` + commit.
+3. **Phase 3 (TDD):** Layer in the behavior corrections the spec mandates (Protocol::OpenAI short-circuits, retry on 429/5xx, candidate filtering). Each behavior change starts with a failing test that exercises the spec requirement.
+4. **Phase 4:** Delete the old code that is now unreferenced.
+5. **Phase 5:** Update external docs and both cluster configs.
+
+Commit after each task. The plan never leaves the tree red across a task boundary.
+
+---
+
+## Phase 1 — Config foundation (TDD)
+
+### Task 1: Add `Protocol` enum
+
+**Files:**
+- Modify: `src/main.rs` near the existing `RoutingStrategy` enum (~line 115)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block (search for `mod tests {` near the end of `src/main.rs`):
+
+```rust
+#[test]
+fn protocol_deserializes_lowercase_strings() {
+    let p: Protocol = serde_json::from_str(r#""anthropic""#).unwrap();
+    assert_eq!(p, Protocol::Anthropic);
+    let p: Protocol = serde_json::from_str(r#""openai""#).unwrap();
+    assert_eq!(p, Protocol::OpenAI);
+}
+
+#[test]
+fn protocol_default_is_anthropic() {
+    assert_eq!(Protocol::default(), Protocol::Anthropic);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test protocol_deserializes_lowercase_strings 2>&1 | tail -5
+```
+
+Expected: `error[E0412]: cannot find type 'Protocol' in this scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert near the `RoutingStrategy` enum (~line 115):
+
+```rust
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Protocol {
+    #[default]
+    Anthropic,
+    OpenAI,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test protocol_ 2>&1 | tail -10
+```
+
+Expected: `test result: ok. 2 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: add Protocol enum (Anthropic, OpenAI)"
+```
+
+---
+
+### Task 2: Add `EndpointConfig` and parse `[[endpoints]]` blocks
+
+**Files:**
+- Modify: `src/main.rs` (Config struct ~line 29, new EndpointConfig struct ~near AccountConfig at line 89)
+
+- [ ] **Step 1: Write the failing test**
+
+In `mod tests`:
+
+```rust
+#[test]
+fn endpoint_config_parses_minimal_anthropic_block() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[endpoints]]
+name = "primary"
+token = "sk-ant-test"
+"#;
+    let cfg: Config = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.endpoints.len(), 1);
+    assert_eq!(cfg.endpoints[0].name, "primary");
+    assert_eq!(cfg.endpoints[0].protocol, Protocol::Anthropic);
+    assert_eq!(cfg.endpoints[0].base_url, None);
+    assert_eq!(cfg.endpoints[0].token, "sk-ant-test");
+    assert!(cfg.endpoints[0].models.is_empty());
+    assert_eq!(cfg.endpoints[0].priority, 0);
+}
+
+#[test]
+fn endpoint_config_parses_openai_with_base_url() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[endpoints]]
+name = "gateway"
+protocol = "openai"
+base_url = "https://gateway.example.com"
+token = "sk-test"
+priority = 100
+models = ["claude-opus-*"]
+"#;
+    let cfg: Config = toml::from_str(toml_str).unwrap();
+    let ep = &cfg.endpoints[0];
+    assert_eq!(ep.protocol, Protocol::OpenAI);
+    assert_eq!(ep.base_url.as_deref(), Some("https://gateway.example.com"));
+    assert_eq!(ep.priority, 100);
+    assert_eq!(ep.models, vec!["claude-opus-*".to_string()]);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test endpoint_config_ 2>&1 | tail -10
+```
+
+Expected: `error: no field 'endpoints' on type 'Config'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the struct near `AccountConfig` (~line 89):
+
+```rust
+#[derive(Deserialize, Clone)]
+struct EndpointConfig {
+    name: String,
+    /// Wire format. Default: anthropic (sends to api.anthropic.com via x-api-key).
+    #[serde(default)]
+    protocol: Protocol,
+    /// Override base URL. For protocol = anthropic, defaults to https://api.anthropic.com.
+    /// For protocol = openai, this field is required (validated at startup).
+    base_url: Option<String>,
+    /// Auth credential. "passthrough" (anthropic only) forwards caller's auth headers.
+    token: String,
+    /// Model allowlist (supports "*" suffix wildcards). Empty = all models.
+    #[serde(default)]
+    models: Vec<String>,
+    /// Priority tier (0 = highest). Lower tiers tried first.
+    #[serde(default)]
+    priority: u32,
+}
+```
+
+Add to `Config` (line 29 area; insert before `accounts`):
+
+```rust
+/// Unified routing endpoints. Each entry is either Anthropic-native or
+/// OpenAI-compatible, distinguished by `protocol`. Replaces [[accounts]]
+/// + [[upstreams]] + fallback_upstream.
+#[serde(default)]
+endpoints: Vec<EndpointConfig>,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test endpoint_config_ 2>&1 | tail -10
+```
+
+Expected: `test result: ok. 2 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: add EndpointConfig and [[endpoints]] config parsing"
+```
+
+---
+
+### Task 3: Reject dead keys (`[[accounts]]`, `[[upstreams]]`, `fallback_upstream`)
+
+**Files:**
+- Modify: `src/main.rs` — add validation helper near config parsing in `main()` (~line 7560), and a `mod tests` test
+
+The Config struct still has `accounts`/`upstreams`/`fallback_upstream` fields at this point — they'll be deleted in Phase 4. We add a post-parse check that scans the raw TOML for dead keys *and* — once those struct fields are gone in Phase 4 — the same check rejects them as unknown.
+
+- [ ] **Step 1: Write the failing test**
+
+In `mod tests`:
+
+```rust
+#[test]
+fn config_rejects_legacy_accounts_block() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[accounts]]
+name = "primary"
+token = "sk-ant-test"
+"#;
+    let value: toml::Value = toml::from_str(toml_str).unwrap();
+    let err = reject_legacy_config_keys(&value).unwrap_err();
+    assert!(err.contains("accounts"), "error must name 'accounts': {err}");
+    assert!(err.contains("endpoints"), "error must mention replacement: {err}");
+}
+
+#[test]
+fn config_rejects_legacy_upstreams_block() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[upstreams]]
+name = "fallback"
+base_url = "https://example.com"
+api_key = "key"
+"#;
+    let value: toml::Value = toml::from_str(toml_str).unwrap();
+    let err = reject_legacy_config_keys(&value).unwrap_err();
+    assert!(err.contains("upstreams"));
+    assert!(err.contains("endpoints"));
+}
+
+#[test]
+fn config_rejects_fallback_upstream_key() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+fallback_upstream = "anything"
+"#;
+    let value: toml::Value = toml::from_str(toml_str).unwrap();
+    let err = reject_legacy_config_keys(&value).unwrap_err();
+    assert!(err.contains("fallback_upstream"));
+    assert!(err.contains("priority"));
+}
+
+#[test]
+fn config_accepts_endpoints_only_schema() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[endpoints]]
+name = "primary"
+token = "sk-ant-test"
+"#;
+    let value: toml::Value = toml::from_str(toml_str).unwrap();
+    assert!(reject_legacy_config_keys(&value).is_ok());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test config_rejects_ config_accepts_endpoints 2>&1 | tail -10
+```
+
+Expected: `cannot find function 'reject_legacy_config_keys' in this scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add this free function above `async fn main()` (~line 7530):
+
+```rust
+/// Reject removed config keys with explicit errors. Run after the raw TOML
+/// has been parsed to a `toml::Value`, before strongly-typed deserialization.
+///
+/// `serde` silently drops unknown keys by default; this gives the operator
+/// a clear migration message instead of a silent misconfiguration.
+fn reject_legacy_config_keys(value: &toml::Value) -> Result<(), String> {
+    let table = match value.as_table() {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    if table.contains_key("accounts") {
+        return Err(
+            "config: [[accounts]] is no longer supported — use [[endpoints]] (see CLAUDE.md)"
+                .to_string(),
+        );
+    }
+    if table.contains_key("upstreams") {
+        return Err(
+            "config: [[upstreams]] is no longer supported — use [[endpoints]] with protocol = \"openai\" (see CLAUDE.md)"
+                .to_string(),
+        );
+    }
+    if table.contains_key("fallback_upstream") {
+        return Err(
+            "config: fallback_upstream is no longer supported — set a high priority on the OpenAI endpoint instead (see CLAUDE.md)"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test config_rejects_ config_accepts_endpoints 2>&1 | tail -10
+```
+
+Expected: `test result: ok. 4 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: reject removed config keys with explicit migration errors"
+```
+
+---
+
+### Task 4: Wire `reject_legacy_config_keys` into `main()`
+
+**Files:**
+- Modify: `src/main.rs` `async fn main()` (~line 7533)
+
+Find the existing block in `main()` that reads the config file and parses it to `Config`. It currently looks something like `let config: Config = toml::from_str(&raw).unwrap_or_else(...)`. Insert the rejection check between raw parse and typed parse.
+
+- [ ] **Step 1: Locate the current parse call**
+
+```bash
+grep -n "toml::from_str\|let config: Config" src/main.rs | head -10
+```
+
+Note the line number for the config-parsing call.
+
+- [ ] **Step 2: Modify `main()` to call the rejector before typed deserialization**
+
+Replace the existing typed parse with a two-step parse. The pattern is:
+
+```rust
+// Parse raw value first so we can reject dead keys with clear errors
+let raw_value: toml::Value = toml::from_str(&config_text)
+    .unwrap_or_else(|e| panic!("config parse error: {e}"));
+if let Err(msg) = reject_legacy_config_keys(&raw_value) {
+    panic!("{msg}");
+}
+let config: Config = raw_value
+    .try_into()
+    .unwrap_or_else(|e| panic!("config parse error: {e}"));
+```
+
+- [ ] **Step 3: Verify it compiles and tests still pass**
+
+```bash
+cargo build 2>&1 | tail -5
+cargo test --lib 2>&1 | tail -5
+```
+
+Expected: clean build, no test regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: wire dead-key rejection into startup config parse"
+```
+
+---
+
+### Task 5: Validate `base_url` and emit priority-collision warning
+
+**Files:**
+- Modify: `src/main.rs` add a free `validate_endpoints()` function and call it from `main()` post-parse
+
+- [ ] **Step 1: Write the failing test**
+
+In `mod tests`:
+
+```rust
+#[test]
+fn validate_endpoints_warns_on_non_anthropic_host() {
+    // Logs side-effect — we only check the return value (Ok if validation passes)
+    let endpoints = vec![EndpointConfig {
+        name: "primary".to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: Some("https://staging.anthropic.example".to_string()),
+        token: "sk-ant".to_string(),
+        models: vec![],
+        priority: 0,
+    }];
+    // Must succeed (warn-only, not reject).
+    assert!(validate_endpoints(&endpoints).is_ok());
+}
+
+#[test]
+fn validate_endpoints_rejects_http_base_url() {
+    let endpoints = vec![EndpointConfig {
+        name: "primary".to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: Some("http://insecure.example".to_string()),
+        token: "sk-ant".to_string(),
+        models: vec![],
+        priority: 0,
+    }];
+    let err = validate_endpoints(&endpoints).unwrap_err();
+    assert!(err.contains("https"), "error must mention https: {err}");
+    assert!(err.contains("primary"));
+}
+
+#[test]
+fn validate_endpoints_requires_base_url_for_openai() {
+    let endpoints = vec![EndpointConfig {
+        name: "gateway".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: None,
+        token: "sk-test".to_string(),
+        models: vec![],
+        priority: 100,
+    }];
+    let err = validate_endpoints(&endpoints).unwrap_err();
+    assert!(err.contains("base_url"));
+    assert!(err.contains("gateway"));
+}
+
+#[test]
+fn validate_endpoints_accepts_well_formed_mix() {
+    let endpoints = vec![
+        EndpointConfig {
+            name: "primary".to_string(),
+            protocol: Protocol::Anthropic,
+            base_url: None,
+            token: "sk-ant".to_string(),
+            models: vec![],
+            priority: 0,
+        },
+        EndpointConfig {
+            name: "gateway".to_string(),
+            protocol: Protocol::OpenAI,
+            base_url: Some("https://gateway.example".to_string()),
+            token: "sk-test".to_string(),
+            models: vec![],
+            priority: 100,
+        },
+    ];
+    assert!(validate_endpoints(&endpoints).is_ok());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test validate_endpoints_ 2>&1 | tail -10
+```
+
+Expected: `cannot find function 'validate_endpoints'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add above `async fn main()` (~line 7530):
+
+```rust
+/// Validate endpoint configuration. Returns the first hard error encountered.
+/// Soft warnings (non-canonical anthropic host, priority collision with an
+/// openai endpoint) are emitted as `warn!` and do not return an error.
+fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
+    for ep in endpoints {
+        if let Some(url) = ep.base_url.as_deref() {
+            if !url.starts_with("https://") {
+                return Err(format!(
+                    "endpoint '{}': base_url must start with https:// (got '{}')",
+                    ep.name, url
+                ));
+            }
+        }
+        match ep.protocol {
+            Protocol::OpenAI => {
+                if ep.base_url.is_none() {
+                    return Err(format!(
+                        "endpoint '{}': base_url is required for protocol = openai",
+                        ep.name
+                    ));
+                }
+            }
+            Protocol::Anthropic => {
+                if let Some(url) = ep.base_url.as_deref() {
+                    if !url.starts_with("https://api.anthropic.com") {
+                        warn!(
+                            endpoint = ep.name,
+                            base_url = url,
+                            "anthropic endpoint base_url is non-canonical — verify this is intentional"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Priority-collision warning: an OpenAI endpoint sharing the lowest tier
+    // with any Anthropic endpoint recreates the bug §Problem cites.
+    let lowest = endpoints.iter().map(|e| e.priority).min().unwrap_or(0);
+    let openai_at_lowest: Vec<&str> = endpoints
+        .iter()
+        .filter(|e| e.protocol == Protocol::OpenAI && e.priority == lowest)
+        .map(|e| e.name.as_str())
+        .collect();
+    let anthropic_at_lowest: Vec<&str> = endpoints
+        .iter()
+        .filter(|e| e.protocol == Protocol::Anthropic && e.priority == lowest)
+        .map(|e| e.name.as_str())
+        .collect();
+    if !openai_at_lowest.is_empty() && !anthropic_at_lowest.is_empty() {
+        warn!(
+            priority = lowest,
+            openai = ?openai_at_lowest,
+            anthropic = ?anthropic_at_lowest,
+            "openai endpoint(s) share the lowest priority tier with anthropic endpoint(s) — paid OpenAI capacity will compete with free Anthropic capacity"
+        );
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test validate_endpoints_ 2>&1 | tail -10
+```
+
+Expected: `test result: ok. 4 passed`.
+
+- [ ] **Step 5: Wire into `main()`**
+
+After the typed-parse call in `main()`, add:
+
+```rust
+if let Err(msg) = validate_endpoints(&config.endpoints) {
+    panic!("{msg}");
+}
+```
+
+Verify:
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib 2>&1 | tail -3
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: validate endpoint base_url and warn on priority collision"
+```
+
+---
+
+## Phase 2 — Runtime type unification (compiler-driven strangler)
+
+This phase introduces the unified runtime `Endpoint` type and migrates each consumer one structural area at a time. Each task ends with a green `cargo test` + commit. The old `Account`/`Upstream` types stay alive until Phase 4.
+
+### Task 6: Add runtime `Endpoint` struct alongside `Account`/`Upstream`
+
+**Files:**
+- Modify: `src/main.rs` add the struct ~near line 451 (after `struct Upstream`), and an enum alias for the routing index
+
+- [ ] **Step 1: Add the new struct**
+
+Insert after `struct Upstream` (~line 459, before `struct AppState`):
+
+```rust
+/// Unified routing endpoint. Replaces the separate `Account` and `Upstream`
+/// runtime structs (which remain temporarily during the migration). After
+/// Phase 4 cleanup, only this struct survives.
+///
+/// Rate-limit/utilization fields are populated only for `Protocol::Anthropic`.
+/// `Protocol::OpenAI` endpoints carry a stub `RateLimitInfo` (all fields None);
+/// three code sites branch on `protocol` to handle this correctly:
+///   1. `routing_candidates()` — short-circuits to a fixed RoutingCandidate.
+///   2. `is_emergency_brake_active()` — iterates only Anthropic endpoints.
+///   3. probe loop — skips OpenAI endpoints.
+struct Endpoint {
+    name: String,
+    protocol: Protocol,
+    /// Resolved at startup: api.anthropic.com for Anthropic default, else the
+    /// explicit base_url. No trailing slash.
+    base_url: String,
+    token: String,
+    /// True iff token == "passthrough". Only meaningful for Protocol::Anthropic.
+    passthrough: bool,
+    models: Vec<String>,
+    priority: u32,
+    requests: AtomicU64,
+    rate_info: RwLock<RateLimitInfo>,
+    burn_rate: Mutex<BurnRate>,
+    input_tokens: AtomicU64,
+    output_tokens: AtomicU64,
+    cache_creation_tokens: AtomicU64,
+    cache_read_tokens: AtomicU64,
+    last_routing_weight: AtomicU64,
+    last_routing_share: AtomicU64,
+    last_effective_gate: AtomicU64,
+}
+
+impl Endpoint {
+    /// Check if this endpoint can serve the given model. Empty allowlist = all.
+    /// Identical to the historical `Account::serves_model` predicate.
+    fn serves_model(&self, model: &str) -> bool {
+        if self.models.is_empty() || model.is_empty() {
+            return true;
+        }
+        self.models.iter().any(|pattern| {
+            if let Some(prefix) = pattern.strip_suffix('*') {
+                model.starts_with(prefix)
+            } else {
+                model == pattern
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo build 2>&1 | tail -3
+```
+
+Expected: clean build (no warnings since the struct is unreferenced; that's fine — the next task uses it). If a `dead_code` warning fires under `-Dwarnings`, prefix with `#[allow(dead_code)]` temporarily and remove the attribute at the end of Phase 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: add runtime Endpoint struct (parallel to Account/Upstream)"
+```
+
+---
+
+### Task 7: Add `endpoints: Vec<Endpoint>` to `AppState` and populate it from config
+
+**Files:**
+- Modify: `src/main.rs` `AppState` struct (~line 460), `main()` config wiring (~line 7618)
+
+- [ ] **Step 1: Add field to `AppState`**
+
+Insert after the `accounts` field in `AppState` (~line 463):
+
+```rust
+/// Unified endpoints. After Phase 4, this replaces `accounts` and `upstreams`.
+/// During migration, both sets are populated so consumers can be migrated
+/// one at a time.
+endpoints: Vec<Endpoint>,
+```
+
+- [ ] **Step 2: Populate it in `main()`**
+
+In `main()`, find the existing `let accounts: Vec<Account> = config.accounts ...` block (~line 7618). Immediately after that block (and the `let upstreams: Vec<Upstream> = ...` block ~line 7648), add:
+
+```rust
+// Build the unified endpoint vector from the new [[endpoints]] config.
+// During the migration, the old accounts/upstreams Vecs remain alongside.
+let endpoints: Vec<Endpoint> = config
+    .endpoints
+    .iter()
+    .map(|ec| {
+        let passthrough = ec.token == "passthrough";
+        let base_url = match ec.protocol {
+            Protocol::Anthropic => ec
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://api.anthropic.com".to_string()),
+            Protocol::OpenAI => ec.base_url.clone().expect(
+                "validate_endpoints should have rejected an openai endpoint without base_url",
+            ),
+        };
+        info!(
+            name = ec.name,
+            protocol = ?ec.protocol,
+            base_url = base_url.as_str(),
+            priority = ec.priority,
+            passthrough,
+            models = ?ec.models,
+            "loaded endpoint"
+        );
+        Endpoint {
+            name: ec.name.clone(),
+            protocol: ec.protocol,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token: ec.token.clone(),
+            passthrough,
+            models: ec.models.clone(),
+            priority: ec.priority,
+            requests: AtomicU64::new(0),
+            rate_info: RwLock::new(RateLimitInfo::default()),
+            burn_rate: Mutex::new(BurnRate::new()),
+            input_tokens: AtomicU64::new(0),
+            output_tokens: AtomicU64::new(0),
+            cache_creation_tokens: AtomicU64::new(0),
+            cache_read_tokens: AtomicU64::new(0),
+            last_routing_weight: AtomicU64::new(0),
+            last_routing_share: AtomicU64::new(0),
+            last_effective_gate: AtomicU64::new(0),
+        }
+    })
+    .collect();
+```
+
+- [ ] **Step 3: Pass `endpoints` to the `AppState` constructor**
+
+In `main()`, find the `Arc::new(AppState { ... })` block (~line 7790). Add `endpoints,` to the struct literal (placement near `accounts,` keeps related fields adjacent).
+
+- [ ] **Step 4: Update test fixture builders**
+
+In `mod tests`, find `test_state_with_strategy` (~line 7979). Add `endpoints: vec![],` to the `AppState { ... }` literal.
+
+- [ ] **Step 5: Verify it compiles and tests pass**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib 2>&1 | tail -3
+```
+
+Expected: clean build, test suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: populate AppState.endpoints from [[endpoints]] config"
+```
+
+---
+
+### Task 8: Migrate `routing_candidates` to read from `state.endpoints`
+
+**Files:**
+- Modify: `src/main.rs` `routing_candidates` (~line 1591), and the `Endpoint` routing-index enum (~line 534)
+
+The routing enum `Endpoint { Account(usize), Upstream(usize) }` conflicts in name with the new runtime struct. **Rename the enum to `EndpointIdx`** before any consumer migrates.
+
+- [ ] **Step 1: Rename routing enum**
+
+Find the routing index enum (~line 534) and rename:
+
+```rust
+/// Index into one of the runtime endpoint pools. After Phase 4 cleanup this
+/// collapses to a bare `usize`. Kept as an enum during the migration so
+/// `Account`/`Upstream` consumers and the new `Endpoint` consumer can coexist.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EndpointIdx {
+    Account(usize),
+    Upstream(usize),
+    /// Index into AppState.endpoints (new unified pool).
+    Unified(usize),
+}
+
+impl EndpointIdx {
+    #[cfg(test)]
+    fn account(self) -> Option<usize> {
+        match self {
+            EndpointIdx::Account(i) => Some(i),
+            _ => None,
+        }
+    }
+}
+```
+
+Update every reference from `Endpoint::Account`/`Endpoint::Upstream` to `EndpointIdx::Account`/`EndpointIdx::Upstream`. Use rust-analyzer or:
+
+```bash
+grep -n "Endpoint::Account\|Endpoint::Upstream\|: Endpoint\b\|Vec<Endpoint>\|&\[Endpoint\]" src/main.rs
+```
+
+Replace each occurrence (use `sed -i` with care — review the diff):
+
+```bash
+sed -i 's/Endpoint::Account/EndpointIdx::Account/g; s/Endpoint::Upstream/EndpointIdx::Upstream/g' src/main.rs
+# Targeted manual edits where `Endpoint` was used as a bare type name in signatures (skip: &[Endpoint], Vec<Endpoint>, etc).
+```
+
+- [ ] **Step 2: Update the routing-index type alias in signatures**
+
+Search for any remaining bare `Endpoint` used as a routing-index type in signatures (not the runtime struct). Specifically `pick_endpoint`, `routing_candidates`, and the `skip` parameter:
+
+```bash
+grep -n "skip: &\[Endpoint\]\|skip: Vec<Endpoint>\|-> Option<Endpoint>\|: Endpoint," src/main.rs
+```
+
+Update those signatures: `Endpoint` → `EndpointIdx`.
+
+- [ ] **Step 3: Verify compile**
+
+```bash
+cargo build 2>&1 | tail -10
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Migrate `routing_candidates` to also enumerate `self.endpoints`**
+
+In `routing_candidates` (~line 1591), after the existing loop over `self.accounts.iter().enumerate()`, add a second loop:
+
+```rust
+// Unified endpoints. During the migration, both the old `accounts`+`upstreams`
+// pools and the new `endpoints` pool are enumerated. The deployed config will
+// populate only one side at a time — both populated is a configuration error
+// caught elsewhere.
+for (i, ep) in self.endpoints.iter().enumerate() {
+    if skip.contains(&EndpointIdx::Unified(i)) {
+        continue;
+    }
+    if !ep.serves_model(model) {
+        continue;
+    }
+    match ep.protocol {
+        Protocol::OpenAI => {
+            // OpenAI endpoints carry no rate-limit data — push a fixed candidate
+            // at the configured priority. This is one of the three named
+            // `match protocol` sites (see Endpoint struct docs).
+            trace!(
+                endpoint = ep.name,
+                priority = ep.priority,
+                "pick: candidate (openai, fixed)"
+            );
+            candidates.push(RoutingCandidate {
+                endpoint: EndpointIdx::Unified(i),
+                priority: ep.priority,
+                gate_5h: 0.0,
+                gate_7d: 0.0,
+                gate: 0.0,
+                wr: 0.0,
+                weight: 1.0,
+                source: "openai",
+            });
+        }
+        Protocol::Anthropic => {
+            let rw = match compute_routing_weight(
+                &*ep.rate_info.read().await,
+                Self::now_epoch(),
+                model,
+            ) {
+                Some(rw) => rw,
+                None => {
+                    trace!(
+                        endpoint = ep.name,
+                        model = model,
+                        "pick: skipping, 7d claim rejected"
+                    );
+                    continue;
+                }
+            };
+            let effective_priority = if rw.overage_active {
+                ep.priority.saturating_add(self.overage_penalty)
+            } else {
+                ep.priority
+            };
+            trace!(
+                endpoint = ep.name,
+                gate = format!("{:.4}", rw.gate),
+                weight = format!("{:.4}", rw.weight),
+                priority = effective_priority,
+                "pick: candidate (anthropic)"
+            );
+            candidates.push(RoutingCandidate {
+                endpoint: EndpointIdx::Unified(i),
+                priority: effective_priority,
+                gate_5h: rw.gate_5h,
+                gate_7d: rw.gate_7d,
+                gate: rw.gate,
+                wr: rw.wr,
+                weight: rw.weight,
+                source: rw.source,
+            });
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib 2>&1 | tail -5
+```
+
+Expected: clean build, all tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: routing_candidates enumerates AppState.endpoints with protocol branch"
+```
+
+---
+
+### Task 9: Migrate proxy_handler dispatch on `EndpointIdx::Unified`
+
+**Files:**
+- Modify: `src/main.rs` `proxy_handler` (~line 3703–4000), `try_fallback_upstream` callers
+
+- [ ] **Step 1: Find the dispatch site**
+
+```bash
+grep -n "match state.pick_endpoint\|match pick_endpoint\|Some(Endpoint::Account\|Some(EndpointIdx::Account\|Some(EndpointIdx::Upstream\|Some(EndpointIdx::Unified" src/main.rs
+```
+
+There are two dispatch sites — one in `proxy_handler` (~line 3848) and one in `openai_chat_handler` (~line 7112).
+
+- [ ] **Step 2: Add a `Unified` arm to `proxy_handler`'s dispatch**
+
+In `proxy_handler` (~line 3848), the current dispatch reads:
+
+```rust
+let idx = match state.pick_endpoint(affinity, &model, &skip).await {
+    Some(EndpointIdx::Account(i)) => i,
+    Some(EndpointIdx::Upstream(u)) => { /* try_fallback_upstream then continue */ }
+    None => { /* 429 all exhausted */ }
+};
+```
+
+Add a `Unified(i)` arm before the `None`:
+
+```rust
+Some(EndpointIdx::Unified(i)) => {
+    let ep = &state.endpoints[i];
+    match ep.protocol {
+        Protocol::Anthropic => {
+            // Take the same path as the existing Account branch using `ep`
+            // instead of `acct`. Detailed forward logic is shared via the
+            // post-pick code block immediately after this match.
+            // (Use `i` as the unified index and a helper closure or branch
+            // on `Protocol::Anthropic` further down where the per-account
+            // headers/url/usage tracking happens.)
+            // Set a `unified_idx = Some(i);` flag and fall through to the
+            // shared Anthropic forward block, OR factor a `forward_anthropic`
+            // helper accepting `&Endpoint`. The implementation choice is
+            // left to the engineer; both compile and test cleanly.
+            unimplemented!("see Task 9 step 4")
+        }
+        Protocol::OpenAI => {
+            match try_fallback_upstream_unified(
+                &state, &body_bytes, &req_id, &client_id, &model, i, true,
+            )
+            .await
+            {
+                Some(resp) => return resp,
+                None => {
+                    skip.push(EndpointIdx::Unified(i));
+                    continue;
+                }
+            }
+        }
+    }
+}
+```
+
+This step intentionally leaves the Anthropic arm with `unimplemented!()` — step 3 factors the shared forwarding code into a function that accepts either an `&Account` or an `&Endpoint`.
+
+- [ ] **Step 3: Factor the shared Anthropic forward path**
+
+The existing Anthropic forward path is ~lines 3878–3975 (everything from `let acct = &state.accounts[idx];` through the response handling and `record_usage` call). Factor it into a helper:
+
+```rust
+/// Forward a single Anthropic-protocol request. Returns:
+///   - Some(Response) — final caller response (success or terminal error)
+///   - None — retry-eligible failure; caller should add to skip and loop
+async fn forward_anthropic(
+    state: &AppState,
+    parts: &http::request::Parts,
+    body_bytes: &[u8],
+    base_url: &str,
+    token: &str,
+    passthrough: bool,
+    endpoint_name: &str,
+    requests_counter: &AtomicU64,
+    rate_info: &RwLock<RateLimitInfo>,
+    burn_rate: &Mutex<BurnRate>,
+    req_id: &str,
+    client_id: &str,
+    model: &str,
+) -> Option<Response> {
+    // SOURCE: copy the inline forward block from proxy_handler at
+    //   src/main.rs lines ~3878–3975 (everything from `let acct = &state.accounts[idx];`
+    //   through the response handling and `record_usage` call).
+    // SUBSTITUTIONS to apply while pasting:
+    //   `state.upstream`        -> `base_url` parameter
+    //   `acct.token`            -> `token` parameter
+    //   `acct.passthrough`      -> `passthrough` parameter
+    //   `acct.name`             -> `endpoint_name` parameter
+    //   `acct.requests`         -> `requests_counter` parameter
+    //   `acct.rate_info`        -> `rate_info` parameter
+    //   `acct.burn_rate`        -> `burn_rate` parameter
+    //   `state.record_usage(idx, ..)` -> leave as `// TODO(unified)` marker;
+    //     Task 14 introduces a `UsageTarget` enum and re-wires this call.
+    // Return type: convert the existing inline `return resp` / `continue` flow
+    //   into `Some(resp)` / `None` so the caller's loop owns retry-vs-respond.
+    todo!("paste lines ~3878–3975 with the substitutions in the comment above")
+}
+```
+
+Important — `record_usage` currently takes `account_idx: usize`. Both the old (`state.accounts`) and new (`state.endpoints`) consumers need to call it. For now, the Account branch keeps calling `record_usage(account_idx, ...)`; the Endpoint branch will call a new `record_usage_unified(endpoint_idx, ...)` introduced in Task 14. Until then, the unified Anthropic forward path can route through either by passing the account index when it's available, or by skipping the call when only `endpoint_idx` is meaningful. **Do not run with traffic in this transitional state — Phase 2 ends with usage tracking restored in Task 14.**
+
+For this task: factor the function with `record_usage` left as a `// TODO(unified): wire record_usage_unified in Task 14` and proceed to step 4 below. The compiler is the test.
+
+- [ ] **Step 4: Update both call sites to use the helper**
+
+Replace the inline Anthropic forward block in the Account arm with:
+
+```rust
+let acct = &state.accounts[idx];
+match forward_anthropic(
+    &state, &parts, &body_bytes,
+    &state.upstream, &acct.token, acct.passthrough,
+    &acct.name, &acct.requests, &acct.rate_info, &acct.burn_rate,
+    &req_id, &client_id, &model,
+).await {
+    Some(resp) => return resp,
+    None => {
+        skip.push(EndpointIdx::Account(idx));
+        continue;
+    }
+}
+```
+
+And in the unified Anthropic arm:
+
+```rust
+let ep = &state.endpoints[i];
+match forward_anthropic(
+    &state, &parts, &body_bytes,
+    &ep.base_url, &ep.token, ep.passthrough,
+    &ep.name, &ep.requests, &ep.rate_info, &ep.burn_rate,
+    &req_id, &client_id, &model,
+).await {
+    Some(resp) => return resp,
+    None => {
+        skip.push(EndpointIdx::Unified(i));
+        continue;
+    }
+}
+```
+
+- [ ] **Step 5: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -5
+cargo test --lib 2>&1 | tail -5
+```
+
+Expected: clean build; tests using the legacy `state.accounts` path still pass (no test currently routes through `state.endpoints`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: factor Anthropic forward path; add Unified arm in proxy_handler"
+```
+
+---
+
+### Task 10: Add `try_fallback_upstream_unified` for `EndpointIdx::Unified` OpenAI endpoints
+
+**Files:**
+- Modify: `src/main.rs` near `try_fallback_upstream` (~line 4181)
+
+- [ ] **Step 1: Add the helper**
+
+Insert immediately after `try_fallback_upstream`:
+
+```rust
+/// Forward to a Protocol::OpenAI endpoint in the unified pool. Identical
+/// behavior to `try_fallback_upstream`, but reads from `state.endpoints`
+/// instead of `state.upstreams`.
+///
+/// IMPORTANT: Returns `None` on upstream 429/5xx so the retry loop can
+/// add the endpoint to `skip` and try the next candidate. The original
+/// `try_fallback_upstream` returns the error response directly; the
+/// unified version corrects that to match Anthropic-endpoint failure
+/// semantics (see spec §Routing & dispatch).
+async fn try_fallback_upstream_unified(
+    state: &AppState,
+    body_bytes: &[u8],
+    req_id: &str,
+    client_id: &str,
+    model: &str,
+    endpoint_idx: usize,
+    translate: bool,
+) -> Option<Response> {
+    let ep = &state.endpoints[endpoint_idx];
+    // Copy the body of `try_fallback_upstream` here, substituting:
+    //   `state.upstreams[upstream_idx]` -> `state.endpoints[endpoint_idx]`
+    //   `upstream.base_url` -> `ep.base_url`
+    //   `upstream.api_key` -> `ep.token`
+    //   `upstream.name`    -> `ep.name`
+    //   `upstream.requests` -> `ep.requests`
+    // Then change the error-response branch (current: `Some(resp_anthropic_error)`)
+    // to return None for status 429 and 5xx (>=500), so the caller can retry.
+    // For 4xx other than 429, keep the existing "return error to caller"
+    // behavior (those are client errors, not retry-eligible).
+    //
+    // The 429/5xx -> None branch is the spec's required behavior change.
+    // SOURCE: copy the body of `try_fallback_upstream` at src/main.rs lines
+    //   ~4181–4426 with the substitutions listed above and the 429/5xx -> None
+    //   change applied at the !status.is_success() branch.
+    todo!("paste lines ~4181–4426 with substitutions + 429/5xx -> None")
+}
+```
+
+Concretely the retry decision at the end of the existing function reads:
+
+```rust
+let status = resp.status();
+if !status.is_success() {
+    // existing: returns Some(error_response)
+    // unified change:
+    if status.as_u16() == 429 || status.is_server_error() {
+        warn!(
+            req_id, endpoint = ep.name,
+            status = status.as_u16(),
+            "fallback: upstream returned retry-eligible error, advancing"
+        );
+        return None;
+    }
+    // 4xx client errors: still return to caller — retry would not help.
+    // ... existing body-to-Anthropic-error-shape translation ...
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+```bash
+cargo build 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: add try_fallback_upstream_unified with 429/5xx-as-retryable"
+```
+
+---
+
+### Task 11: Migrate `openai_chat_handler` candidate filter and dispatch
+
+**Files:**
+- Modify: `src/main.rs` `openai_chat_handler` (~line 6987)
+
+- [ ] **Step 1: Add candidate filtering — Protocol::OpenAI only**
+
+In `openai_chat_handler`, the dispatch loop currently picks from any endpoint via `state.pick_endpoint`. The spec requires this handler to target only `Protocol::OpenAI` endpoints. The cleanest path: add a `pick_endpoint_filtered(filter: Option<Protocol>)` method on `AppState`, or filter the result of `routing_candidates` before calling into the picker.
+
+Choose the second — less surface area. Replace the current pick call with:
+
+```rust
+let idx = {
+    let all_candidates = state.routing_candidates(&model, &skip).await;
+    // Filter: only Protocol::OpenAI endpoints from the unified pool.
+    // (Legacy `accounts` -> EndpointIdx::Account candidates remain — drop them
+    // until Phase 4 deletes the old pool entirely.)
+    let openai_only: Vec<RoutingCandidate> = all_candidates
+        .into_iter()
+        .filter(|c| match c.endpoint {
+            EndpointIdx::Unified(i) => {
+                matches!(state.endpoints[i].protocol, Protocol::OpenAI)
+            }
+            EndpointIdx::Upstream(_) => true,  // legacy upstream — also openai
+            EndpointIdx::Account(_) => false,
+        })
+        .collect();
+    state.pick_from_candidates_or_none(openai_only, affinity).await
+};
+```
+
+To avoid duplicating tier logic, **first extract** `pick_endpoint`'s tier-and-pick body into a private helper, then call it from both `pick_endpoint` and the new filtered path.
+
+Refactor `pick_endpoint` (~line 2116) to:
+
+```rust
+async fn pick_endpoint(
+    &self,
+    affinity_key: Option<&str>,
+    model: &str,
+    skip: &[EndpointIdx],
+) -> Option<EndpointIdx> {
+    let candidates = self.routing_candidates(model, skip).await;
+    self.pick_from_tiered_candidates(candidates, affinity_key)
+}
+
+/// Apply priority-tier partitioning and intra-tier soft-limit handling
+/// to an already-filtered candidate set. Returns the chosen index, or
+/// None if every tier has zero weight.
+fn pick_from_tiered_candidates(
+    &self,
+    candidates: Vec<RoutingCandidate>,
+    affinity_key: Option<&str>,
+) -> Option<EndpointIdx> {
+    if candidates.is_empty() {
+        debug!("pick: no available endpoints");
+        return None;
+    }
+    let mut tiers: Vec<u32> = candidates.iter().map(|c| c.priority).collect();
+    tiers.sort_unstable();
+    tiers.dedup();
+    for tier in &tiers {
+        let tier_candidates: Vec<&RoutingCandidate> =
+            candidates.iter().filter(|c| c.priority == *tier).collect();
+        let healthy: Vec<&RoutingCandidate> = tier_candidates
+            .iter()
+            .filter(|c| c.gate < self.soft_limit)
+            .copied()
+            .collect();
+        let (effective, degraded): (Vec<&RoutingCandidate>, bool) = if !healthy.is_empty() {
+            (healthy, false)
+        } else {
+            (tier_candidates.clone(), true)
+        };
+        let total_weight: f64 = effective.iter().map(|c| c.weight).sum();
+        if total_weight <= 0.0 {
+            debug!(tier = tier, "pick: tier exhausted (zero weight), trying next");
+            continue;
+        }
+        if degraded {
+            debug!(tier = tier, "pick: tier all soft-limited — degrading within tier");
+        }
+        return Some(self.pick_from_candidates(&effective, total_weight, affinity_key, *tier));
+    }
+    debug!("pick: all tiers exhausted");
+    None
+}
+```
+
+Then `openai_chat_handler` can do:
+
+```rust
+let candidates = state.routing_candidates(&model, &skip).await;
+let openai_only: Vec<RoutingCandidate> = candidates
+    .into_iter()
+    .filter(|c| match c.endpoint {
+        EndpointIdx::Unified(i) => matches!(state.endpoints[i].protocol, Protocol::OpenAI),
+        EndpointIdx::Upstream(_) => true,
+        EndpointIdx::Account(_) => false,
+    })
+    .collect();
+let idx = state.pick_from_tiered_candidates(openai_only, affinity);
+```
+
+- [ ] **Step 2: Dispatch on protocol after pick**
+
+After the picker call, branch:
+
+```rust
+let idx_resolved = match idx {
+    Some(EndpointIdx::Unified(i)) => i,
+    Some(EndpointIdx::Upstream(u)) => {
+        // legacy upstream path — try_fallback_upstream
+        match try_fallback_upstream(
+            &state, &body_bytes, &req_id, &client_id, &model, u, false,
+        )
+        .await
+        {
+            Some(resp) => return resp,
+            None => {
+                skip.push(EndpointIdx::Upstream(u));
+                continue;
+            }
+        }
+    }
+    Some(EndpointIdx::Account(_)) => unreachable!("filtered out above"),
+    None => {
+        warn!("all openai endpoints exhausted");
+        return (StatusCode::TOO_MANY_REQUESTS, "no openai endpoint available").into_response();
+    }
+};
+// Unified OpenAI endpoint — forward direct, no translation
+match try_fallback_upstream_unified(
+    &state, &body_bytes, &req_id, &client_id, &model, idx_resolved, false,
+).await {
+    Some(resp) => return resp,
+    None => {
+        skip.push(EndpointIdx::Unified(idx_resolved));
+        continue;
+    }
+}
+```
+
+- [ ] **Step 3: Move eager translation inside the protocol branch**
+
+The current `openai_chat_handler` runs `translate_openai_request_to_anthropic` before the retry loop (~line 7076). The spec says translation must happen *after* `pick_endpoint`, and only for Anthropic targets. Since the candidate filter above excludes Anthropic candidates, the translation call can be **deleted entirely** from this handler — the only remaining targets are OpenAI endpoints that need no translation.
+
+Remove the eager `translate_openai_request_to_anthropic` block. The body forwarded downstream is the original OpenAI-format body.
+
+- [ ] **Step 4: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -5
+cargo test --lib openai_chat 2>&1 | tail -10
+cargo test --lib 2>&1 | tail -3
+```
+
+Expected: clean build. Existing OpenAI-chat tests use `[[upstreams]]` (legacy) and should still pass via the `EndpointIdx::Upstream` arm. Tests targeting the unified pool come in Phase 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: openai_chat_handler filters to OpenAI endpoints, dispatch by index"
+```
+
+---
+
+### Task 12: Migrate emergency brake — skip `Protocol::OpenAI` endpoints
+
+**Files:**
+- Modify: `src/main.rs` `is_emergency_brake_active` (~line 3346)
+
+- [ ] **Step 1: Write the failing test**
+
+In `mod tests`:
+
+```rust
+#[tokio::test]
+async fn emergency_brake_fires_when_only_anthropic_above_threshold_with_openai_present() {
+    // Setup: 1 anthropic at utilization 0.95, 1 openai with stub rate info.
+    // Pre-fix: brake never fires because openai stub yields (0.5, "unknown").
+    // Post-fix: brake fires because openai is skipped from the iteration.
+    let acct = make_account("anthropic", "sk-ant");
+    {
+        let mut info = acct.rate_info.write().await;
+        info.utilization = Some(0.95);
+        info.utilization_5h = Some(0.95);
+    }
+    let mut state = test_state_with(vec![acct]);
+    let st = Arc::get_mut(&mut state).expect("uniquely owned");
+    st.endpoints.push(Endpoint {
+        name: "openai".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: "https://gateway.example".to_string(),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 100,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
+    st.emergency_threshold = 0.88;
+    assert!(state.is_emergency_brake_active().await,
+        "brake must fire: anthropic is above threshold; openai must not vote");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test emergency_brake_fires_when_only_anthropic 2>&1 | tail -15
+```
+
+Expected: assertion fails (brake does not fire because OpenAI endpoint's stub voted against it).
+
+- [ ] **Step 3: Modify `is_emergency_brake_active`**
+
+Replace the body (~line 3346–3368) with:
+
+```rust
+async fn is_emergency_brake_active(&self) -> bool {
+    if !self.emergency_brake {
+        return false;
+    }
+    let now_epoch = Self::now_epoch();
+    let mut all_above = true;
+    let mut any_known = false;
+
+    // Iterate legacy Account pool — Anthropic by definition.
+    for acct in &self.accounts {
+        let info = acct.rate_info.read().await;
+        let (util, source, _, _) = effective_utilization(&info, now_epoch, "");
+        if source != "unknown" {
+            any_known = true;
+        }
+        if util < self.emergency_threshold {
+            all_above = false;
+            break;
+        }
+    }
+
+    // Iterate unified endpoints, but ONLY Protocol::Anthropic.
+    // OpenAI endpoints have no rate-limit data and must not vote against firing
+    // the brake — their stub RateLimitInfo would otherwise resolve to
+    // (0.5, "unknown"), forcing all_above = false. This is one of the three
+    // named `match protocol` sites (see Endpoint struct docs).
+    if all_above {
+        for ep in &self.endpoints {
+            if ep.protocol != Protocol::Anthropic {
+                continue;
+            }
+            let info = ep.rate_info.read().await;
+            let (util, source, _, _) = effective_utilization(&info, now_epoch, "");
+            if source != "unknown" {
+                any_known = true;
+            }
+            if util < self.emergency_threshold {
+                all_above = false;
+                break;
+            }
+        }
+    }
+
+    all_above && any_known
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cargo test emergency_brake_ 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "fix: emergency brake skips Protocol::OpenAI endpoints"
+```
+
+---
+
+### Task 13: Migrate probe loop — skip `Protocol::OpenAI` endpoints
+
+**Files:**
+- Modify: `src/main.rs` `probe_account` (~line 783) and `main()` probe-loop spawn (~line 7851)
+
+- [ ] **Step 1: Find the probe loop**
+
+```bash
+grep -n "tokio::spawn.*async move\|probe_account\|PROBE_MODELS\|n_accounts = " src/main.rs
+```
+
+The probe loop is in `main()` (~line 7851) and iterates by account index calling `probe_account`. We need an analogous loop for unified endpoints.
+
+- [ ] **Step 2: Write the failing test**
+
+This is harder to unit-test cleanly because the probe loop spawns. Add a smaller test that verifies a probe-style helper skips OpenAI endpoints:
+
+```rust
+#[tokio::test]
+async fn probe_endpoint_unified_skips_openai() {
+    let ep = Endpoint {
+        name: "openai".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: "http://127.0.0.1:1".to_string(),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 100,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    };
+    let mut state = test_state_with(vec![]);
+    Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
+    // probe_endpoint_unified must early-return without HTTP. We assert it
+    // does not panic, does not increment requests, and completes in <100ms
+    // (since base_url 127.0.0.1:1 would hang/connect-refuse otherwise).
+    let start = std::time::Instant::now();
+    state.probe_endpoint_unified(0, "claude-haiku-4-5").await;
+    assert!(start.elapsed() < Duration::from_millis(100),
+        "probe must short-circuit for OpenAI endpoints");
+    assert_eq!(state.endpoints[0].requests.load(Ordering::Relaxed), 0);
+}
+```
+
+- [ ] **Step 3: Add the unified probe method**
+
+Near `probe_account` (~line 783), add:
+
+```rust
+/// Probe a unified-pool endpoint by index. Skips Protocol::OpenAI endpoints —
+/// they have no rate-limit headers to refresh. This is one of the three
+/// named `match protocol` sites (see Endpoint struct docs).
+async fn probe_endpoint_unified(&self, idx: usize, model: &str) {
+    let ep = &self.endpoints[idx];
+    if ep.protocol == Protocol::OpenAI {
+        debug!(endpoint = ep.name, "skipping probe for openai endpoint");
+        return;
+    }
+    if ep.passthrough {
+        debug!(endpoint = ep.name, "skipping probe for passthrough endpoint");
+        return;
+    }
+    // SOURCE: copy the body of `probe_account` at src/main.rs lines ~783–~980
+    //   with these substitutions:
+    //     `&self.accounts[idx]`  -> `&self.endpoints[idx]`
+    //     `acct.passthrough`     -> (already checked above; remove duplicate)
+    //     `acct.token`           -> `ep.token`
+    //     `acct.name`            -> `ep.name`
+    //     `acct.rate_info`       -> `ep.rate_info`
+    //     `state.upstream`       -> `ep.base_url`
+    todo!("paste lines ~783–~980 with the substitutions in the comment above")
+}
+```
+
+- [ ] **Step 4: Add a probe-loop branch for endpoints**
+
+In `main()`, after the existing `let n_accounts = probe_state.accounts.len();` probe loop, add a parallel loop:
+
+```rust
+let n_endpoints = probe_state.endpoints.len();
+if n_endpoints > 0 {
+    let probe_state = state.clone();
+    tokio::spawn(async move {
+        const PROBE_MODELS: &[&str] =
+            &["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"];
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let mut model_idx = 0;
+        loop {
+            for i in 0..n_endpoints {
+                let model = PROBE_MODELS[model_idx % PROBE_MODELS.len()];
+                probe_state.probe_endpoint_unified(i, model).await;
+            }
+            model_idx += 1;
+            tokio::time::sleep(Duration::from_secs(probe_interval)).await;
+        }
+    });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cargo test probe_endpoint_unified_skips_openai 2>&1 | tail -10
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "fix: probe loop skips Protocol::OpenAI endpoints"
+```
+
+---
+
+### Task 14: Add `record_usage_unified`, finalize Anthropic forward path
+
+**Files:**
+- Modify: `src/main.rs` `record_usage` (~line 3145), `forward_anthropic` from Task 9
+
+- [ ] **Step 1: Add the unified record helper**
+
+Above `record_usage` (~line 3145):
+
+```rust
+/// Per-endpoint usage tracking (unified pool). Mirrors `record_usage` exactly,
+/// but indexes into `state.endpoints` instead of `state.accounts`.
+///
+/// After Phase 4 cleanup, `record_usage` is removed and only this version
+/// survives.
+async fn record_usage_unified(
+    &self,
+    endpoint_idx: usize,
+    client_id: &str,
+    usage: &TokenUsage,
+) {
+    let ep = &self.endpoints[endpoint_idx];
+    // SOURCE: copy the body of `record_usage` at src/main.rs lines ~3145–~3340
+    //   with these substitutions:
+    //     `&self.accounts[account_idx]` -> `&self.endpoints[endpoint_idx]`
+    //     `acct.input_tokens`           -> `ep.input_tokens`
+    //     `acct.output_tokens`          -> `ep.output_tokens`
+    //     `acct.cache_creation_tokens`  -> `ep.cache_creation_tokens`
+    //     `acct.cache_read_tokens`      -> `ep.cache_read_tokens`
+    //     `acct.name`                   -> `ep.name`
+    //     (Redis key paths keyed by ep.name remain unchanged — Phase 2 Task 18.)
+    todo!("paste lines ~3145–~3340 with the substitutions in the comment above")
+}
+```
+
+- [ ] **Step 2: Wire it into `forward_anthropic`**
+
+In `forward_anthropic`, the `record_usage` call (which had the `TODO(unified)` marker from Task 9) needs both branches. Accept a `usage_target: UsageTarget` enum:
+
+```rust
+enum UsageTarget {
+    LegacyAccount(usize),
+    Unified(usize),
+}
+
+// In forward_anthropic signature: add `usage_target: UsageTarget` and
+// dispatch:
+match usage_target {
+    UsageTarget::LegacyAccount(i) => state.record_usage(i, client_id, &usage).await,
+    UsageTarget::Unified(i) => state.record_usage_unified(i, client_id, &usage).await,
+}
+```
+
+Update both call sites in `proxy_handler` to pass `UsageTarget::LegacyAccount(idx)` and `UsageTarget::Unified(i)` respectively.
+
+- [ ] **Step 3: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib 2>&1 | tail -5
+```
+
+Expected: clean build, all tests pass. The unified path is now fully functional including usage tracking.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: record_usage_unified + UsageTarget; finalize Anthropic forward path"
+```
+
+---
+
+### Task 15: Migrate persistence — `PersistedEndpoint`, top-level `endpoints` key
+
+**Files:**
+- Modify: `src/main.rs` `PersistedState`/`PersistedAccount` (~line 615), `save_state`/`load_state` (~lines 724, 985)
+
+- [ ] **Step 1: Write the failing test**
+
+In `mod tests`:
+
+```rust
+#[tokio::test]
+async fn load_state_warns_and_starts_clean_on_legacy_accounts_key() {
+    // Pre: state file uses `accounts` (legacy) top-level key.
+    // Expect: load_state returns without populating, no panic.
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), r#"{"accounts":[{"name":"primary","requests_total":42}],"saved_at":0}"#).unwrap();
+    let mut state = test_state_with(vec![]);
+    Arc::get_mut(&mut state).unwrap().state_path = tmp.path().to_path_buf();
+    Arc::get_mut(&mut state).unwrap().endpoints.push(Endpoint {
+        name: "primary".to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: "https://api.anthropic.com".to_string(),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 0,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
+    state.load_state().await;  // must not panic
+    // Legacy `accounts` key must NOT have been used to populate endpoints
+    assert_eq!(state.endpoints[0].requests.load(Ordering::Relaxed), 0,
+        "legacy accounts-keyed state file must not deserialize into endpoints");
+}
+```
+
+- [ ] **Step 2: Rename `PersistedAccount` → `PersistedEndpoint` and the top-level key**
+
+Replace `struct PersistedState` and `struct PersistedAccount` (~lines 615–660):
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct PersistedState {
+    /// Per-endpoint persisted runtime state. Replaces the legacy `accounts` key.
+    endpoints: Vec<PersistedEndpoint>,
+    #[serde(default)]
+    saved_at: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedEndpoint {
+    name: String,
+    requests_total: u64,
+    utilization: Option<f64>,
+    #[serde(default)]
+    utilization_7d: Option<f64>,
+    #[serde(default)]
+    utilization_5h: Option<f64>,
+    representative_claim: Option<String>,
+    #[serde(default)]
+    reset_5h: Option<u64>,
+    #[serde(default)]
+    reset_7d: Option<u64>,
+    #[serde(default)]
+    status_5h: Option<String>,
+    #[serde(default)]
+    status_7d: Option<String>,
+    #[serde(default)]
+    claims_7d: HashMap<String, ClaimWindowData>,
+    remaining_requests: Option<u64>,
+    remaining_tokens: Option<u64>,
+    limit_requests: Option<u64>,
+    limit_tokens: Option<u64>,
+    #[serde(default)]
+    overage_in_use: bool,
+    #[serde(default)]
+    overage_status: Option<String>,
+    #[serde(default)]
+    overage_utilization: Option<f64>,
+    #[serde(default)]
+    overage_reset: Option<u64>,
+    hard_limited_until_epoch: Option<u64>,
+    #[serde(default)]
+    last_updated_epoch: Option<u64>,
+}
+```
+
+- [ ] **Step 3: Update `save_state` to write `endpoints` from `self.endpoints`**
+
+In `save_state` (~line 724), replace the loop over `self.accounts` with a loop over `self.endpoints`. During the migration both pools exist; **the unified pool is now the canonical state**. The legacy `self.accounts` loop is removed from `save_state` entirely (any production rollout will have already populated `self.endpoints` from `[[endpoints]]` config).
+
+- [ ] **Step 4: Update `load_state` to read `endpoints`**
+
+In `load_state` (~line 985), replace `for pa in &persisted.accounts` with `for pe in &persisted.endpoints` and `self.accounts.iter().find` with `self.endpoints.iter().find`.
+
+Add an explicit warn for legacy-format state:
+
+```rust
+let persisted: PersistedState = match serde_json::from_str(&data) {
+    Ok(s) => s,
+    Err(e) => {
+        warn!(error = %e,
+            "failed to parse persisted state — possible legacy format ('accounts' top-level key was removed); starting fresh"
+        );
+        return;
+    }
+};
+```
+
+Because `PersistedState` no longer has an `accounts` field, the legacy file fails to deserialize (no `endpoints` key present), triggering the warn-and-return branch.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cargo test load_state_warns_and_starts_clean 2>&1 | tail -10
+cargo test --lib 2>&1 | tail -5
+```
+
+Expected: new test passes; existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: persist as PersistedEndpoint under 'endpoints' top-level key"
+```
+
+---
+
+### Task 16: Migrate metrics emit (`refresh_metrics_weights`, prometheus output)
+
+**Files:**
+- Modify: `src/main.rs` `refresh_metrics_weights` (~line 1727), `metrics_handler` Prometheus block (~lines 4943–5260)
+
+- [ ] **Step 1: Migrate `refresh_metrics_weights`**
+
+Currently iterates `self.accounts`. Add a second pass that iterates `self.endpoints` and updates the same gauges on the unified runtime fields (`last_routing_weight`, `last_routing_share`, `last_effective_gate`).
+
+```bash
+grep -n "fn refresh_metrics_weights" src/main.rs
+```
+
+Read the function body and add a parallel `for ep in &self.endpoints` block at the end that performs the same per-endpoint computation but on `Endpoint` fields.
+
+- [ ] **Step 2: Migrate Prometheus emission**
+
+Search for `anthropic_account_` references in `metrics_handler`:
+
+```bash
+grep -n "anthropic_account_" src/main.rs
+```
+
+Per spec, **metric names are left unchanged** (`anthropic_account_*`). The metrics emit loop already iterates `self.accounts`. Add a second iteration over `self.endpoints` that emits the same metrics with the endpoint's `name` as the `name` label. Both pools share the same metric names — the labels differ only by which name each entry has, and there are no collisions in production (one pool is populated at a time after Phase 5).
+
+- [ ] **Step 3: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib metrics 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: metrics_handler and refresh_metrics_weights enumerate AppState.endpoints"
+```
+
+---
+
+### Task 17: Migrate `stats_handler` JSON output
+
+**Files:**
+- Modify: `src/main.rs` `stats_handler` (~look for `fn stats_handler` and the response builder block)
+
+- [ ] **Step 1: Find stats_handler**
+
+```bash
+grep -n "fn stats_handler\|\"accounts\":" src/main.rs | head -10
+```
+
+- [ ] **Step 2: Add an `endpoints` array to the JSON response**
+
+The JSON currently has an `accounts` array. Add a parallel `endpoints` array sourced from `self.endpoints` with the same field shape (`name`, `requests`, `passthrough`, utilization fields, priority, etc.). Add a `protocol` field to each entry.
+
+- [ ] **Step 3: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib stats 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat: stats_handler exposes 'endpoints' array alongside 'accounts'"
+```
+
+---
+
+### Task 18: Migrate Redis sync (rate-info, hard-limit, heartbeat)
+
+**Files:**
+- Modify: `src/main.rs` Redis sync functions (search for `sync_from_redis`, `redis_set_hard_limit`, `redis_heartbeat`)
+
+- [ ] **Step 1: Find Redis call sites**
+
+```bash
+grep -n "alb:rate:\|alb:hard:\|alb:heartbeat:\|sync_from_redis" src/main.rs | head -20
+```
+
+- [ ] **Step 2: Mirror each sync function to enumerate `self.endpoints`**
+
+For each function that currently iterates `self.accounts`, add a parallel iteration over `self.endpoints` using the endpoint's `name` as the Redis key (matches the existing key format `alb:rate:<name>`, etc.). Skip `Protocol::OpenAI` endpoints — they have no rate-limit data to sync.
+
+- [ ] **Step 3: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib redis 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: Redis sync paths enumerate AppState.endpoints (Anthropic only)"
+```
+
+---
+
+## Phase 3 — Behavior corrections (TDD)
+
+### Task 19: New test — OpenAI endpoint participates in priority routing
+
+**Files:**
+- Modify: `src/main.rs` `mod tests`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+#[tokio::test]
+async fn openai_endpoint_participates_at_configured_priority() {
+    let acct = make_account("anthropic", "sk-ant");
+    {
+        let mut info = acct.rate_info.write().await;
+        info.utilization = Some(0.0); // healthy
+    }
+    let mut state = test_state_with(vec![acct]);
+    let st = Arc::get_mut(&mut state).unwrap();
+    st.endpoints.push(Endpoint {
+        name: "openai".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: "https://gw.example".to_string(),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 100,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
+    let candidates = state.routing_candidates("claude-opus-4-7", &[]).await;
+    let openai_candidate = candidates.iter().find(|c| matches!(c.endpoint, EndpointIdx::Unified(_)));
+    assert!(openai_candidate.is_some(), "openai endpoint must be a candidate");
+    let c = openai_candidate.unwrap();
+    assert_eq!(c.priority, 100);
+    assert_eq!(c.weight, 1.0);
+    assert_eq!(c.gate, 0.0);
+}
+```
+
+- [ ] **Step 2: Run — expect pass (the routing_candidates change in Task 8 already covers this)**
+
+```bash
+cargo test openai_endpoint_participates 2>&1 | tail -5
+```
+
+Expected: pass (this test is verification of Task 8's behavior).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "test: openai endpoint participates in priority routing at configured tier"
+```
+
+---
+
+### Task 20: New test — model allowlist on OpenAI endpoint filters correctly
+
+**Files:**
+- Modify: `src/main.rs` `mod tests`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+#[tokio::test]
+async fn openai_endpoint_with_opus_only_allowlist_excludes_sonnet() {
+    let mut state = test_state_with(vec![]);
+    Arc::get_mut(&mut state).unwrap().endpoints.push(Endpoint {
+        name: "opus-gw".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: "https://gw.example".to_string(),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec!["claude-opus-*".to_string()],
+        priority: 0,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
+    let cs_opus = state.routing_candidates("claude-opus-4-7", &[]).await;
+    let cs_sonnet = state.routing_candidates("claude-sonnet-4-6", &[]).await;
+    assert_eq!(cs_opus.len(), 1, "opus must hit the opus-only endpoint");
+    assert_eq!(cs_sonnet.len(), 0, "sonnet must be filtered out");
+}
+```
+
+- [ ] **Step 2: Run — expect pass**
+
+```bash
+cargo test openai_endpoint_with_opus_only 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "test: model allowlist filters openai endpoints by model match"
+```
+
+---
+
+### Task 21: New test — `forward_translated()` returns `None` on upstream 429/5xx
+
+**Files:**
+- Modify: `src/main.rs` `mod tests` (integration-style with a mock upstream)
+
+- [ ] **Step 1: Write the test**
+
+```rust
+#[tokio::test]
+async fn try_fallback_upstream_unified_returns_none_on_429() {
+    // Mock upstream returns 429
+    let app = Router::new().fallback(any(|| async { (StatusCode::TOO_MANY_REQUESTS, "rate limited").into_response() }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
+    let mut state = test_state_with(vec![]);
+    Arc::get_mut(&mut state).unwrap().endpoints.push(Endpoint {
+        name: "rl-gw".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: format!("http://{}", addr),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 0,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
+    let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+    let result = try_fallback_upstream_unified(
+        &state, body, "req-1", "client-1", "claude-opus-4-7", 0, false,
+    ).await;
+    assert!(result.is_none(), "429 must return None for retry, not Response");
+}
+
+#[tokio::test]
+async fn try_fallback_upstream_unified_returns_none_on_500() {
+    let app = Router::new().fallback(any(|| async { (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response() }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
+    let mut state = test_state_with(vec![]);
+    Arc::get_mut(&mut state).unwrap().endpoints.push(Endpoint {
+        name: "broken".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: format!("http://{}", addr),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 0,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
+    let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+    let result = try_fallback_upstream_unified(
+        &state, body, "req-1", "client-1", "claude-opus-4-7", 0, false,
+    ).await;
+    assert!(result.is_none(), "500 must return None for retry");
+}
+```
+
+- [ ] **Step 2: Run — expect pass (Task 10 already implements this behavior)**
+
+```bash
+cargo test try_fallback_upstream_unified 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "test: try_fallback_upstream_unified returns None on 429/5xx for retry"
+```
+
+---
+
+### Task 22: New test — `openai_chat_handler` routes only to OpenAI endpoints
+
+**Files:**
+- Modify: `src/main.rs` `mod tests`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+#[tokio::test]
+async fn openai_chat_handler_skips_anthropic_only_pool() {
+    // Pool: only Anthropic endpoints in the unified pool. An OpenAI-format
+    // request must NOT route to them (no reverse-translation path per spec).
+    // Expect: 429 "all openai endpoints exhausted".
+    let acct = make_account("anthropic", "sk-ant");
+    let state = test_state_with(vec![acct]);  // legacy accounts also Anthropic
+    // No endpoints added. openai_chat_handler must return 429.
+    let app = Router::new()
+        .route("/v1/chat/completions", axum::routing::post(openai_chat_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{}/v1/chat/completions", addr))
+        .json(&serde_json::json!({
+            "model": "claude-opus-4-7",
+            "messages": [{"role": "user", "content": "hi"}],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 429,
+        "openai_chat_handler must NOT route an OpenAI-format request to an Anthropic endpoint");
+}
+```
+
+- [ ] **Step 2: Run — expect pass (Task 11 implements this filter)**
+
+```bash
+cargo test openai_chat_handler_skips_anthropic_only 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "test: openai_chat_handler does not route to Anthropic endpoints"
+```
+
+---
+
+### Task 23: New test — `proxy_handler` translates to OpenAI endpoint
+
+**Files:**
+- Modify: `src/main.rs` `mod tests`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+#[tokio::test]
+async fn proxy_handler_translates_to_openai_endpoint() {
+    // Mock OpenAI upstream: assert it received an OpenAI-format request
+    // (contains `messages` array but no Anthropic-only fields like `system` as array).
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<serde_json::Value>(1);
+    let app = Router::new().fallback(any(move |req: Request<Body>| {
+        let tx = tx.clone();
+        async move {
+            let bytes = axum::body::to_bytes(req.into_body(), usize::MAX).await.unwrap();
+            let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            let _ = tx.send(v).await;
+            (StatusCode::OK, axum::Json(serde_json::json!({
+                "id": "chatcmpl-x",
+                "object": "chat.completion",
+                "model": "claude-opus-4-7",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hi back"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+            }))).into_response()
+        }
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
+
+    let mut state = test_state_with(vec![]);
+    Arc::get_mut(&mut state).unwrap().endpoints.push(Endpoint {
+        name: "openai-gw".to_string(),
+        protocol: Protocol::OpenAI,
+        base_url: format!("http://{}", upstream_addr),
+        token: "sk".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 0,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
+
+    let proxy_app = Router::new()
+        .fallback(any(proxy_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, proxy_app).await.unwrap(); });
+
+    let client = reqwest::Client::new();
+    let _ = client
+        .post(format!("http://{}/v1/messages", proxy_addr))
+        .json(&serde_json::json!({
+            "model": "claude-opus-4-7",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hi"}],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let received = rx.recv().await.expect("upstream must receive a request");
+    assert!(received.get("messages").is_some(),
+        "translated request must have OpenAI `messages` field");
+    assert_eq!(received["model"], "claude-opus-4-7");
+}
+```
+
+- [ ] **Step 2: Run — expect pass**
+
+```bash
+cargo test proxy_handler_translates_to_openai 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "test: proxy_handler translates Anthropic request to OpenAI endpoint"
+```
+
+---
+
+## Phase 4 — Cleanup
+
+### Task 24: Remove `upstream_handler` and `/upstream/{name}/*` route
+
+**Files:**
+- Modify: `src/main.rs` (`upstream_handler` ~line 4430, router definition ~line 7830)
+
+- [ ] **Step 1: Delete the route registration**
+
+In `main()` (~line 7830), remove the line:
+
+```rust
+.route("/upstream/{name}/{*rest}", any(upstream_handler))
+```
+
+- [ ] **Step 2: Delete the handler function**
+
+Delete `async fn upstream_handler(...) { ... }` entirely (~line 4430 through end of function).
+
+- [ ] **Step 3: Delete its tests**
+
+```bash
+grep -n "upstream_handler_forwards_to_named\|upstream_handler_rejects_unknown" src/main.rs
+```
+
+Delete the two test functions found.
+
+- [ ] **Step 4: Verify compile and tests**
+
+```bash
+cargo build 2>&1 | tail -3
+cargo test --lib 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: remove /upstream/{name}/* passthrough route and handler"
+```
+
+---
+
+### Task 25: Remove legacy `accounts`, `upstreams`, `fallback_upstream`, `upstream` from runtime
+
+**Files:**
+- Modify: `src/main.rs` `AppState`, `Config`, all remaining `state.accounts`/`state.upstreams`/`state.fallback_upstream`/`state.upstream` references
+
+- [ ] **Step 1: Find every remaining reference**
+
+```bash
+grep -nE "state\.(accounts|upstreams|fallback_upstream|upstream)\b|self\.(accounts|upstreams|fallback_upstream|upstream)\b|config\.(accounts|upstreams|fallback_upstream|upstream)\b" src/main.rs
+```
+
+For each: replace with the equivalent endpoints-based access. Most are mechanical (`self.accounts.iter()` → no longer needed; was already migrated to `self.endpoints` in Phase 2).
+
+- [ ] **Step 2: Delete fields from `AppState`**
+
+In `struct AppState`:
+- Delete `accounts: Vec<Account>,`
+- Delete `upstreams: Vec<Upstream>,`
+- Delete `fallback_upstream: Option<usize>,`
+- Delete `upstream: String,`
+
+- [ ] **Step 3: Delete fields from `Config`**
+
+In `struct Config`:
+- Delete `accounts: Vec<AccountConfig>,`
+- Delete `#[serde(default)] upstreams: Vec<UpstreamConfig>,`
+- Delete `fallback_upstream: Option<String>,`
+- Delete `upstream: String,`
+
+- [ ] **Step 4: Delete dead struct definitions**
+
+- Delete `struct AccountConfig` (~line 89)
+- Delete `struct UpstreamConfig` (~line 104)
+- Delete `struct Account` (~line 421)
+- Delete `struct Upstream` (~line 451)
+
+- [ ] **Step 5: Collapse `EndpointIdx` to bare `usize`**
+
+The enum now has only one variant in use (`Unified(usize)`). Replace `EndpointIdx` with a type alias or just `usize`:
+
+- Delete `enum EndpointIdx { ... }` and `impl EndpointIdx { ... }`
+- Replace `EndpointIdx::Unified(i)` with `i` everywhere it appears
+- Replace `skip: &[EndpointIdx]` with `skip: &[usize]` in function signatures
+- Replace `RoutingCandidate { endpoint: EndpointIdx, .. }` with `endpoint: usize`
+
+```bash
+grep -n "EndpointIdx" src/main.rs
+```
+
+Iterate until grep returns nothing.
+
+- [ ] **Step 6: Delete `try_fallback_upstream`, `record_usage`, `probe_account` (legacy)**
+
+These were the legacy-Account versions. The unified versions (`try_fallback_upstream_unified`, `record_usage_unified`, `probe_endpoint_unified`) replace them. Rename the unified versions to drop the `_unified` suffix:
+
+```bash
+sed -i 's/try_fallback_upstream_unified/try_fallback_upstream/g; s/record_usage_unified/record_usage/g; s/probe_endpoint_unified/probe_account/g' src/main.rs
+# Then manually rename the function definitions.
+```
+
+Hmm — `probe_account` is a misnomer if it now operates on `Endpoint`. Rename to `probe_endpoint` instead.
+
+- [ ] **Step 7: Delete `make_account` test helper, replace with `make_endpoint`**
+
+In `mod tests`, replace `fn make_account` with:
+
+```rust
+fn make_endpoint(name: &str, token: &str) -> Endpoint {
+    Endpoint {
+        name: name.to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: "https://api.anthropic.com".to_string(),
+        token: token.to_string(),
+        passthrough: token == "passthrough",
+        models: vec![],
+        priority: 0,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    }
+}
+```
+
+Replace every `make_account(...)` call with `make_endpoint(...)` and update test_state_with* signatures from `Vec<Account>` to `Vec<Endpoint>`. The `accounts:` field in the `AppState { ... }` test literals becomes `endpoints:` (it already exists from Task 7) — just pass the vec to the right field.
+
+`test_state_with_fallback` is no longer needed (the fallback concept is gone) — delete it. Any test using it must be rewritten to insert an `Endpoint { protocol: OpenAI, .. }` into `state.endpoints` directly.
+
+- [ ] **Step 8: Verify compile and all tests pass**
+
+```bash
+cargo build 2>&1 | tail -10
+cargo test --lib 2>&1 | tail -10
+RUSTFLAGS="-Dwarnings" cargo clippy --all-targets 2>&1 | tail -10
+cargo fmt --check 2>&1 | tail -3
+```
+
+Expected: clean build, **all** tests green, clippy clean, fmt clean. This is the moment of truth — the refactor is done.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "refactor: delete legacy Account/Upstream/fallback_upstream; collapse EndpointIdx to usize"
+```
+
+---
+
+## Phase 5 — Docs & deployment
+
+### Task 26: Update local `config.toml` example
+
+**Files:**
+- Modify: `config.toml` (project root)
+
+- [ ] **Step 1: Rewrite as `[[endpoints]]`**
+
+Replace any `[[accounts]]` / `[[upstreams]]` / `fallback_upstream` lines with `[[endpoints]]` blocks per the new schema. Remove the global `upstream = "..."` key.
+
+- [ ] **Step 2: Verify the binary parses it**
+
+```bash
+./target/release/anthropic-lb config.toml --check 2>&1 | tail -10
+# (If --check doesn't exist, run normally and Ctrl-C after startup logs confirm "loaded endpoint ..." entries)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config.toml
+git commit -m "docs: rewrite local config.toml example with [[endpoints]] schema"
+```
+
+---
+
+### Task 27: Update `CLAUDE.md` config schema docs
+
+**Files:**
+- Modify: `CLAUDE.md` (project root)
+
+- [ ] **Step 1: Update the "Config Fields" table**
+
+Find the table section:
+
+```bash
+grep -n "Config Fields\|accounts\[\]\|upstreams\[\]\|fallback_upstream" CLAUDE.md
+```
+
+Rewrite to use `endpoints[]` rows with the new field set: `name`, `protocol`, `base_url`, `token`, `models`, `priority`. Remove rows for `accounts[]`, `upstreams[]`, `fallback_upstream`, and the global `upstream`.
+
+- [ ] **Step 2: Update the "Architecture" / "Unified Endpoint Priority" sections**
+
+The section describes how accounts and the fallback upstream share one priority space. Rewrite to describe a single `[[endpoints]]` pool with a `protocol` field.
+
+- [ ] **Step 3: Update the "Token Type Detection (by prefix)" section**
+
+Mention that `protocol = "openai"` endpoints are authed via `Bearer` (no prefix logic), while `protocol = "anthropic"` retains the prefix-based behavior (`sk-ant-oat*` → Bearer + OAuth beta headers, `sk-ant-api*` → `x-api-key`, `"passthrough"` → forward client auth).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md for [[endpoints]] schema"
+```
+
+---
+
+### Task 28: Update mem cluster ExternalSecret
+
+**Files:**
+- Modify: `/home/fish/code/27b.io/fleet-infra/apps/mem/anthropic-lb/externalsecret.yaml`
+
+- [ ] **Step 1: Rewrite the inline TOML template**
+
+Replace the three `[[accounts]]` blocks with `[[endpoints]]` blocks. There are no upstreams in the mem cluster — just the three Anthropic accounts.
+
+```yaml
+        config.toml: |
+          listen = "0.0.0.0:8082"
+          redis_url = "redis://:{{ .redis_password }}@redis.redis.svc.cluster.local:6379"
+          strategy = "sticky-weighted-v2"
+          auto_cache = true
+          shadow_log = "/tmp/shadow.jsonl"
+          soft_limit = 0.90
+          probe_interval_secs = 300
+
+          emergency_brake = false
+          emergency_threshold = 0.95
+
+          [client_names]
+
+          [[endpoints]]
+          name = "primary"
+          token = "{{ .token_primary }}"
+
+          [[endpoints]]
+          name = "jeff"
+          token = "{{ .token_jeff }}"
+
+          [[endpoints]]
+          name = "insight"
+          token = "{{ .token_claude_code_insight }}"
+```
+
+Note: the global `upstream = "https://api.anthropic.com"` line is removed — endpoints derive their base URL from `protocol` (defaulting to Anthropic).
+
+- [ ] **Step 2: Commit (in the fleet-infra repo)**
+
+```bash
+cd /home/fish/code/27b.io/fleet-infra
+git add apps/mem/anthropic-lb/externalsecret.yaml
+git commit -m "anthropic-lb: migrate config to [[endpoints]] schema"
+```
+
+Note: do not push yet — the binary must ship in lockstep.
+
+---
+
+### Task 29: Update lab cluster ExternalSecret
+
+**Files:**
+- Modify: `/home/fish/code/27b.io/lab/k8s/mcp/anthropic-lb-externalsecret.yaml`
+
+- [ ] **Step 1: Rewrite the inline TOML template**
+
+Convert all `[[accounts]]` blocks to `[[endpoints]]` and convert the `[[upstreams]]` block to `[[endpoints]]` with `protocol = "openai"`. Remove the `fallback_upstream = "..."` line and the global `upstream = "..."` line.
+
+```yaml
+        config.toml: |
+          listen = "0.0.0.0:8082"
+          strategy = "sticky-weighted-v2"
+          rate_limit_cooldown_secs = 60
+          probe_interval_secs = 300
+          auto_cache = true
+          soft_limit = 0.90
+          emergency_brake = false
+          emergency_threshold = 0.95
+
+          [[endpoints]]
+          name = "passbolt"
+          token = "{{ .token_passbolt }}"
+
+          [[endpoints]]
+          name = "primary"
+          token = "{{ .token_primary }}"
+
+          [[endpoints]]
+          name = "jeff"
+          token = "{{ .token_jeff }}"
+
+          [[endpoints]]
+          name = "insight"
+          token = "{{ .token_insight }}"
+
+          [[endpoints]]
+          name = "insight-gateway"
+          protocol = "openai"
+          base_url = "https://gateway.lobster-python.ts.net"
+          token = "{{ .token_insight_gateway }}"
+          priority = 100
+```
+
+Confirm with the operator (Ray) whether the current `priority = 1` settings on all four accounts (as seen in the file's existing state) should be preserved verbatim or normalized to defaults during this migration.
+
+- [ ] **Step 2: Commit (in the lab repo)**
+
+```bash
+cd /home/fish/code/27b.io/lab
+git add k8s/mcp/anthropic-lb-externalsecret.yaml
+git commit -m "anthropic-lb: migrate config to [[endpoints]] schema"
+```
+
+Note: do not push yet — coordinate with the binary roll-out.
+
+---
+
+### Task 30: Final quality gates and integration sanity
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run all quality gates**
+
+```bash
+cd /home/fish/code/anthropic-lb
+cargo fmt --check 2>&1 | tail -3
+RUSTFLAGS="-Dwarnings" cargo clippy --all-targets 2>&1 | tail -3
+cargo test 2>&1 | tail -10
+```
+
+Expected: all clean.
+
+- [ ] **Step 2: Smoke test locally**
+
+```bash
+cargo build --release
+./target/release/anthropic-lb config.toml &
+sleep 2
+curl -sv http://127.0.0.1:8080/_stats | jq '.endpoints | length'
+kill %1
+```
+
+Expected: the smoke test returns the configured endpoint count.
+
+- [ ] **Step 3: Push the binary, then the configs (in this order)**
+
+```bash
+cd /home/fish/code/anthropic-lb
+git push origin feat/overage-aware-routing
+
+# After CI passes and the binary image lands:
+cd /home/fish/code/27b.io/fleet-infra && git push
+cd /home/fish/code/27b.io/lab && git push
+```
+
+- [ ] **Step 4: Verify the deployments**
+
+```bash
+kubectl --context mem -n anthropic-lb logs -l app=anthropic-lb --since=2m | grep -E "loaded endpoint|protocol"
+kubectl --context lab -n mcp logs -l app=anthropic-lb --since=2m | grep -E "loaded endpoint|protocol"
+```
+
+Expected: each pod logs `loaded endpoint ... protocol=Anthropic|OpenAI` lines for every configured endpoint.
+
+- [ ] **Step 5: Final commit (if any docs slipped)**
+
+```bash
+cd /home/fish/code/anthropic-lb
+git status
+# If any tracked file was modified mid-task and not committed, commit now.
+```
+
+---
+
+## Rollback procedure (if a roll-out fails)
+
+If `cargo test` was green but a cluster pod fails to start or behaves incorrectly:
+
+1. **Identify the prior good image digest:**
+
+   ```bash
+   kubectl --context <ctx> -n <ns> describe deployment anthropic-lb | grep "Image:"
+   ```
+
+   Find the prior digest in the deployment's revision history:
+
+   ```bash
+   kubectl --context <ctx> -n <ns> rollout history deployment/anthropic-lb
+   ```
+
+2. **Roll back the binary and the config together:**
+
+   ```bash
+   kubectl --context <ctx> -n <ns> rollout undo deployment/anthropic-lb
+   cd /home/fish/code/27b.io/<repo>
+   git revert HEAD       # reverts the externalsecret.yaml migration
+   git push
+   ```
+
+3. **Verify recovery:**
+
+   ```bash
+   kubectl --context <ctx> -n <ns> logs -l app=anthropic-lb --since=1m | tail -20
+   ```
+
+The old binary and the old `[[accounts]]`-style config must travel together — neither side parses the other.
+
+---
+
+## Notes for the implementing engineer
+
+- **The single-file refactor is structurally aggressive but mechanically simple.** The compiler enumerates every site that needs to change. Trust the type system; do not rush past clippy warnings.
+- **Do not skip the warn on legacy state file load.** Silent state discard in production is the kind of thing that becomes a 3am surprise.
+- **Phase 2 tasks have non-trivial coupling** between `forward_anthropic`, `record_usage_unified`, and the `UsageTarget` enum. Read all three of Tasks 9, 10, and 14 before starting any of them.
+- **Phase 3 tests should already pass** after Phase 2's structural changes — they are spec-coverage tests, not red-green increments. If any fails, it indicates the structural change in Phase 2 missed a case; do not try to fix the test, fix the structural code.
+- **Phase 5 deploys are last** because the binary must be deployed before the config switch in either cluster (any pod that picks up the new config before getting the new binary will crash-loop on parse).
+- **Commits are atomic, but the refactor is not.** Plan ~4 hours of focused work; budget 6.

--- a/docs/superpowers/plans/2026-05-21-unified-endpoints.md
+++ b/docs/superpowers/plans/2026-05-21-unified-endpoints.md
@@ -1174,170 +1174,121 @@ git commit -m "feat: add try_fallback_upstream_unified with 429/5xx-as-retryable
 
 ---
 
-### Task 11: Migrate `openai_chat_handler` candidate filter and dispatch
+### Task 11: Add a unified-endpoint dispatch arm to `openai_chat_handler`
+
+> **Revised 2026-05-22.** An earlier version of this task filtered
+> `openai_chat_handler` to OpenAI endpoints only, on the false belief that the
+> handler reached only upstreams today. It does not — `openai_chat_handler`
+> already translates OpenAI→Anthropic and routes to Anthropic accounts. That
+> behavior is preserved. This task ADDS a `Unified` dispatch arm; it does not
+> filter anything out.
 
 **Files:**
-- Modify: `src/main.rs` `openai_chat_handler` (~line 6987)
+- Modify: `src/main.rs` `openai_chat_handler` (locate via `grep -n "async fn openai_chat_handler"`).
 
-- [ ] **Step 1: Add candidate filtering — Protocol::OpenAI only**
+**Context.** `openai_chat_handler` has a retry loop with a `match state.pick_endpoint(...)` dispatch. Today it has three arms:
+- `EndpointIdx::Account(i)` — translates the request to Anthropic, forwards to `state.upstream`, translates the response back to OpenAI. This is a large inline block.
+- `EndpointIdx::Upstream(u)` — calls `try_fallback_upstream(.., translate=false)` (forwards the original OpenAI body directly).
+- `EndpointIdx::Unified(_) => unreachable!(...)` — the placeholder added in Phase 2a.
 
-In `openai_chat_handler`, the dispatch loop currently picks from any endpoint via `state.pick_endpoint`. The spec requires this handler to target only `Protocol::OpenAI` endpoints. The cleanest path: add a `pick_endpoint_filtered(filter: Option<Protocol>)` method on `AppState`, or filter the result of `routing_candidates` before calling into the picker.
+You will replace the `unreachable!()` with a real arm that branches on `state.endpoints[i].protocol`:
+- `Protocol::OpenAI` → forward direct, no translation (same as the `Upstream` arm).
+- `Protocol::Anthropic` → translate + forward + translate-back (same as the `Account` arm).
 
-Choose the second — less surface area. Replace the current pick call with:
+- [ ] **Step 1: Factor the openai-compat Anthropic forward path**
+
+The `EndpointIdx::Account(i)` arm contains a large inline block: build the Anthropic-translated request, forward to the Anthropic API, handle 429/529/5xx, parse rate-limit headers, `record_usage`, and translate the response (streaming + non-streaming) back to OpenAI.
+
+Factor this block into a helper — call it `forward_openai_compat_anthropic` — parameterised the same way `forward_anthropic` was in Task 9: it takes `base_url`, `token`, `passthrough`, `endpoint_name`, `usage_target: UsageTarget`, `requests_counter: &AtomicU64`, `rate_info: &RwLock<RateLimitInfo>`, `burn_rate: &Mutex<BurnRate>`, plus the pre-translated `anthropic_body` / `oauth_anthropic_body`, the request context (`req_id`, `client_id`, etc.), and whatever else the inline block reads. Return a `ForwardOutcome` (the enum from Task 9) so the retry loop owns `skip`/`saw_529`/retry exactly as it does for `forward_anthropic`.
+
+This mirrors Task 9 precisely. If `forward_anthropic` and `forward_openai_compat_anthropic` end up sharing significant structure, that is acceptable — do NOT try to merge them; Phase 4 collapses pool-specific code. Copy-and-adapt is fine here.
+
+- [ ] **Step 2: Replace the dispatch match**
 
 ```rust
-let idx = {
-    let all_candidates = state.routing_candidates(&model, &skip).await;
-    // Filter: only Protocol::OpenAI endpoints from the unified pool.
-    // (Legacy `accounts` -> EndpointIdx::Account candidates remain — drop them
-    // until Phase 4 deletes the old pool entirely.)
-    let openai_only: Vec<RoutingCandidate> = all_candidates
-        .into_iter()
-        .filter(|c| match c.endpoint {
-            EndpointIdx::Unified(i) => {
-                matches!(state.endpoints[i].protocol, Protocol::OpenAI)
-            }
-            EndpointIdx::Upstream(_) => true,  // legacy upstream — also openai
-            EndpointIdx::Account(_) => false,
-        })
-        .collect();
-    state.pick_from_candidates_or_none(openai_only, affinity).await
+let picked = match state.pick_endpoint(affinity, &model, &skip).await {
+    Some(e) => e,
+    None => {
+        warn!("all endpoints exhausted");
+        return (StatusCode::TOO_MANY_REQUESTS, "all upstream endpoints exhausted")
+            .into_response();
+    }
 };
-```
-
-To avoid duplicating tier logic, **first extract** `pick_endpoint`'s tier-and-pick body into a private helper, then call it from both `pick_endpoint` and the new filtered path.
-
-Refactor `pick_endpoint` (~line 2116) to:
-
-```rust
-async fn pick_endpoint(
-    &self,
-    affinity_key: Option<&str>,
-    model: &str,
-    skip: &[EndpointIdx],
-) -> Option<EndpointIdx> {
-    let candidates = self.routing_candidates(model, skip).await;
-    self.pick_from_tiered_candidates(candidates, affinity_key)
-}
-
-/// Apply priority-tier partitioning and intra-tier soft-limit handling
-/// to an already-filtered candidate set. Returns the chosen index, or
-/// None if every tier has zero weight.
-fn pick_from_tiered_candidates(
-    &self,
-    candidates: Vec<RoutingCandidate>,
-    affinity_key: Option<&str>,
-) -> Option<EndpointIdx> {
-    if candidates.is_empty() {
-        debug!("pick: no available endpoints");
-        return None;
-    }
-    let mut tiers: Vec<u32> = candidates.iter().map(|c| c.priority).collect();
-    tiers.sort_unstable();
-    tiers.dedup();
-    for tier in &tiers {
-        let tier_candidates: Vec<&RoutingCandidate> =
-            candidates.iter().filter(|c| c.priority == *tier).collect();
-        let healthy: Vec<&RoutingCandidate> = tier_candidates
-            .iter()
-            .filter(|c| c.gate < self.soft_limit)
-            .copied()
-            .collect();
-        let (effective, degraded): (Vec<&RoutingCandidate>, bool) = if !healthy.is_empty() {
-            (healthy, false)
-        } else {
-            (tier_candidates.clone(), true)
-        };
-        let total_weight: f64 = effective.iter().map(|c| c.weight).sum();
-        if total_weight <= 0.0 {
-            debug!(tier = tier, "pick: tier exhausted (zero weight), trying next");
-            continue;
-        }
-        if degraded {
-            debug!(tier = tier, "pick: tier all soft-limited — degrading within tier");
-        }
-        return Some(self.pick_from_candidates(&effective, total_weight, affinity_key, *tier));
-    }
-    debug!("pick: all tiers exhausted");
-    None
-}
-```
-
-Then `openai_chat_handler` can do:
-
-```rust
-let candidates = state.routing_candidates(&model, &skip).await;
-let openai_only: Vec<RoutingCandidate> = candidates
-    .into_iter()
-    .filter(|c| match c.endpoint {
-        EndpointIdx::Unified(i) => matches!(state.endpoints[i].protocol, Protocol::OpenAI),
-        EndpointIdx::Upstream(_) => true,
-        EndpointIdx::Account(_) => false,
-    })
-    .collect();
-let idx = state.pick_from_tiered_candidates(openai_only, affinity);
-```
-
-- [ ] **Step 2: Dispatch on protocol after pick**
-
-After the picker call, branch:
-
-```rust
-let idx_resolved = match idx {
-    Some(EndpointIdx::Unified(i)) => i,
-    Some(EndpointIdx::Upstream(u)) => {
-        // legacy upstream path — try_fallback_upstream
-        match try_fallback_upstream(
-            &state, &body_bytes, &req_id, &client_id, &model, u, false,
-        )
-        .await
-        {
-            Some(resp) => return resp,
-            None => {
-                skip.push(EndpointIdx::Upstream(u));
+match picked {
+    EndpointIdx::Account(i) => {
+        let acct = &state.accounts[i];
+        match forward_openai_compat_anthropic(
+            &state, &parts, &anthropic_body, &oauth_anthropic_body,
+            &state.upstream, &acct.token, acct.passthrough, &acct.name,
+            UsageTarget::Account(i), &acct.requests, &acct.rate_info, &acct.burn_rate,
+            &req_id, &client_id, /* ...remaining ctx args... */ &model,
+        ).await {
+            ForwardOutcome::Done(resp) => return resp,
+            ForwardOutcome::Retry { saw_529: s, push_skip } => {
+                if s { saw_529 = true; }
+                if push_skip { skip.push(EndpointIdx::Account(i)); }
                 continue;
             }
         }
     }
-    Some(EndpointIdx::Account(_)) => unreachable!("filtered out above"),
-    None => {
-        warn!("all openai endpoints exhausted");
-        return (StatusCode::TOO_MANY_REQUESTS, "no openai endpoint available").into_response();
+    EndpointIdx::Upstream(u) => {
+        match try_fallback_upstream(&state, &body_bytes, &req_id, &client_id, &model, u, false).await {
+            Some(resp) => return resp,
+            None => { skip.push(EndpointIdx::Upstream(u)); continue; }
+        }
     }
-};
-// Unified OpenAI endpoint — forward direct, no translation
-match try_fallback_upstream_unified(
-    &state, &body_bytes, &req_id, &client_id, &model, idx_resolved, false,
-).await {
-    Some(resp) => return resp,
-    None => {
-        skip.push(EndpointIdx::Unified(idx_resolved));
-        continue;
+    EndpointIdx::Unified(i) => {
+        let ep = &state.endpoints[i];
+        match ep.protocol {
+            Protocol::Anthropic => {
+                match forward_openai_compat_anthropic(
+                    &state, &parts, &anthropic_body, &oauth_anthropic_body,
+                    &ep.base_url, &ep.token, ep.passthrough, &ep.name,
+                    UsageTarget::Unified(i), &ep.requests, &ep.rate_info, &ep.burn_rate,
+                    &req_id, &client_id, /* ...remaining ctx args... */ &model,
+                ).await {
+                    ForwardOutcome::Done(resp) => return resp,
+                    ForwardOutcome::Retry { saw_529: s, push_skip } => {
+                        if s { saw_529 = true; }
+                        if push_skip { skip.push(EndpointIdx::Unified(i)); }
+                        continue;
+                    }
+                }
+            }
+            Protocol::OpenAI => {
+                match try_fallback_upstream_unified(
+                    &state, &body_bytes, &req_id, &client_id, &model, i, false,
+                ).await {
+                    Some(resp) => return resp,
+                    None => { skip.push(EndpointIdx::Unified(i)); continue; }
+                }
+            }
+        }
     }
 }
 ```
 
-- [ ] **Step 3: Move eager translation inside the protocol branch**
+The exact parameter lists must match whatever `forward_openai_compat_anthropic` ends up needing — adapt. The point: Account and Unified-Anthropic both call the helper; Upstream and Unified-OpenAI both forward direct.
 
-The current `openai_chat_handler` runs `translate_openai_request_to_anthropic` before the retry loop (~line 7076). The spec says translation must happen *after* `pick_endpoint`, and only for Anthropic targets. Since the candidate filter above excludes Anthropic candidates, the translation call can be **deleted entirely** from this handler — the only remaining targets are OpenAI endpoints that need no translation.
+- [ ] **Step 3: Keep the eager translation**
 
-Remove the eager `translate_openai_request_to_anthropic` block. The body forwarded downstream is the original OpenAI-format body.
+`openai_chat_handler` translates `openai_body` → `anthropic_body` (and the OAuth variant) before the retry loop. **Keep that** — both the Account arm and the new Unified-Anthropic arm consume `anthropic_body`. (The earlier plan said to delete it; that was tied to the now-reverted "OpenAI-only" filtering. The OpenAI-protocol arms simply ignore `anthropic_body` and forward `body_bytes` — a small unused-translation cost on the all-OpenAI-endpoints path, acceptable and unchanged from today's behavior where the translation also always runs.)
 
 - [ ] **Step 4: Verify compile and tests**
 
 ```bash
 cargo build 2>&1 | tail -5
-cargo test --lib openai_chat 2>&1 | tail -10
-cargo test --lib 2>&1 | tail -3
+cargo test --bin anthropic-lb 2>&1 | tail -8
+RUSTFLAGS="-Dwarnings" cargo clippy --all-targets 2>&1 | tail -3
 ```
 
-Expected: clean build. Existing OpenAI-chat tests use `[[upstreams]]` (legacy) and should still pass via the `EndpointIdx::Upstream` arm. Tests targeting the unified pool come in Phase 3.
+Expected: clean build, all existing tests pass (the ~10 `test_openai_app` tests route through the `Account` arm, which still calls the same logic — now via `forward_openai_compat_anthropic`).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/main.rs
-git commit -m "refactor: openai_chat_handler filters to OpenAI endpoints, dispatch by index"
+git commit -m "refactor: factor openai-compat Anthropic forward; openai_chat_handler dispatches unified endpoints"
 ```
 
 ---
@@ -2108,54 +2059,91 @@ git commit -m "test: try_fallback_upstream_unified returns None on 429/5xx for r
 
 ---
 
-### Task 22: New test — `openai_chat_handler` routes only to OpenAI endpoints
+### Task 22: New test — `openai_chat_handler` routes to a unified Anthropic endpoint
+
+> **Revised 2026-05-22.** Was "openai_chat_handler routes only to OpenAI
+> endpoints" — reversed along with Task 11. This test now proves the OPPOSITE:
+> an OpenAI-format request is correctly served by a unified `Protocol::Anthropic`
+> endpoint via the OpenAI→Anthropic→OpenAI round-trip translation.
 
 **Files:**
 - Modify: `src/main.rs` `mod tests`
 
 - [ ] **Step 1: Write the test**
 
+Use a mock upstream that returns a canned Anthropic `messages` response. Build an `AppState` whose `endpoints` pool contains one `Protocol::Anthropic` endpoint pointed at the mock (and empty `accounts`/`upstreams`). POST an OpenAI-format `/v1/chat/completions` request; assert a 200 whose body is OpenAI-shaped (`choices[0].message.content` present), proving the request was translated to Anthropic, forwarded to the unified endpoint, and the response translated back.
+
 ```rust
 #[tokio::test]
-async fn openai_chat_handler_skips_anthropic_only_pool() {
-    // Pool: only Anthropic endpoints in the unified pool. An OpenAI-format
-    // request must NOT route to them (no reverse-translation path per spec).
-    // Expect: 429 "all openai endpoints exhausted".
-    let acct = make_account("anthropic", "sk-ant");
-    let state = test_state_with(vec![acct]);  // legacy accounts also Anthropic
-    // No endpoints added. openai_chat_handler must return 429.
+async fn openai_chat_handler_routes_to_unified_anthropic_endpoint() {
+    // Mock Anthropic upstream: returns a minimal messages response.
+    let mock = Router::new().fallback(any(|| async {
+        axum::Json(serde_json::json!({
+            "id": "msg_1", "type": "message", "role": "assistant",
+            "model": "claude-opus-4-7",
+            "content": [{"type": "text", "text": "hi back"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 2}
+        })).into_response()
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mock_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, mock).await.unwrap(); });
+
+    let mut state = test_state_with(vec![]); // no legacy accounts
+    Arc::get_mut(&mut state).unwrap().endpoints.push(Endpoint {
+        name: "unified-anthropic".to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: format!("http://{}", mock_addr),
+        token: "sk-ant-api-test".to_string(),
+        passthrough: false,
+        models: vec![],
+        priority: 0,
+        requests: AtomicU64::new(0),
+        rate_info: RwLock::new(RateLimitInfo::default()),
+        burn_rate: Mutex::new(BurnRate::new()),
+        input_tokens: AtomicU64::new(0),
+        output_tokens: AtomicU64::new(0),
+        cache_creation_tokens: AtomicU64::new(0),
+        cache_read_tokens: AtomicU64::new(0),
+        last_routing_weight: AtomicU64::new(0),
+        last_routing_share: AtomicU64::new(0),
+        last_effective_gate: AtomicU64::new(0),
+    });
     let app = Router::new()
         .route("/v1/chat/completions", axum::routing::post(openai_chat_handler))
         .with_state(state);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
-    let client = reqwest::Client::new();
-    let resp = client
+
+    let resp = reqwest::Client::new()
         .post(format!("http://{}/v1/chat/completions", addr))
         .json(&serde_json::json!({
             "model": "claude-opus-4-7",
             "messages": [{"role": "user", "content": "hi"}],
         }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status().as_u16(), 429,
-        "openai_chat_handler must NOT route an OpenAI-format request to an Anthropic endpoint");
+        .send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["choices"][0]["message"]["content"].is_string(),
+        "response must be OpenAI-shaped after round-trip translation");
 }
 ```
 
-- [ ] **Step 2: Run — expect pass (Task 11 implements this filter)**
+Adapt the `Endpoint { .. }` field list and the mock response shape to whatever the actual structs require. If the codebase has a `make_endpoint` test helper by this point (added in Phase 4 Task 25 — may not exist yet), use it; otherwise hand-construct.
+
+- [ ] **Step 2: Run — expect pass (Task 11 wired this path)**
 
 ```bash
-cargo test openai_chat_handler_skips_anthropic_only 2>&1 | tail -10
+cargo test --bin anthropic-lb openai_chat_handler_routes_to_unified_anthropic 2>&1 | tail -10
 ```
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add src/main.rs
-git commit -m "test: openai_chat_handler does not route to Anthropic endpoints"
+git commit -m "test: openai_chat_handler routes to a unified Anthropic endpoint with translation"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-05-21-unified-endpoints.md
+++ b/docs/superpowers/plans/2026-05-21-unified-endpoints.md
@@ -1,5 +1,18 @@
 # Unified Endpoints Implementation Plan
 
+**Status:** Executed and shipped — preserved as a historical artifact.
+
+> **Note:** This is the implementation plan as it was *written* before execution,
+> including mid-execution corrections (look for `REVISED` markers). The actual
+> implementation diverged from this plan in several places — for example, the
+> runtime introduced `UsageTarget` and `ForwardOutcome` enums and a shared
+> `classify_retry_status` helper that this plan did not anticipate; Task 11 was
+> rewritten mid-execution when the spec's premise about `openai_chat_handler`
+> turned out to be wrong; line ranges and helper signatures evolved through
+> review. The **source code on `main` is the authoritative reference**; this
+> document is kept in-tree to record the planning process and the design
+> trade-offs made along the way, not as a live execution guide.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Collapse `[[accounts]]` and `[[upstreams]]` into a single `[[endpoints]]` concept with a `protocol` field, delete the `fallback_upstream` and global `upstream` config keys, and concentrate endpoint-type special-casing into three named, commented call sites.

--- a/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
@@ -1,0 +1,231 @@
+# Unified Endpoints — Design
+
+**Date:** 2026-05-21
+**Status:** Approved for planning
+**Author:** Ray Walker
+
+## Problem
+
+The proxy has two routing-candidate types — `[[accounts]]` (Anthropic-native) and
+`[[upstreams]]` (OpenAI-compatible) — plus a `fallback_upstream` config key that
+names one upstream as a special routing participant.
+
+Three things are wrong with this:
+
+1. **`fallback_upstream` is a misnomer.** It was added before priority tiers
+   existed, as a pure last-resort escape hatch. Priority tiers landed afterward
+   and now decide routing order entirely. "Fallback" semantics ("only when
+   everything else fails") are just `priority = 100` today — the name lies about
+   what the field does.
+2. **`upstream` (the runtime/config concept) is a misnomer.** The whole binary
+   is an upstream proxy. Calling one specific endpoint kind "upstream" overloads
+   the word. What it actually denotes is "an endpoint that speaks a different
+   wire format and needs a translation layer."
+3. **Two config sections do essentially the same job.** Accounts and upstreams
+   are both routing candidates partitioned into the same priority space. They
+   differ only in wire format and auth injection. Two structs, two runtime
+   types, and a special-cased `Option<usize>` index encode a distinction that
+   should be a single field.
+
+A concrete failure this caused: in the lab deployment, the `insight-gateway`
+upstream had no `priority` set (default `0`), placing it in the same tier as the
+main accounts. It won traffic immediately instead of acting as a last resort.
+The fix was `priority = 100`, but the design invited the mistake.
+
+## Goal
+
+Collapse accounts and upstreams into a single `[[endpoints]]` concept. The wire
+format becomes one field (`protocol`). Routing order is decided purely by
+`priority`. The `fallback_upstream` and global `upstream` config keys are
+deleted. No special-casing remains in the routing path.
+
+## Non-goals
+
+- Supporting wire formats beyond Anthropic-native and OpenAI chat-completions.
+  The design leaves room for more (`protocol` is an enum) but only two variants
+  ship now.
+- A config deprecation period. This is a hard break (see Migration).
+- Keeping the `/upstream/{name}/*` passthrough route. It is unused and removed.
+
+## Design
+
+### Config schema
+
+`[[accounts]]` and `[[upstreams]]` collapse into `[[endpoints]]`. The
+`fallback_upstream` and `upstream` top-level keys are deleted.
+
+```toml
+listen = "0.0.0.0:8082"
+soft_limit = 0.90
+# no `upstream` key — base URL is encoded by each endpoint's protocol
+
+[[endpoints]]
+name = "primary"
+token = "sk-ant-..."
+# protocol = "anthropic" is the default
+
+[[endpoints]]
+name = "passbolt"
+token = "sk-ant-oat01-..."
+priority = 1
+
+[[endpoints]]
+name = "insight-gateway"
+protocol = "openai"
+base_url = "https://gateway.example.com"
+token = "sk-..."
+priority = 100
+models = ["claude-opus-*"]
+```
+
+`EndpointConfig`:
+
+| Field      | Type        | Default              | Notes |
+|------------|-------------|----------------------|-------|
+| `name`     | string      | required             | Display name; used for metrics labels and Redis keys |
+| `protocol` | enum string | `"anthropic"`        | `"anthropic"` or `"openai"` |
+| `base_url` | string?     | protocol-dependent   | Required for `openai`. For `anthropic`, defaults to `https://api.anthropic.com`; overridable for staging/self-hosted |
+| `token`    | string      | required             | Auth credential. `"passthrough"` (anthropic only) forwards the caller's auth headers unchanged |
+| `models`   | string[]    | `[]` (all)           | Model allowlist; supports `*` suffix wildcards. Works for both protocols |
+| `priority` | u32         | `0`                  | Priority tier; lower tried first |
+
+`protocol` encodes three things at once: wire format, auth injection method
+(`x-api-key` for anthropic, `Bearer` for openai), and the default base URL.
+
+### Runtime model
+
+The `Account` and `Upstream` runtime structs merge into one `Endpoint`. The
+routing enum `Endpoint { Account(usize), Upstream(usize) }` collapses to a plain
+`usize` index into `state.endpoints`.
+
+```rust
+enum Protocol { Anthropic, OpenAI }
+
+struct Endpoint {
+    name: String,
+    protocol: Protocol,
+    base_url: String,            // resolved at startup
+    token: String,
+    passthrough: bool,           // only meaningful for Protocol::Anthropic
+    models: Vec<String>,
+    priority: u32,
+    requests: AtomicU64,
+    rate_info: RwLock<RateLimitInfo>,   // stub for OpenAI endpoints
+    // ... token counters, burn rate, routing-weight gauges (unchanged)
+}
+```
+
+OpenAI endpoints carry a stub `RateLimitInfo`: all gates `0.0`, weight `1.0`,
+no claims. This lets them flow through `routing_candidates()` and `pick_endpoint`
+with zero special-casing — they look like a permanently healthy account. The
+probe loop skips them, exactly as it already skips passthrough accounts.
+
+`AppState` changes:
+
+- `accounts: Vec<Account>` → `endpoints: Vec<Endpoint>`
+- `upstreams: Vec<Upstream>` → deleted
+- `fallback_upstream: Option<usize>` → deleted
+- `upstream: String` → deleted
+
+The `skip` list threaded through the retry loop in both handlers becomes
+`Vec<usize>` instead of `Vec<Endpoint>`.
+
+### Routing & dispatch
+
+`pick_endpoint` is structurally unchanged — same priority-tier partitioning,
+same intra-tier soft-limit degradation. The only difference: candidates come
+from a single `state.endpoints` pool, and `routing_candidates()` no longer has
+the `if let Some(u_idx) = self.fallback_upstream` block.
+
+After an endpoint is picked, the handler dispatches on `endpoint.protocol`:
+
+| Handler input              | Endpoint protocol | Action |
+|----------------------------|-------------------|--------|
+| Anthropic (`proxy_handler`)| Anthropic         | forward to `base_url`, parse rate-limit headers, track utilization |
+| Anthropic (`proxy_handler`)| OpenAI            | translate Anthropic→OpenAI, forward, translate response back |
+| OpenAI (`openai_chat_handler`) | Anthropic     | translate OpenAI→Anthropic, forward, translate response back |
+| OpenAI (`openai_chat_handler`) | OpenAI        | forward direct, no translation |
+
+The `openai_chat_handler` → Anthropic-endpoint cell is **new behavior**. Today
+an OpenAI-format request can only reach OpenAI upstreams. After this change it
+can route to Anthropic accounts via reverse translation, widening the routing
+surface. This is intentional and desired.
+
+`try_fallback_upstream` is renamed `forward_translated()` (or inlined). The
+`/upstream/{name}/*` route and `upstream_handler` are deleted.
+
+### Persistence & state
+
+`PersistedState` / `PersistedAccount` rename to use endpoint terminology. The
+state-file format changes: an old file with an `accounts` key will not load.
+This is a **hard break** — acceptable because the state file is fully
+reconstructed from probe responses within one probe cycle (~5 min). On load
+failure, start clean.
+
+Redis keys (`alb:budget:*`, `alb:rate:*`, `alb:hard:*`, `alb:heartbeat:*`) are
+keyed by `client_id` and endpoint `name`. Neither identifier changes, so no
+Redis migration is needed.
+
+### Metrics
+
+Prometheus metrics named `anthropic_account_*` (request count, routing weight,
+routing share, effective gate, utilization, passthrough flag) gain
+`anthropic_endpoint_*` equivalents. Both series are emitted for one release:
+the new `anthropic_endpoint_*` names carry the same values, and the old
+`anthropic_account_*` names are kept as deprecated aliases so existing Grafana
+dashboards and alert rules keep working.
+
+The old aliases are marked deprecated in code comments and removed in a
+follow-up change once dashboards have been migrated. This is the one place the
+redesign does *not* take a hard break — metrics are an external contract with
+dashboards outside this repo, and a dual-emit window costs little.
+
+### Config migration
+
+No backward-compat shim. A config using `[[accounts]]`, `[[upstreams]]`, or
+`fallback_upstream` fails to parse at startup with an explicit error naming the
+removed keys and their replacements.
+
+Both production deployments are updated in lockstep with the binary roll-out:
+
+- **mem cluster** — `27b-io/fleet-infra`, `apps/mem/anthropic-lb/externalsecret.yaml`
+- **lab cluster** — `27b-io/lab`, `k8s/mcp/anthropic-lb-externalsecret.yaml`
+
+The repo's own `config.toml` and `CLAUDE.md` config-schema docs are updated in
+the same change.
+
+## Testing
+
+Mechanical rewrites across existing fixtures (~60 sites):
+
+- test state builders: `accounts` field → `endpoints` field
+- `fallback_upstream: None` → removed
+- `Endpoint::Account(i)` → bare `i`; `Endpoint::Upstream(u)` → bare `u`
+- `test_state_with()` / `test_app()` gain a way to register `Protocol::OpenAI`
+  endpoints alongside Anthropic ones
+
+New tests:
+
+- OpenAI-protocol endpoint participates in priority-tier routing
+- Model allowlist on an OpenAI endpoint (e.g. opus-only) filters correctly
+- `proxy_handler` → OpenAI endpoint performs Anthropic→OpenAI translation
+- `openai_chat_handler` → Anthropic endpoint performs OpenAI→Anthropic reverse
+  translation (new capability — no current coverage)
+- Config parse rejects `[[accounts]]`, `[[upstreams]]`, and `fallback_upstream`
+  with helpful error messages
+
+Quality gates unchanged: `cargo test`, `cargo fmt --check`,
+`RUSTFLAGS="-Dwarnings" cargo clippy --all-targets`.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| External Grafana dashboards reference `anthropic_account_*` | Old metric names kept as deprecated aliases for one release; dashboards migrate before aliases are removed |
+| State file fails to load post-upgrade | Expected; probes reconstruct within ~5 min. No action needed |
+| Both cluster configs must change in lockstep with the binary | Single coordinated change; configs and binary roll out together |
+| Large mechanical test refactor introduces typos | `cargo test` + clippy gate catches them |
+
+## Open questions
+
+None. All resolved during brainstorming.

--- a/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
@@ -46,13 +46,17 @@ runtime type, and `Option<usize>` index.
 - Supporting wire formats beyond Anthropic-native and OpenAI chat-completions.
   The design leaves room for more (`protocol` is an enum) but only two variants
   ship now.
-- **Routing OpenAI-format requests to Anthropic accounts** (an OpenAI→Anthropic
-  reverse-translation path). `openai_chat_handler` keeps targeting only
-  `Protocol::OpenAI` endpoints, exactly as it reaches only upstreams today. The
-  reverse path is a distinct feature with its own budget/usage-tracking
-  requirements; it is not bundled into this refactor.
 - A config deprecation period. This is a hard break (see Migration).
 - Keeping the `/upstream/{name}/*` passthrough route. It is unused and removed.
+
+> **Correction (2026-05-22):** An earlier revision of this spec listed
+> "routing OpenAI-format requests to Anthropic accounts" as a non-goal, on the
+> belief that `openai_chat_handler` reached only upstreams. That belief was
+> wrong — `openai_chat_handler` has always translated OpenAI→Anthropic, routed
+> to Anthropic accounts, and translated the response back. That behavior is
+> existing, tested, and **preserved**: in the unified model `openai_chat_handler`
+> dispatches to both `Protocol::OpenAI` endpoints (direct) and
+> `Protocol::Anthropic` endpoints (translated), symmetric with `proxy_handler`.
 
 ## Design
 
@@ -174,36 +178,35 @@ same intra-tier soft-limit degradation. The only difference: candidates come
 from a single `state.endpoints` pool, and `routing_candidates()` no longer has
 the `if let Some(u_idx) = self.fallback_upstream` block.
 
-**Candidate sets differ per handler.** `proxy_handler` (Anthropic-format input)
-can target any endpoint — Anthropic directly, OpenAI via translation.
-`openai_chat_handler` (OpenAI-format input) targets **only** `Protocol::OpenAI`
-endpoints; its `routing_candidates()` call filters out Anthropic endpoints. This
-matches today's behavior exactly (`openai_chat_handler` only ever reached
-upstreams) and avoids adding an OpenAI→Anthropic reverse-translation path, which
-is a separate feature out of scope here (see Non-goals).
+**Both handlers can target any endpoint.** Each of the two inbound wire
+formats can be served by each of the two endpoint protocols — four dispatch
+cells, all of which exist in the code today. The refactor changes how the
+endpoint is *selected* (one unified pool), not what happens after.
 
-After an endpoint is picked, `proxy_handler` dispatches on `endpoint.protocol`:
+After an endpoint is picked, the handler dispatches on `endpoint.protocol`:
 
-| Handler                  | Endpoint protocol | Action |
-|--------------------------|-------------------|--------|
-| `proxy_handler`          | Anthropic         | forward to `base_url`, parse rate-limit headers, track utilization, `record_usage` |
-| `proxy_handler`          | OpenAI            | translate Anthropic→OpenAI, forward, translate response back |
-| `openai_chat_handler`    | OpenAI            | forward direct, no translation |
+| Handler               | Endpoint protocol | Action |
+|-----------------------|-------------------|--------|
+| `proxy_handler`       | Anthropic         | forward to `base_url`, parse rate-limit headers, track utilization, `record_usage` |
+| `proxy_handler`       | OpenAI            | translate Anthropic→OpenAI request, forward, translate response back |
+| `openai_chat_handler` | Anthropic         | translate OpenAI→Anthropic request, forward, parse rate-limit headers, `record_usage`, translate response back |
+| `openai_chat_handler` | OpenAI            | forward direct, no translation |
 
-All three cells exist in the code today; this refactor only changes how the
-endpoint is *selected*, not what happens after. Translation must be deferred
-until **after** `pick_endpoint` and branched on `endpoint.protocol` —
-`openai_chat_handler` currently translates eagerly before the retry loop; that
-translation moves inside the protocol branch.
+All four cells exist in the code today (`openai_chat_handler` already routes to
+both Anthropic accounts and OpenAI upstreams). The refactor preserves every
+cell; it only swaps the two legacy pools (`accounts`, `upstreams`) for the one
+unified `endpoints` pool feeding `pick_endpoint`.
 
-`try_fallback_upstream` is renamed `forward_translated()`. **Critical change to
-its contract:** it currently returns the upstream's error response directly
-(`Some(resp) => return resp`), so an OpenAI endpoint's 429/5xx is sent straight
-to the caller instead of being retried. `forward_translated()` must instead
-return `None` on upstream 429/5xx so the shared retry loop adds the endpoint to
-`skip` and tries the next one — matching Anthropic-endpoint failure semantics.
-The `requests` counter increment, `skip` push, and retry remain owned by the
-shared loop, not the helper.
+A new `try_fallback_upstream_unified()` serves OpenAI-protocol endpoints from
+the unified pool, alongside the legacy `try_fallback_upstream()` (deleted in
+Phase 4). **Critical contract difference:** `try_fallback_upstream()` returns
+the upstream's error response directly (`Some(resp) => return resp`), so an
+OpenAI endpoint's 429/5xx is sent straight to the caller instead of being
+retried. `try_fallback_upstream_unified()` returns `None` on upstream 429/5xx
+so the shared retry loop adds the endpoint to `skip` and tries the next one —
+matching Anthropic-endpoint failure semantics. Non-429 4xx errors are still
+returned to the caller (retry would not help). The `skip` push and retry are
+owned by the shared loop, not the helper.
 
 The `/upstream/{name}/*` route and `upstream_handler` are deleted.
 
@@ -302,10 +305,10 @@ New tests:
 - OpenAI-protocol endpoint participates in priority-tier routing
 - Model allowlist on an OpenAI endpoint (e.g. opus-only) filters correctly
 - `proxy_handler` → OpenAI endpoint performs Anthropic→OpenAI translation
-- `openai_chat_handler` routes only to OpenAI endpoints; an Anthropic-only
-  endpoint pool yields no candidate (no reverse-translation path)
-- `forward_translated()` returns `None` on an upstream 429/5xx so the retry
-  loop advances to the next endpoint
+- `openai_chat_handler` → unified `Protocol::Anthropic` endpoint performs the
+  OpenAI→Anthropic request + response round-trip translation
+- `try_fallback_upstream_unified()` returns `None` on an upstream 429/5xx so the
+  retry loop advances to the next endpoint
 - Emergency brake still fires when all Anthropic endpoints are above threshold
   even with an OpenAI endpoint present in the pool
 - Config parse is rejected for `[[accounts]]`, `[[upstreams]]`, and

--- a/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
@@ -1,8 +1,16 @@
 # Unified Endpoints — Design
 
 **Date:** 2026-05-21
-**Status:** Approved for planning
+**Status:** Shipped — preserved as a historical artifact
 **Author:** Ray Walker
+
+> **Note:** This document records the design as it was *specified*, including
+> mid-execution corrections (look for `REVISED` / `Correction` markers). The
+> implementation diverged from this spec in places — for example, the runtime
+> introduced `UsageTarget` and `ForwardOutcome` enums and the `classify_retry_status`
+> helper that are not described here. The **source code is the authoritative
+> reference**; this spec is kept in-tree to record the design process and the
+> decisions made along the way, not as a live API contract.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-21-unified-endpoints-design.md
@@ -37,13 +37,20 @@ The fix was `priority = 100`, but the design invited the mistake.
 Collapse accounts and upstreams into a single `[[endpoints]]` concept. The wire
 format becomes one field (`protocol`). Routing order is decided purely by
 `priority`. The `fallback_upstream` and global `upstream` config keys are
-deleted. No special-casing remains in the routing path.
+deleted. Endpoint-type special-casing in the routing path is reduced to three
+named, commented call sites (see Runtime model) instead of a separate struct,
+runtime type, and `Option<usize>` index.
 
 ## Non-goals
 
 - Supporting wire formats beyond Anthropic-native and OpenAI chat-completions.
   The design leaves room for more (`protocol` is an enum) but only two variants
   ship now.
+- **Routing OpenAI-format requests to Anthropic accounts** (an OpenAI→Anthropic
+  reverse-translation path). `openai_chat_handler` keeps targeting only
+  `Protocol::OpenAI` endpoints, exactly as it reaches only upstreams today. The
+  reverse path is a distinct feature with its own budget/usage-tracking
+  requirements; it is not bundled into this refactor.
 - A config deprecation period. This is a hard break (see Migration).
 - Keeping the `/upstream/{name}/*` passthrough route. It is unused and removed.
 
@@ -53,6 +60,21 @@ deleted. No special-casing remains in the routing path.
 
 `[[accounts]]` and `[[upstreams]]` collapse into `[[endpoints]]`. The
 `fallback_upstream` and `upstream` top-level keys are deleted.
+
+**`base_url` safety.** For `protocol = "anthropic"`, the default base URL is
+`https://api.anthropic.com`. An explicit override is allowed (staging /
+self-hosted Anthropic-compatible gateways), but startup validation enforces:
+(1) the URL must use the `https://` scheme; (2) if the host is not
+`api.anthropic.com`, a `warn!` is logged at startup naming the endpoint and
+host. A typo'd `base_url` would otherwise send real OAuth/API tokens to an
+attacker-controlled host — `inject_account_auth` is host-agnostic and attaches
+credentials based purely on token prefix.
+
+**Priority validation.** At startup, if any `protocol = "openai"` endpoint
+shares the lowest priority tier with any `protocol = "anthropic"` endpoint, a
+`warn!` is logged naming both. This preserves the safety check the deleted
+`fallback_upstream` priority comparison provided, and prevents the exact
+lab `insight-gateway` incident in §Problem from recurring with the new schema.
 
 ```toml
 listen = "0.0.0.0:8082"
@@ -115,10 +137,25 @@ struct Endpoint {
 }
 ```
 
-OpenAI endpoints carry a stub `RateLimitInfo`: all gates `0.0`, weight `1.0`,
-no claims. This lets them flow through `routing_candidates()` and `pick_endpoint`
-with zero special-casing — they look like a permanently healthy account. The
-probe loop skips them, exactly as it already skips passthrough accounts.
+OpenAI endpoints carry a stub `RateLimitInfo` (all fields `None`). This is
+**not** indistinguishable from a healthy account: `effective_utilization()`
+maps all-`None` fields to `(0.5, "unknown")`, which would break the emergency
+brake and routing weight calculation. Three code paths therefore branch on
+`endpoint.protocol`:
+
+1. `routing_candidates()` — for `Protocol::OpenAI`, skip `compute_routing_weight`
+   and push a fixed `RoutingCandidate { gate: 0.0, weight: 1.0, source: "openai" }`
+   at the endpoint's configured priority. This is explicit, not implicit.
+2. `is_emergency_brake_active()` — iterate only `Protocol::Anthropic` endpoints
+   when checking the all-above-threshold condition. An OpenAI endpoint's
+   `(0.5, "unknown")` must not vote against firing the brake.
+3. Probe loop — skip `Protocol::OpenAI` endpoints. The existing
+   `acct.passthrough` skip is a different predicate (OpenAI endpoints have
+   `passthrough: false`); a separate explicit check is required.
+
+The earlier framing of "zero special-casing" was wrong. The right framing:
+special-casing is concentrated in three named call sites, each with a comment
+explaining why and what it gates.
 
 `AppState` changes:
 
@@ -137,30 +174,55 @@ same intra-tier soft-limit degradation. The only difference: candidates come
 from a single `state.endpoints` pool, and `routing_candidates()` no longer has
 the `if let Some(u_idx) = self.fallback_upstream` block.
 
-After an endpoint is picked, the handler dispatches on `endpoint.protocol`:
+**Candidate sets differ per handler.** `proxy_handler` (Anthropic-format input)
+can target any endpoint — Anthropic directly, OpenAI via translation.
+`openai_chat_handler` (OpenAI-format input) targets **only** `Protocol::OpenAI`
+endpoints; its `routing_candidates()` call filters out Anthropic endpoints. This
+matches today's behavior exactly (`openai_chat_handler` only ever reached
+upstreams) and avoids adding an OpenAI→Anthropic reverse-translation path, which
+is a separate feature out of scope here (see Non-goals).
 
-| Handler input              | Endpoint protocol | Action |
-|----------------------------|-------------------|--------|
-| Anthropic (`proxy_handler`)| Anthropic         | forward to `base_url`, parse rate-limit headers, track utilization |
-| Anthropic (`proxy_handler`)| OpenAI            | translate Anthropic→OpenAI, forward, translate response back |
-| OpenAI (`openai_chat_handler`) | Anthropic     | translate OpenAI→Anthropic, forward, translate response back |
-| OpenAI (`openai_chat_handler`) | OpenAI        | forward direct, no translation |
+After an endpoint is picked, `proxy_handler` dispatches on `endpoint.protocol`:
 
-The `openai_chat_handler` → Anthropic-endpoint cell is **new behavior**. Today
-an OpenAI-format request can only reach OpenAI upstreams. After this change it
-can route to Anthropic accounts via reverse translation, widening the routing
-surface. This is intentional and desired.
+| Handler                  | Endpoint protocol | Action |
+|--------------------------|-------------------|--------|
+| `proxy_handler`          | Anthropic         | forward to `base_url`, parse rate-limit headers, track utilization, `record_usage` |
+| `proxy_handler`          | OpenAI            | translate Anthropic→OpenAI, forward, translate response back |
+| `openai_chat_handler`    | OpenAI            | forward direct, no translation |
 
-`try_fallback_upstream` is renamed `forward_translated()` (or inlined). The
-`/upstream/{name}/*` route and `upstream_handler` are deleted.
+All three cells exist in the code today; this refactor only changes how the
+endpoint is *selected*, not what happens after. Translation must be deferred
+until **after** `pick_endpoint` and branched on `endpoint.protocol` —
+`openai_chat_handler` currently translates eagerly before the retry loop; that
+translation moves inside the protocol branch.
+
+`try_fallback_upstream` is renamed `forward_translated()`. **Critical change to
+its contract:** it currently returns the upstream's error response directly
+(`Some(resp) => return resp`), so an OpenAI endpoint's 429/5xx is sent straight
+to the caller instead of being retried. `forward_translated()` must instead
+return `None` on upstream 429/5xx so the shared retry loop adds the endpoint to
+`skip` and tries the next one — matching Anthropic-endpoint failure semantics.
+The `requests` counter increment, `skip` push, and retry remain owned by the
+shared loop, not the helper.
+
+The `/upstream/{name}/*` route and `upstream_handler` are deleted.
 
 ### Persistence & state
 
-`PersistedState` / `PersistedAccount` rename to use endpoint terminology. The
-state-file format changes: an old file with an `accounts` key will not load.
-This is a **hard break** — acceptable because the state file is fully
-reconstructed from probe responses within one probe cycle (~5 min). On load
-failure, start clean.
+`PersistedState` / `PersistedAccount` rename to `PersistedState` /
+`PersistedEndpoint`. The top-level state-file key changes from `accounts` to
+`endpoints`, so an old file does not deserialize into the new struct. This is a
+**hard break**. On load failure or a missing `endpoints` key, the load path
+logs a `warn!` ("state file format changed, starting clean") and starts with
+empty runtime state — the failure must be visible in logs, not silent.
+
+Routing is **not** instantly correct after a clean start: until the first probe
+cycle completes, endpoints have no rate data and `effective_utilization()`
+returns `(0.5, "unknown")`, so routing runs on uninformed default weights for
+up to one `probe_interval_secs` (default 300s). This degraded-but-functional
+window already exists today on any fresh start; the refactor does not change it.
+It is acceptable — the proxy still serves traffic, just without utilization-
+optimized routing for that window.
 
 Redis keys (`alb:budget:*`, `alb:rate:*`, `alb:hard:*`, `alb:heartbeat:*`) are
 keyed by `client_id` and endpoint `name`. Neither identifier changes, so no
@@ -168,23 +230,45 @@ Redis migration is needed.
 
 ### Metrics
 
-Prometheus metrics named `anthropic_account_*` (request count, routing weight,
-routing share, effective gate, utilization, passthrough flag) gain
-`anthropic_endpoint_*` equivalents. Both series are emitted for one release:
-the new `anthropic_endpoint_*` names carry the same values, and the old
-`anthropic_account_*` names are kept as deprecated aliases so existing Grafana
-dashboards and alert rules keep working.
-
-The old aliases are marked deprecated in code comments and removed in a
-follow-up change once dashboards have been migrated. This is the one place the
-redesign does *not* take a hard break — metrics are an external contract with
-dashboards outside this repo, and a dual-emit window costs little.
+Prometheus metric names are **left unchanged**: `anthropic_account_*` (request
+count, routing weight, routing share, effective gate, utilization, passthrough
+flag) keep their current names. The metric *values* are unaffected by this
+refactor — only the internal config/runtime nouns change. Renaming the series
+would create a Grafana-dashboard migration and a deprecation window for zero
+functional gain, so it is explicitly out of scope. The `account` noun in the
+metric name is a known, accepted minor staleness.
 
 ### Config migration
 
 No backward-compat shim. A config using `[[accounts]]`, `[[upstreams]]`, or
-`fallback_upstream` fails to parse at startup with an explicit error naming the
+`fallback_upstream` is rejected at startup with an explicit error naming the
 removed keys and their replacements.
+
+**Rejection mechanism.** `serde` silently ignores unknown TOML keys by default,
+so a removed key would simply be dropped, not rejected. `#[serde(deny_unknown_fields)]`
+is *not* used — it would break forward-compatibility of every other optional
+config field. Instead, a targeted post-deserialize check runs the raw parsed
+TOML `Value` for the three dead keys (`accounts`, `upstreams`, `fallback_upstream`)
+and returns a hard error naming each one found and its replacement. This is new
+code, ~15 lines, not a free side effect of the struct rename.
+
+### Rollback
+
+The roll-out is a hard break across three artifacts that change together: the
+binary, the state-file format, and both cluster configs. A botched roll-out
+(malformed `[[endpoints]]` config) causes a startup parse failure — the pod
+crash-loops rather than serving wrong traffic, which is the safe failure mode.
+
+Rollback procedure, prepared *before* cutover:
+
+1. Record the current (pre-change) image digest from the running deployment.
+2. Keep the pre-change config revision available in git (it already is — it is
+   the prior commit of each `externalsecret.yaml`).
+3. To roll back: pin the deployment image to the recorded prior digest and
+   revert both `externalsecret.yaml` files to their prior revision. The old
+   binary reads the old config; the state file is regenerated by probes.
+4. The old and new binaries are **not** config-compatible in either direction —
+   roll back binary and config together, never one without the other.
 
 Both production deployments are updated in lockstep with the binary roll-out:
 
@@ -196,7 +280,16 @@ the same change.
 
 ## Testing
 
-Mechanical rewrites across existing fixtures (~60 sites):
+**Blast radius.** `main.rs` is ~19500 lines with ~491 references to the
+collapsed concepts (`accounts`, `fallback_upstream`, `Endpoint::`) and ~46
+`fallback_upstream: None` test fixtures. This is not a typo-class find-replace:
+the `Endpoint { Account(usize), Upstream(usize) }` enum is load-bearing — it
+gives the compiler account-vs-upstream discrimination in the `skip` list and
+`RoutingCandidate`. Collapsing it to a bare `usize` index into one unified
+`Vec` removes that type-level safety; `pick_endpoint`, `routing_candidates`,
+and both handler retry loops are a coupled set that must change in one commit.
+
+Mechanical rewrites across existing fixtures:
 
 - test state builders: `accounts` field → `endpoints` field
 - `fallback_upstream: None` → removed
@@ -209,10 +302,15 @@ New tests:
 - OpenAI-protocol endpoint participates in priority-tier routing
 - Model allowlist on an OpenAI endpoint (e.g. opus-only) filters correctly
 - `proxy_handler` → OpenAI endpoint performs Anthropic→OpenAI translation
-- `openai_chat_handler` → Anthropic endpoint performs OpenAI→Anthropic reverse
-  translation (new capability — no current coverage)
-- Config parse rejects `[[accounts]]`, `[[upstreams]]`, and `fallback_upstream`
-  with helpful error messages
+- `openai_chat_handler` routes only to OpenAI endpoints; an Anthropic-only
+  endpoint pool yields no candidate (no reverse-translation path)
+- `forward_translated()` returns `None` on an upstream 429/5xx so the retry
+  loop advances to the next endpoint
+- Emergency brake still fires when all Anthropic endpoints are above threshold
+  even with an OpenAI endpoint present in the pool
+- Config parse is rejected for `[[accounts]]`, `[[upstreams]]`, and
+  `fallback_upstream`, each with a helpful error message
+- Loading an old `accounts`-keyed state file starts clean and logs a `warn!`
 
 Quality gates unchanged: `cargo test`, `cargo fmt --check`,
 `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets`.
@@ -221,9 +319,10 @@ Quality gates unchanged: `cargo test`, `cargo fmt --check`,
 
 | Risk | Mitigation |
 |------|------------|
-| External Grafana dashboards reference `anthropic_account_*` | Old metric names kept as deprecated aliases for one release; dashboards migrate before aliases are removed |
-| State file fails to load post-upgrade | Expected; probes reconstruct within ~5 min. No action needed |
-| Both cluster configs must change in lockstep with the binary | Single coordinated change; configs and binary roll out together |
+| State file fails to load post-upgrade | Expected; load path logs `warn!` and starts clean. Routing runs on default weights until the first probe cycle (~300s) — degraded but functional, same as any fresh start |
+| Botched roll-out: malformed config crash-loops the pod | Safe failure mode (no wrong traffic). Rollback procedure (see Rollback) prepared before cutover: pin prior image digest + revert both `externalsecret.yaml` revisions together |
+| Both cluster configs must change in lockstep with the binary | Single coordinated change; configs and binary roll out together. Binary and config are not compatible across the break in either direction |
+| Enum collapse (`Endpoint` → bare `usize`) loses compiler discrimination | The coupled set (`pick_endpoint`, `routing_candidates`, both handlers) changes in one commit; new tests cover endpoint-selection behavior, not just compilation |
 | Large mechanical test refactor introduces typos | `cargo test` + clippy gate catches them |
 
 ## Open questions

--- a/src/main.rs
+++ b/src/main.rs
@@ -7565,6 +7565,66 @@ async fn openai_chat_handler(
 
 // ── Main ────────────────────────────────────────────────────────────
 
+/// Validate endpoint configuration. Returns the first hard error encountered.
+/// Soft warnings (non-canonical anthropic host, priority collision with an
+/// openai endpoint) are emitted as `warn!` and do not return an error.
+fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
+    for ep in endpoints {
+        if let Some(url) = ep.base_url.as_deref() {
+            if !url.starts_with("https://") {
+                return Err(format!(
+                    "endpoint '{}': base_url must start with https:// (got '{}')",
+                    ep.name, url
+                ));
+            }
+        }
+        match ep.protocol {
+            Protocol::OpenAI => {
+                if ep.base_url.is_none() {
+                    return Err(format!(
+                        "endpoint '{}': base_url is required for protocol = openai",
+                        ep.name
+                    ));
+                }
+            }
+            Protocol::Anthropic => {
+                if let Some(url) = ep.base_url.as_deref() {
+                    if !url.starts_with("https://api.anthropic.com") {
+                        warn!(
+                            endpoint = ep.name,
+                            base_url = url,
+                            "anthropic endpoint base_url is non-canonical — verify this is intentional"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Priority-collision warning: an OpenAI endpoint sharing the lowest tier
+    // with any Anthropic endpoint recreates the bug §Problem cites.
+    let lowest = endpoints.iter().map(|e| e.priority).min().unwrap_or(0);
+    let openai_at_lowest: Vec<&str> = endpoints
+        .iter()
+        .filter(|e| e.protocol == Protocol::OpenAI && e.priority == lowest)
+        .map(|e| e.name.as_str())
+        .collect();
+    let anthropic_at_lowest: Vec<&str> = endpoints
+        .iter()
+        .filter(|e| e.protocol == Protocol::Anthropic && e.priority == lowest)
+        .map(|e| e.name.as_str())
+        .collect();
+    if !openai_at_lowest.is_empty() && !anthropic_at_lowest.is_empty() {
+        warn!(
+            priority = lowest,
+            openai = ?openai_at_lowest,
+            anthropic = ?anthropic_at_lowest,
+            "openai endpoint(s) share the lowest priority tier with anthropic endpoint(s) — paid OpenAI capacity will compete with free Anthropic capacity"
+        );
+    }
+    Ok(())
+}
+
 /// Reject removed config keys with explicit errors. Run after the raw TOML
 /// has been parsed to a `toml::Value`, before strongly-typed deserialization.
 ///
@@ -7612,6 +7672,9 @@ async fn main() {
     let config: Config = raw_value
         .try_into()
         .unwrap_or_else(|e| panic!("config parse error: {e}"));
+    if let Err(msg) = validate_endpoints(&config.endpoints) {
+        panic!("{msg}");
+    }
 
     // Set up tracing: stderr (info+) always, plus optional debug log file
     {
@@ -8149,6 +8212,72 @@ token = "sk-ant-test"
 "#;
         let value: toml::Value = toml::from_str(toml_str).unwrap();
         assert!(reject_legacy_config_keys(&value).is_ok());
+    }
+
+    #[test]
+    fn validate_endpoints_warns_on_non_anthropic_host() {
+        let endpoints = vec![EndpointConfig {
+            name: "primary".to_string(),
+            protocol: Protocol::Anthropic,
+            base_url: Some("https://staging.anthropic.example".to_string()),
+            token: "sk-ant".to_string(),
+            models: vec![],
+            priority: 0,
+        }];
+        assert!(validate_endpoints(&endpoints).is_ok());
+    }
+
+    #[test]
+    fn validate_endpoints_rejects_http_base_url() {
+        let endpoints = vec![EndpointConfig {
+            name: "primary".to_string(),
+            protocol: Protocol::Anthropic,
+            base_url: Some("http://insecure.example".to_string()),
+            token: "sk-ant".to_string(),
+            models: vec![],
+            priority: 0,
+        }];
+        let err = validate_endpoints(&endpoints).unwrap_err();
+        assert!(err.contains("https"), "error must mention https: {err}");
+        assert!(err.contains("primary"));
+    }
+
+    #[test]
+    fn validate_endpoints_requires_base_url_for_openai() {
+        let endpoints = vec![EndpointConfig {
+            name: "gateway".to_string(),
+            protocol: Protocol::OpenAI,
+            base_url: None,
+            token: "sk-test".to_string(),
+            models: vec![],
+            priority: 100,
+        }];
+        let err = validate_endpoints(&endpoints).unwrap_err();
+        assert!(err.contains("base_url"));
+        assert!(err.contains("gateway"));
+    }
+
+    #[test]
+    fn validate_endpoints_accepts_well_formed_mix() {
+        let endpoints = vec![
+            EndpointConfig {
+                name: "primary".to_string(),
+                protocol: Protocol::Anthropic,
+                base_url: None,
+                token: "sk-ant".to_string(),
+                models: vec![],
+                priority: 0,
+            },
+            EndpointConfig {
+                name: "gateway".to_string(),
+                protocol: Protocol::OpenAI,
+                base_url: Some("https://gateway.example".to_string()),
+                token: "sk-test".to_string(),
+                models: vec![],
+                priority: 100,
+            },
+        ];
+        assert!(validate_endpoints(&endpoints).is_ok());
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -2380,20 +2380,41 @@ impl AppState {
             None => return,
         };
         use redis::AsyncCommands;
-        for acct in &self.accounts {
-            let w = f64::from_bits(acct.last_routing_weight.load(Ordering::Relaxed));
-            let s = f64::from_bits(acct.last_routing_share.load(Ordering::Relaxed));
-            let g = f64::from_bits(acct.last_effective_gate.load(Ordering::Relaxed));
-            let key = format!("alb:weight:{}", acct.name);
+        let ttl = Self::routing_weight_publish_ttl(self.probe_interval_secs);
+        let publish = |name: &str, weight: &AtomicU64, share: &AtomicU64, gate: &AtomicU64| {
+            let w = f64::from_bits(weight.load(Ordering::Relaxed));
+            let s = f64::from_bits(share.load(Ordering::Relaxed));
+            let g = f64::from_bits(gate.load(Ordering::Relaxed));
+            let key = format!("alb:weight:{}", name);
             let val = format!("{w},{s},{g}");
             let mut conn = redis.clone();
-            let ttl = Self::routing_weight_publish_ttl(self.probe_interval_secs);
             tokio::spawn(async move {
                 let result: redis::RedisResult<()> = conn.set_ex(&key, val, ttl).await;
                 if let Err(e) = result {
                     tracing::warn!(error = %e, "redis routing weight publish failed");
                 }
             });
+        };
+        for acct in &self.accounts {
+            publish(
+                &acct.name,
+                &acct.last_routing_weight,
+                &acct.last_routing_share,
+                &acct.last_effective_gate,
+            );
+        }
+        // Parallel pass over the unified endpoint pool. OpenAI endpoints are
+        // skipped — sync_from_redis only reads weights for Anthropic targets.
+        for ep in &self.endpoints {
+            if ep.protocol == Protocol::OpenAI {
+                continue;
+            }
+            publish(
+                &ep.name,
+                &ep.last_routing_weight,
+                &ep.last_routing_share,
+                &ep.last_effective_gate,
+            );
         }
     }
 
@@ -3119,11 +3140,43 @@ impl AppState {
         let now_epoch = Self::now_epoch();
         let now_instant = Instant::now();
 
-        // 1. Sync hard limits (MGET for all accounts in one round-trip)
-        let hard_keys: Vec<String> = self
-            .accounts
+        // Unified sync target list. Spans both the legacy account pool and the
+        // unified endpoint pool — in a real config exactly one is non-empty.
+        // OpenAI endpoints are skipped: they carry no Anthropic rate-limit data.
+        struct SyncTarget<'a> {
+            name: &'a str,
+            rate_info: &'a RwLock<RateLimitInfo>,
+            weight: &'a AtomicU64,
+            share: &'a AtomicU64,
+            gate: &'a AtomicU64,
+        }
+        let mut targets: Vec<SyncTarget<'_>> = Vec::new();
+        for a in &self.accounts {
+            targets.push(SyncTarget {
+                name: &a.name,
+                rate_info: &a.rate_info,
+                weight: &a.last_routing_weight,
+                share: &a.last_routing_share,
+                gate: &a.last_effective_gate,
+            });
+        }
+        for e in &self.endpoints {
+            if e.protocol == Protocol::OpenAI {
+                continue;
+            }
+            targets.push(SyncTarget {
+                name: &e.name,
+                rate_info: &e.rate_info,
+                weight: &e.last_routing_weight,
+                share: &e.last_routing_share,
+                gate: &e.last_effective_gate,
+            });
+        }
+
+        // 1. Sync hard limits (MGET for all targets in one round-trip)
+        let hard_keys: Vec<String> = targets
             .iter()
-            .map(|a| format!("alb:hard:{}", a.name))
+            .map(|t| format!("alb:hard:{}", t.name))
             .collect();
 
         if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&hard_keys).await {
@@ -3138,26 +3191,23 @@ impl AppState {
                         // escalation, and resetting it based on another replica's
                         // unrelated success would mask abuse patterns and thrash
                         // the exponential backoff.
-                        let mut info = self.accounts[i].rate_info.write().await;
+                        let mut info = targets[i].rate_info.write().await;
                         if info.hard_limited_until.is_some() {
                             info.hard_limited_until = None;
                             trace!(
-                                account = self.accounts[i].name,
+                                endpoint = targets[i].name,
                                 "synced hard-limit clear sentinel from redis"
                             );
                         }
                     }
                     HardLimitSync::Update(until_instant) => {
-                        let mut info = self.accounts[i].rate_info.write().await;
+                        let mut info = targets[i].rate_info.write().await;
                         let should_update = info
                             .hard_limited_until
                             .is_none_or(|local| until_instant > local);
                         if should_update {
                             info.hard_limited_until = Some(until_instant);
-                            trace!(
-                                account = self.accounts[i].name,
-                                "synced hard-limit from redis"
-                            );
+                            trace!(endpoint = targets[i].name, "synced hard-limit from redis");
                         }
                     }
                     HardLimitSync::Ignore => {}
@@ -3165,18 +3215,17 @@ impl AppState {
             }
         }
 
-        // 2. Sync rate info (MGET for all accounts in one round-trip)
-        let rate_keys: Vec<String> = self
-            .accounts
+        // 2. Sync rate info (MGET for all targets in one round-trip)
+        let rate_keys: Vec<String> = targets
             .iter()
-            .map(|a| format!("alb:rate:{}", a.name))
+            .map(|t| format!("alb:rate:{}", t.name))
             .collect();
 
         if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&rate_keys).await {
             for (i, val) in values.iter().enumerate() {
                 if let Some(json) = val {
                     if let Ok(remote) = serde_json::from_str::<RedisRateInfo>(json) {
-                        let mut info = self.accounts[i].rate_info.write().await;
+                        let mut info = targets[i].rate_info.write().await;
                         // "Most recent wins": only apply remote data if it's newer
                         // Both ages use wall-clock epoch to avoid mixed-clock-domain bugs
                         let local_age = info
@@ -3205,7 +3254,7 @@ impl AppState {
                             info.last_updated = Some(now_instant);
                             info.last_updated_epoch = Some(remote.updated_at);
                             trace!(
-                                account = self.accounts[i].name,
+                                endpoint = targets[i].name,
                                 remote_age,
                                 "synced rate info from redis"
                             );
@@ -3216,10 +3265,9 @@ impl AppState {
         }
 
         // 3. Sync precomputed routing weights (published by probing pod)
-        let weight_keys: Vec<String> = self
-            .accounts
+        let weight_keys: Vec<String> = targets
             .iter()
-            .map(|a| format!("alb:weight:{}", a.name))
+            .map(|t| format!("alb:weight:{}", t.name))
             .collect();
         if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&weight_keys).await {
             for (i, val) in values.iter().enumerate() {
@@ -3227,17 +3275,11 @@ impl AppState {
                     let mut parts = csv.splitn(3, ',');
                     if let (Some(w_str), Some(s_str)) = (parts.next(), parts.next()) {
                         if let (Ok(w), Ok(s)) = (w_str.parse::<f64>(), s_str.parse::<f64>()) {
-                            self.accounts[i]
-                                .last_routing_weight
-                                .store(w.to_bits(), Ordering::Relaxed);
-                            self.accounts[i]
-                                .last_routing_share
-                                .store(s.to_bits(), Ordering::Relaxed);
+                            targets[i].weight.store(w.to_bits(), Ordering::Relaxed);
+                            targets[i].share.store(s.to_bits(), Ordering::Relaxed);
                             // Gate is optional (backward compat with older publishers)
                             if let Some(Ok(g)) = parts.next().map(|g| g.parse::<f64>()) {
-                                self.accounts[i]
-                                    .last_effective_gate
-                                    .store(g.to_bits(), Ordering::Relaxed);
+                                targets[i].gate.store(g.to_bits(), Ordering::Relaxed);
                             }
                         }
                     }
@@ -18298,6 +18340,44 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Should not panic or error when redis is None
         state.sync_from_redis().await;
         // Cluster cache should remain None
+        assert!(state.cluster_info_cache.lock().unwrap().is_none());
+    }
+
+    /// sync_from_redis / publish_routing_weights build the unified SyncTarget
+    /// list over BOTH pools. With an endpoints-only config (and a mix of
+    /// Anthropic + OpenAI protocols) neither path may panic.
+    #[tokio::test]
+    async fn sync_and_publish_handle_endpoint_pool_without_redis() {
+        fn make_ep(name: &str, protocol: Protocol) -> Endpoint {
+            Endpoint {
+                name: name.to_string(),
+                protocol,
+                base_url: "https://api.anthropic.com".to_string(),
+                token: "sk-ant-api-test".to_string(),
+                passthrough: false,
+                models: vec![],
+                priority: 0,
+                requests: AtomicU64::new(0),
+                rate_info: RwLock::new(RateLimitInfo::default()),
+                burn_rate: Mutex::new(BurnRate::new()),
+                input_tokens: AtomicU64::new(0),
+                output_tokens: AtomicU64::new(0),
+                cache_creation_tokens: AtomicU64::new(0),
+                cache_read_tokens: AtomicU64::new(0),
+                last_routing_weight: AtomicU64::new(0),
+                last_routing_share: AtomicU64::new(0),
+                last_effective_gate: AtomicU64::new(0),
+            }
+        }
+        let mut state = test_state_with(vec![]);
+        {
+            let st = Arc::get_mut(&mut state).unwrap();
+            st.endpoints.push(make_ep("ep-a", Protocol::Anthropic));
+            st.endpoints.push(make_ep("ep-oai", Protocol::OpenAI));
+        }
+        // Both paths must be no-ops (redis is None) and must not panic.
+        state.sync_from_redis().await;
+        state.publish_routing_weights().await;
         assert!(state.cluster_info_cache.lock().unwrap().is_none());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1670,15 +1670,12 @@ fn classify_hard_limit_sync(
 }
 
 impl AppState {
-    /// Display name for an endpoint (account or upstream), for logging.
+    /// Display name for an endpoint (account, upstream, or unified pool), for logging.
     fn endpoint_name(&self, ep: EndpointIdx) -> &str {
         match ep {
             EndpointIdx::Account(i) => &self.accounts[i].name,
             EndpointIdx::Upstream(i) => &self.upstreams[i].name,
-            // Phase 2: AppState.endpoints not yet wired. Filled in Task 7.
-            EndpointIdx::Unified(_) => {
-                unreachable!("EndpointIdx::Unified constructed before AppState.endpoints exists")
-            }
+            EndpointIdx::Unified(i) => &self.endpoints[i].name,
         }
     }
 
@@ -4051,7 +4048,7 @@ async fn proxy_handler(
                     }
                 }
                 Some(EndpointIdx::Unified(_)) => unreachable!(
-                    "EndpointIdx::Unified constructed before routing_candidates wires it"
+                    "Phase 2b: handler dispatch for EndpointIdx::Unified is not yet wired; the startup guard in main() rejects [[endpoints]] configs until this branch lands."
                 ),
                 None => {
                     warn!("all endpoints exhausted");
@@ -7319,7 +7316,7 @@ async fn openai_chat_handler(
                     }
                 }
                 Some(EndpointIdx::Unified(_)) => unreachable!(
-                    "EndpointIdx::Unified constructed before routing_candidates wires it"
+                    "Phase 2b: handler dispatch for EndpointIdx::Unified is not yet wired; the startup guard in main() rejects [[endpoints]] configs until this branch lands."
                 ),
                 None => {
                     warn!("all endpoints exhausted");
@@ -7833,6 +7830,18 @@ async fn main() {
         .unwrap_or_else(|e| panic!("config parse error: {e}"));
     if let Err(msg) = validate_endpoints(&config.endpoints) {
         panic!("{msg}");
+    }
+
+    // TRANSIENT GUARD (Phase 2a → Phase 2b): routing_candidates produces
+    // EndpointIdx::Unified(i) candidates for any populated [[endpoints]],
+    // but handler dispatch for that variant is not wired until Phase 2b.
+    // Selecting a Unified candidate would panic via `unreachable!()`. Refuse
+    // to start until dispatch lands. This block is deleted by Phase 2b.
+    if !config.endpoints.is_empty() {
+        panic!(
+            "config: [[endpoints]] is declared ({} entries) but handler dispatch is not yet wired (Phase 2b incoming). Use [[accounts]] / [[upstreams]] for now.",
+            config.endpoints.len()
+        );
     }
 
     // Set up tracing: stderr (info+) always, plus optional debug log file

--- a/src/main.rs
+++ b/src/main.rs
@@ -21713,4 +21713,64 @@ upstream = "https://api.anthropic.com"
         .await;
         assert!(result.is_none(), "500 must return None for retry");
     }
+    // ── Unified endpoint: cross-protocol handler routing ───────────
+
+    #[tokio::test]
+    async fn openai_chat_handler_routes_to_unified_anthropic_endpoint() {
+        // Mock Anthropic upstream: returns a minimal messages response.
+        let mock = Router::new().fallback(any(|| async {
+            axum::Json(serde_json::json!({
+                "id": "msg_1", "type": "message", "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": "hi back"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 2}
+            }))
+            .into_response()
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, mock).await.unwrap();
+        });
+
+        let mut state = test_state_with(vec![]); // no legacy accounts
+        let mut ep = make_endpoint("unified-anthropic", Protocol::Anthropic);
+        ep.base_url = format!("http://{}", mock_addr);
+        ep.token = "sk-ant-api-test".to_string();
+        Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
+
+        let app = Router::new()
+            .route(
+                "/v1/chat/completions",
+                axum::routing::post(openai_chat_handler),
+            )
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://{}/v1/chat/completions", addr))
+            .json(&serde_json::json!({
+                "model": "claude-opus-4-7",
+                "messages": [{"role": "user", "content": "hi"}],
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(
+            body["choices"][0]["message"]["content"].is_string(),
+            "response must be OpenAI-shaped after round-trip translation"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -703,13 +703,13 @@ impl AppState {
 
 #[derive(Serialize, Deserialize)]
 struct PersistedState {
-    accounts: Vec<PersistedAccount>,
+    endpoints: Vec<PersistedEndpoint>,
     #[serde(default)]
     saved_at: u64,
 }
 
 #[derive(Serialize, Deserialize)]
-struct PersistedAccount {
+struct PersistedEndpoint {
     name: String,
     requests_total: u64,
     utilization: Option<f64>,
@@ -812,22 +812,29 @@ impl AppState {
     }
 
     async fn save_state(&self) {
-        let mut accounts = Vec::new();
+        let mut endpoints = Vec::new();
         let now = Instant::now();
 
-        for acct in &self.accounts {
-            let info = acct.rate_info.read().await;
+        // Build a PersistedEndpoint from the shared (name, requests, rate_info)
+        // fields common to both Account and Endpoint.
+        async fn persist_one(
+            name: &str,
+            requests: &AtomicU64,
+            rate_info: &RwLock<RateLimitInfo>,
+            now: Instant,
+        ) -> PersistedEndpoint {
+            let info = rate_info.read().await;
             let hard_until_epoch = info.hard_limited_until.and_then(|until| {
                 if until > now {
                     let remaining = until.duration_since(now);
-                    Some(Self::now_epoch() + remaining.as_secs())
+                    Some(AppState::now_epoch() + remaining.as_secs())
                 } else {
                     None
                 }
             });
-            accounts.push(PersistedAccount {
-                name: acct.name.clone(),
-                requests_total: acct.requests.load(Ordering::Relaxed),
+            PersistedEndpoint {
+                name: name.to_string(),
+                requests_total: requests.load(Ordering::Relaxed),
                 utilization: info.utilization,
                 utilization_7d: info.utilization_7d,
                 utilization_5h: info.utilization_5h,
@@ -847,11 +854,24 @@ impl AppState {
                 overage_reset: info.overage_reset,
                 hard_limited_until_epoch: hard_until_epoch,
                 last_updated_epoch: info.last_updated_epoch,
-            });
+            }
+        }
+
+        // In practice exactly one pool is non-empty; persist both for safety.
+        // Accounts are always Anthropic. Skip OpenAI endpoints — their
+        // rate_info is a permanent stub with no state worth persisting.
+        for acct in &self.accounts {
+            endpoints.push(persist_one(&acct.name, &acct.requests, &acct.rate_info, now).await);
+        }
+        for ep in &self.endpoints {
+            if ep.protocol == Protocol::OpenAI {
+                continue;
+            }
+            endpoints.push(persist_one(&ep.name, &ep.requests, &ep.rate_info, now).await);
         }
 
         let state = PersistedState {
-            accounts,
+            endpoints,
             saved_at: Self::now_epoch(),
         };
 
@@ -1300,7 +1320,7 @@ impl AppState {
         let persisted: PersistedState = match serde_json::from_str(&data) {
             Ok(s) => s,
             Err(e) => {
-                warn!(error = %e, "failed to parse persisted state, starting fresh");
+                warn!(error = %e, "failed to parse persisted state (possible legacy 'accounts'-keyed format — that schema was removed); starting fresh");
                 return;
             }
         };
@@ -1308,10 +1328,23 @@ impl AppState {
         let now_epoch = Self::now_epoch();
         let now_instant = Instant::now();
 
-        for pa in &persisted.accounts {
-            if let Some(acct) = self.accounts.iter().find(|a| a.name == pa.name) {
-                acct.requests.store(pa.requests_total, Ordering::Relaxed);
-                let mut info = acct.rate_info.write().await;
+        for pa in &persisted.endpoints {
+            // Distribute each persisted entry to whichever pool holds a
+            // matching name: legacy accounts first, then unified endpoints.
+            let restore_target: Option<(&AtomicU64, &RwLock<RateLimitInfo>)> = self
+                .accounts
+                .iter()
+                .find(|a| a.name == pa.name)
+                .map(|a| (&a.requests, &a.rate_info))
+                .or_else(|| {
+                    self.endpoints
+                        .iter()
+                        .find(|e| e.name == pa.name)
+                        .map(|e| (&e.requests, &e.rate_info))
+                });
+            if let Some((requests, rate_info)) = restore_target {
+                requests.store(pa.requests_total, Ordering::Relaxed);
+                let mut info = rate_info.write().await;
                 info.utilization = pa.utilization;
                 info.utilization_7d = pa.utilization_7d;
                 info.utilization_5h = pa.utilization_5h;
@@ -18624,9 +18657,9 @@ upstream = "https://api.anthropic.com"
         // Verify file exists and is valid JSON
         let data = tokio::fs::read_to_string(&state_path).await.unwrap();
         let persisted: PersistedState = serde_json::from_str(&data).unwrap();
-        assert_eq!(persisted.accounts.len(), 2);
-        assert_eq!(persisted.accounts[0].requests_total, 42);
-        assert_eq!(persisted.accounts[1].requests_total, 17);
+        assert_eq!(persisted.endpoints.len(), 2);
+        assert_eq!(persisted.endpoints[0].requests_total, 42);
+        assert_eq!(persisted.endpoints[1].requests_total, 17);
         assert!(persisted.saved_at > 0);
 
         // Create a fresh state and load into it
@@ -18714,6 +18747,86 @@ upstream = "https://api.anthropic.com"
                 "hard_limited_until should survive round-trip"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn load_state_warns_and_starts_clean_on_legacy_accounts_key() {
+        // A state file using the legacy `accounts` top-level key must NOT
+        // deserialize into the new `endpoints`-keyed PersistedState. load_state
+        // logs a warn and starts clean.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"accounts":[{"name":"primary","requests_total":42}],"saved_at":0}"#,
+        )
+        .unwrap();
+        let mut state = test_state_with(vec![make_account("primary", "sk-ant")]);
+        Arc::get_mut(&mut state).unwrap().state_path = tmp.path().to_path_buf();
+        state.load_state().await; // must not panic
+        assert_eq!(
+            state.accounts[0].requests.load(Ordering::Relaxed),
+            0,
+            "legacy accounts-keyed state file must not load into the new schema"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_load_roundtrip_unified_endpoints() {
+        fn make_test_endpoint(name: &str) -> Endpoint {
+            Endpoint {
+                name: name.to_string(),
+                protocol: Protocol::Anthropic,
+                base_url: "https://api.anthropic.com".to_string(),
+                token: "sk-ant-api-test".to_string(),
+                passthrough: false,
+                models: vec![],
+                priority: 0,
+                requests: AtomicU64::new(0),
+                rate_info: RwLock::new(RateLimitInfo::default()),
+                burn_rate: Mutex::new(BurnRate::new()),
+                input_tokens: AtomicU64::new(0),
+                output_tokens: AtomicU64::new(0),
+                cache_creation_tokens: AtomicU64::new(0),
+                cache_read_tokens: AtomicU64::new(0),
+                last_routing_weight: AtomicU64::new(0),
+                last_routing_share: AtomicU64::new(0),
+                last_effective_gate: AtomicU64::new(0),
+            }
+        }
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut state = test_state_with(vec![]);
+        {
+            let st = Arc::get_mut(&mut state).unwrap();
+            st.state_path = tmp.path().to_path_buf();
+            st.endpoints.push(make_test_endpoint("ep1"));
+        }
+        let now_epoch = AppState::now_epoch();
+        state.endpoints[0].requests.store(7, Ordering::Relaxed);
+        {
+            // load_state recomputes `utilization` from the surviving 5h/7d
+            // windows, so a bare flat `utilization` would not survive. Set a
+            // 5h window with a future reset so it persists and drives util.
+            let mut info = state.endpoints[0].rate_info.write().await;
+            info.utilization = Some(0.42);
+            info.utilization_5h = Some(0.42);
+            info.reset_5h = Some(now_epoch + 18000);
+        }
+        state.save_state().await;
+
+        // Fresh state with the same endpoint name, load from the file.
+        let mut state2 = test_state_with(vec![]);
+        {
+            let st = Arc::get_mut(&mut state2).unwrap();
+            st.state_path = tmp.path().to_path_buf();
+            st.endpoints.push(make_test_endpoint("ep1"));
+        }
+        state2.load_state().await;
+        assert_eq!(state2.endpoints[0].requests.load(Ordering::Relaxed), 7);
+        assert_eq!(
+            state2.endpoints[0].rate_info.read().await.utilization,
+            Some(0.42)
+        );
     }
 
     // ── Budget day rollover ──────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -7570,7 +7570,6 @@ async fn openai_chat_handler(
 ///
 /// `serde` silently drops unknown keys by default; this gives the operator
 /// a clear migration message instead of a silent misconfiguration.
-#[allow(dead_code)] // Wired into main() in Task 4 of the unified-endpoints refactor.
 fn reject_legacy_config_keys(value: &toml::Value) -> Result<(), String> {
     let table = match value.as_table() {
         Some(t) => t,
@@ -7605,8 +7604,14 @@ async fn main() {
         .unwrap_or_else(|| "config.toml".to_string());
     let config_str = std::fs::read_to_string(&config_path)
         .unwrap_or_else(|e| panic!("failed to read {config_path}: {e}"));
-    let config: Config =
-        toml::from_str(&config_str).unwrap_or_else(|e| panic!("invalid config: {e}"));
+    let raw_value: toml::Value =
+        toml::from_str(&config_str).unwrap_or_else(|e| panic!("config parse error: {e}"));
+    if let Err(msg) = reject_legacy_config_keys(&raw_value) {
+        panic!("{msg}");
+    }
+    let config: Config = raw_value
+        .try_into()
+        .unwrap_or_else(|e| panic!("config parse error: {e}"));
 
     // Set up tracing: stderr (info+) always, plus optional debug log file
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5546,6 +5546,133 @@ async fn upstream_handler(
 
 // ── Stats endpoint ──────────────────────────────────────────────────
 
+/// Build one `/stats` JSON entry from the shared (name, priority, rate_info,
+/// burn_rate, counters) field set common to both `Account` and the unified
+/// `Endpoint`. When `protocol` is `Some`, a `"protocol"` field is added — the
+/// only shape difference between an account entry and an endpoint entry.
+#[allow(clippy::too_many_arguments)]
+async fn build_stats_entry(
+    name: &str,
+    passthrough: bool,
+    priority: u32,
+    protocol: Option<&str>,
+    rate_info: &RwLock<RateLimitInfo>,
+    burn_rate: &Mutex<BurnRate>,
+    requests: &AtomicU64,
+    token_counters: [&AtomicU64; 4],
+    now_epoch: u64,
+    total_headroom: &mut Option<u64>,
+) -> serde_json::Value {
+    let info = rate_info.read().await;
+    let hard_limited = match info.hard_limited_until {
+        Some(until) if Instant::now() < until => {
+            Some(until.duration_since(Instant::now()).as_secs())
+        }
+        _ => None,
+    };
+
+    // Burn rate from EWMA tracker
+    let (br_5m, br_1h, br_6h) = burn_rate
+        .lock()
+        .map(|br| (br.rate_5m.value, br.rate_1h.value, br.rate_6h.value))
+        .unwrap_or((0.0, 0.0, 0.0));
+
+    // Headroom: prefer remaining_requests header, else (1-util)*limit, else null
+    let headroom: Option<u64> = if let Some(rem) = info.remaining_requests {
+        Some(rem)
+    } else if let (Some(util), Some(limit)) = (info.utilization, info.limit_requests) {
+        Some(((1.0 - util) * limit as f64).max(0.0) as u64)
+    } else {
+        None
+    };
+    match (total_headroom.as_mut(), headroom) {
+        (Some(total), Some(h)) => *total += h,
+        _ => *total_headroom = None,
+    }
+
+    // Projected throttle time
+    let (eff_util, _, _, _) = effective_utilization(&info, now_epoch, "");
+    let projected_throttle_at: serde_json::Value = if eff_util < 0.5 || br_1h < 0.01 {
+        serde_json::Value::Null
+    } else if let Some(headroom_reqs) = headroom {
+        if headroom_reqs == 0 {
+            // Already at limit — check if hard-limited and report cooldown expiry
+            if let Some(hl_secs) = hard_limited {
+                serde_json::Value::String(AppState::epoch_to_iso8601(now_epoch + hl_secs))
+            } else {
+                serde_json::Value::String(AppState::epoch_to_iso8601(now_epoch))
+            }
+        } else {
+            let minutes_remaining = headroom_reqs as f64 / br_1h;
+            let secs_remaining = (minutes_remaining * 60.0) as u64;
+            let projected_epoch = now_epoch + secs_remaining;
+            // If projection is beyond next reset, account will recover → null
+            let mut next_reset = info.reset_5h.unwrap_or(u64::MAX);
+            for c in info.claims_7d.values() {
+                if let Some(r) = c.reset {
+                    next_reset = next_reset.min(r);
+                }
+            }
+            if projected_epoch > next_reset && next_reset != u64::MAX {
+                serde_json::Value::Null
+            } else {
+                serde_json::Value::String(AppState::epoch_to_iso8601(projected_epoch))
+            }
+        }
+    } else {
+        serde_json::Value::Null
+    };
+
+    let mut entry = serde_json::json!({
+        "name": name,
+        "passthrough": passthrough,
+        "priority": priority,
+        "requests_total": requests.load(Ordering::Relaxed),
+        "utilization": info.utilization,
+        "utilization_7d": info.utilization_7d,
+        "utilization_5h": info.utilization_5h,
+        "representative_claim": info.representative_claim,
+        "reset_5h": info.reset_5h,
+        "reset_7d": info.reset_7d,
+        "status_5h": info.status_5h,
+        "status_7d": info.status_7d,
+        "overage_in_use": info.overage_in_use,
+        "overage_status": info.overage_status,
+        "overage_utilization": info.overage_utilization,
+        "overage_reset": info.overage_reset,
+        "claims_7d": info.claims_7d.iter().map(|(k, v)| {
+            (k.clone(), serde_json::json!({
+                "utilization": v.utilization,
+                "reset": v.reset,
+                "status": v.status,
+                "waste_risk": waste_risk(v.utilization, v.reset, now_epoch),
+            }))
+        }).collect::<serde_json::Map<String, serde_json::Value>>(),
+        "remaining_requests": info.remaining_requests,
+        "remaining_tokens": info.remaining_tokens,
+        "limit_requests": info.limit_requests,
+        "limit_tokens": info.limit_tokens,
+        "hard_limited_remaining_secs": hard_limited,
+        "burn_rate": {
+            "last_5m": (br_5m * 100.0).round() / 100.0,
+            "last_1h": (br_1h * 100.0).round() / 100.0,
+            "last_6h": (br_6h * 100.0).round() / 100.0,
+        },
+        "headroom_requests": headroom,
+        "projected_throttle_at": projected_throttle_at,
+        "token_usage": {
+            "input_tokens": token_counters[0].load(Ordering::Relaxed),
+            "output_tokens": token_counters[1].load(Ordering::Relaxed),
+            "cache_creation_input_tokens": token_counters[2].load(Ordering::Relaxed),
+            "cache_read_input_tokens": token_counters[3].load(Ordering::Relaxed),
+        },
+    });
+    if let Some(p) = protocol {
+        entry["protocol"] = serde_json::json!(p);
+    }
+    entry
+}
+
 async fn stats_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::ConnectInfo(client_addr): axum::extract::ConnectInfo<SocketAddr>,
@@ -5565,111 +5692,56 @@ async fn stats_handler(
     let mut out = Vec::new();
     let mut total_headroom: Option<u64> = Some(0);
     for acct in &state.accounts {
-        let info = acct.rate_info.read().await;
-        let hard_limited = match info.hard_limited_until {
-            Some(until) if Instant::now() < until => {
-                Some(until.duration_since(Instant::now()).as_secs())
-            }
-            _ => None,
+        out.push(
+            build_stats_entry(
+                &acct.name,
+                acct.passthrough,
+                acct.priority,
+                None,
+                &acct.rate_info,
+                &acct.burn_rate,
+                &acct.requests,
+                [
+                    &acct.input_tokens,
+                    &acct.output_tokens,
+                    &acct.cache_creation_tokens,
+                    &acct.cache_read_tokens,
+                ],
+                now_epoch,
+                &mut total_headroom,
+            )
+            .await,
+        );
+    }
+    // Parallel pass over the unified endpoint pool. Same field shape as the
+    // `accounts` entries, plus a "protocol" field. In a real config exactly
+    // one pool is non-empty.
+    let mut endpoint_stats = Vec::new();
+    for ep in &state.endpoints {
+        let protocol = match ep.protocol {
+            Protocol::Anthropic => "anthropic",
+            Protocol::OpenAI => "openai",
         };
-
-        // Burn rate from EWMA tracker
-        let (br_5m, br_1h, br_6h) = acct
-            .burn_rate
-            .lock()
-            .map(|br| (br.rate_5m.value, br.rate_1h.value, br.rate_6h.value))
-            .unwrap_or((0.0, 0.0, 0.0));
-
-        // Headroom: prefer remaining_requests header, else (1-util)*limit, else null
-        let headroom: Option<u64> = if let Some(rem) = info.remaining_requests {
-            Some(rem)
-        } else if let (Some(util), Some(limit)) = (info.utilization, info.limit_requests) {
-            Some(((1.0 - util) * limit as f64).max(0.0) as u64)
-        } else {
-            None
-        };
-        match (total_headroom.as_mut(), headroom) {
-            (Some(total), Some(h)) => *total += h,
-            _ => total_headroom = None,
-        }
-
-        // Projected throttle time
-        let (eff_util, _, _, _) = effective_utilization(&info, now_epoch, "");
-        let projected_throttle_at: serde_json::Value = if eff_util < 0.5 || br_1h < 0.01 {
-            serde_json::Value::Null
-        } else if let Some(headroom_reqs) = headroom {
-            if headroom_reqs == 0 {
-                // Already at limit — check if hard-limited and report cooldown expiry
-                if let Some(hl_secs) = hard_limited {
-                    serde_json::Value::String(AppState::epoch_to_iso8601(now_epoch + hl_secs))
-                } else {
-                    serde_json::Value::String(AppState::epoch_to_iso8601(now_epoch))
-                }
-            } else {
-                let minutes_remaining = headroom_reqs as f64 / br_1h;
-                let secs_remaining = (minutes_remaining * 60.0) as u64;
-                let projected_epoch = now_epoch + secs_remaining;
-                // If projection is beyond next reset, account will recover → null
-                let mut next_reset = info.reset_5h.unwrap_or(u64::MAX);
-                for c in info.claims_7d.values() {
-                    if let Some(r) = c.reset {
-                        next_reset = next_reset.min(r);
-                    }
-                }
-                if projected_epoch > next_reset && next_reset != u64::MAX {
-                    serde_json::Value::Null
-                } else {
-                    serde_json::Value::String(AppState::epoch_to_iso8601(projected_epoch))
-                }
-            }
-        } else {
-            serde_json::Value::Null
-        };
-
-        out.push(serde_json::json!({
-            "name": acct.name,
-            "passthrough": acct.passthrough,
-            "priority": acct.priority,
-            "requests_total": acct.requests.load(Ordering::Relaxed),
-            "utilization": info.utilization,
-            "utilization_7d": info.utilization_7d,
-            "utilization_5h": info.utilization_5h,
-            "representative_claim": info.representative_claim,
-            "reset_5h": info.reset_5h,
-            "reset_7d": info.reset_7d,
-            "status_5h": info.status_5h,
-            "status_7d": info.status_7d,
-            "overage_in_use": info.overage_in_use,
-            "overage_status": info.overage_status,
-            "overage_utilization": info.overage_utilization,
-            "overage_reset": info.overage_reset,
-            "claims_7d": info.claims_7d.iter().map(|(k, v)| {
-                (k.clone(), serde_json::json!({
-                    "utilization": v.utilization,
-                    "reset": v.reset,
-                    "status": v.status,
-                    "waste_risk": waste_risk(v.utilization, v.reset, now_epoch),
-                }))
-            }).collect::<serde_json::Map<String, serde_json::Value>>(),
-            "remaining_requests": info.remaining_requests,
-            "remaining_tokens": info.remaining_tokens,
-            "limit_requests": info.limit_requests,
-            "limit_tokens": info.limit_tokens,
-            "hard_limited_remaining_secs": hard_limited,
-            "burn_rate": {
-                "last_5m": (br_5m * 100.0).round() / 100.0,
-                "last_1h": (br_1h * 100.0).round() / 100.0,
-                "last_6h": (br_6h * 100.0).round() / 100.0,
-            },
-            "headroom_requests": headroom,
-            "projected_throttle_at": projected_throttle_at,
-            "token_usage": {
-                "input_tokens": acct.input_tokens.load(Ordering::Relaxed),
-                "output_tokens": acct.output_tokens.load(Ordering::Relaxed),
-                "cache_creation_input_tokens": acct.cache_creation_tokens.load(Ordering::Relaxed),
-                "cache_read_input_tokens": acct.cache_read_tokens.load(Ordering::Relaxed),
-            },
-        }));
+        endpoint_stats.push(
+            build_stats_entry(
+                &ep.name,
+                ep.passthrough,
+                ep.priority,
+                Some(protocol),
+                &ep.rate_info,
+                &ep.burn_rate,
+                &ep.requests,
+                [
+                    &ep.input_tokens,
+                    &ep.output_tokens,
+                    &ep.cache_creation_tokens,
+                    &ep.cache_read_tokens,
+                ],
+                now_epoch,
+                &mut total_headroom,
+            )
+            .await,
+        );
     }
     let mut upstream_stats = Vec::new();
     for u in &state.upstreams {
@@ -5812,6 +5884,7 @@ async fn stats_handler(
 
     let mut response = serde_json::json!({
         "accounts": out,
+        "endpoints": endpoint_stats,
         "upstreams": upstream_stats,
         "client_usage": client_usage,
         "client_budgets": budgets,
@@ -11471,6 +11544,60 @@ token = "sk-ant-test"
         let upstreams = body["upstreams"].as_array().unwrap();
         assert_eq!(upstreams.len(), 1);
         assert_eq!(upstreams[0]["name"], "mock");
+        // Endpoints array is always present (empty for a legacy accounts config).
+        assert_eq!(body["endpoints"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn stats_endpoint_exposes_endpoints_array() {
+        fn make_ep(name: &str, protocol: Protocol) -> Endpoint {
+            Endpoint {
+                name: name.to_string(),
+                protocol,
+                base_url: "https://api.anthropic.com".to_string(),
+                token: "sk-ant-api-test".to_string(),
+                passthrough: false,
+                models: vec![],
+                priority: 5,
+                requests: AtomicU64::new(0),
+                rate_info: RwLock::new(RateLimitInfo::default()),
+                burn_rate: Mutex::new(BurnRate::new()),
+                input_tokens: AtomicU64::new(0),
+                output_tokens: AtomicU64::new(0),
+                cache_creation_tokens: AtomicU64::new(0),
+                cache_read_tokens: AtomicU64::new(0),
+                last_routing_weight: AtomicU64::new(0),
+                last_routing_share: AtomicU64::new(0),
+                last_effective_gate: AtomicU64::new(0),
+            }
+        }
+        // Endpoints-only config: legacy accounts pool is empty.
+        let mut state = test_state_with(vec![]);
+        {
+            let st = Arc::get_mut(&mut state).expect("uniquely owned before router build");
+            st.endpoints
+                .push(make_ep("ep-anthropic", Protocol::Anthropic));
+            st.endpoints.push(make_ep("ep-openai", Protocol::OpenAI));
+        }
+        let addr = serve(build_router(state)).await;
+
+        let client = Client::new();
+        let resp = client
+            .get(format!("http://{}/_stats", addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        // Legacy accounts array present and empty.
+        assert_eq!(body["accounts"].as_array().unwrap().len(), 0);
+        let endpoints = body["endpoints"].as_array().unwrap();
+        assert_eq!(endpoints.len(), 2);
+        assert_eq!(endpoints[0]["name"], "ep-anthropic");
+        assert_eq!(endpoints[0]["protocol"], "anthropic");
+        assert_eq!(endpoints[0]["priority"], 5);
+        assert_eq!(endpoints[1]["name"], "ep-openai");
+        assert_eq!(endpoints[1]["protocol"], "openai");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7589,7 +7589,13 @@ fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
             }
             Protocol::Anthropic => {
                 if let Some(url) = ep.base_url.as_deref() {
-                    if !url.starts_with("https://api.anthropic.com") {
+                    // Parse the URL and compare hosts exactly. A naive
+                    // `starts_with("https://api.anthropic.com")` would accept
+                    // `https://api.anthropic.com.evil.example` as canonical.
+                    let host = reqwest::Url::parse(url)
+                        .ok()
+                        .and_then(|u| u.host_str().map(str::to_string));
+                    if host.as_deref() != Some("api.anthropic.com") {
                         warn!(
                             endpoint = ep.name,
                             base_url = url,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2167,121 +2167,62 @@ impl AppState {
             }
 
             let info = acct.rate_info.read().await;
-
-            // Hard-limited accounts contribute zero (mirrors routing_candidates filter).
-            if let Some(until) = info.hard_limited_until {
-                if now < until {
-                    continue;
-                }
-            }
-
-            let stale_after_hard_limit = info
-                .hard_limited_until
-                .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
-
-            // 5h gate — same logic as routing_candidates
-            let gate_5h = if stale_after_hard_limit {
-                0.5
-            } else {
-                time_adjusted_utilization(
-                    info.utilization_5h,
-                    info.reset_5h,
-                    info.status_5h.as_deref(),
-                    NEAR_RESET_5H_SECS,
-                    now_epoch,
-                )
-                .unwrap_or_else(|| {
-                    if let Some(util) = info.utilization {
-                        util
-                    } else if let Some(remaining) = info.remaining_tokens {
-                        let limit = info.limit_tokens.unwrap_or(1_000_000);
-                        (1.0 - (remaining as f64 / limit as f64)).clamp(0.0, 1.0)
-                    } else {
-                        0.5
-                    }
-                })
-            };
-
-            // 7d gate + waste_risk from a SINGLE representative ClaimWindowData
-            // — utilization, reset and status are read as a coherent triple
-            // from one real claim, not Frankensteined from independently
-            // aggregated maxima/minima across claims.
-            //
-            // Selection precedence:
-            //   1. info.representative_claim if it points to a 7d entry
-            //      (this is the LB's own "binding constraint" signal)
-            //   2. The general "seven_day" claim if present
-            //   3. The model-specific claim with the highest waste_risk
-            //      (worst-case representative for the dashboard)
-            //   4. None → no 7d data, fall back to headroom-only
-            let claim_is_fresh = |c: &&ClaimWindowData| {
-                c.reset.is_some()
-                    && time_adjusted_utilization(
-                        Some(0.0),
-                        c.reset,
-                        c.status.as_deref(),
-                        NEAR_RESET_7D_SECS,
-                        now_epoch,
-                    )
-                    .is_some()
-            };
-            let representative: Option<&ClaimWindowData> = {
-                let rep_key = info.representative_claim.as_deref();
-                rep_key
-                    .filter(|k| k.starts_with("seven_day"))
-                    .and_then(|k| info.claims_7d.get(k))
-                    .filter(claim_is_fresh)
-                    .or_else(|| info.claims_7d.get("seven_day").filter(claim_is_fresh))
-                    .or_else(|| {
-                        info.claims_7d
-                            .values()
-                            .filter(claim_is_fresh)
-                            .max_by(|a, b| {
-                                let wr_a = waste_risk(a.utilization, a.reset, now_epoch);
-                                let wr_b = waste_risk(b.utilization, b.reset, now_epoch);
-                                wr_a.partial_cmp(&wr_b).unwrap_or(std::cmp::Ordering::Equal)
-                            })
-                    })
-            };
-
-            let (gate_7d, wr) = if let Some(claim) = representative {
-                let g = if stale_after_hard_limit {
-                    0.5
-                } else {
-                    time_adjusted_utilization(
-                        Some(0.0),
-                        claim.reset,
-                        claim.status.as_deref(),
-                        NEAR_RESET_7D_SECS,
-                        now_epoch,
-                    )
-                    .unwrap_or(0.0)
-                };
-                let w = waste_risk(claim.utilization, claim.reset, now_epoch);
-                (g, w)
-            } else {
-                // No 7d claim at all — headroom-only
-                let g = if stale_after_hard_limit { 0.5 } else { 0.0 };
-                (g, 0.0)
-            };
-
-            let gate = gate_5h.max(gate_7d);
-            let headroom = (1.0 - gate).max(0.01);
-            let weight = if wr > 0.0 { wr * headroom } else { headroom };
-            let weight = if gate >= 1.0 { 0.0 } else { weight };
-
-            entries[i] = Some((gate, weight));
+            entries[i] = metrics_gate_weight(&info, now_epoch, now);
         }
 
+        // Mirror the same computation over the unified endpoint pool. OpenAI
+        // endpoints carry no rate-limit data — their representative weight is
+        // the fixed (gate 0.0, weight 1.0) candidate that routing_candidates
+        // produces. Anthropic endpoints run the identical Anthropic computation.
+        let mut endpoint_entries: Vec<Option<(f64, f64)>> = vec![None; self.endpoints.len()];
+        for (i, ep) in self.endpoints.iter().enumerate() {
+            match ep.protocol {
+                Protocol::OpenAI => {
+                    endpoint_entries[i] = Some((0.0, 1.0));
+                }
+                Protocol::Anthropic => {
+                    if ep.passthrough {
+                        continue;
+                    }
+                    let info = ep.rate_info.read().await;
+                    endpoint_entries[i] = metrics_gate_weight(&info, now_epoch, now);
+                }
+            }
+        }
+
+        self.store_metrics_weights(&entries, &self.accounts, |a| {
+            (
+                &a.last_routing_weight,
+                &a.last_routing_share,
+                &a.last_effective_gate,
+            )
+        });
+        self.store_metrics_weights(&endpoint_entries, &self.endpoints, |e| {
+            (
+                &e.last_routing_weight,
+                &e.last_routing_share,
+                &e.last_effective_gate,
+            )
+        });
+    }
+
+    /// Normalize per-entry (gate, weight) pairs into the three gauge atomics
+    /// of each pool member, applying pick_account's graceful soft-limit
+    /// degradation. Pool-agnostic: works for both `Account` and `Endpoint`
+    /// since the gauge atomics share field names.
+    fn store_metrics_weights<T>(
+        &self,
+        entries: &[Option<(f64, f64)>],
+        pool: &[T],
+        gauges: impl Fn(&T) -> (&AtomicU64, &AtomicU64, &AtomicU64),
+    ) {
         // Mirror pick_account's graceful-degradation: only filter soft-limited
-        // accounts when at least one healthy account exists in the pool.
-        // Otherwise the entire pool is degraded and we still want the dashboard
-        // to reflect the routable accounts (pick_account would route to them).
+        // members when at least one healthy member exists in the pool.
         let has_healthy = entries
             .iter()
             .any(|e| matches!(e, Some((gate, _)) if *gate < self.soft_limit));
 
-        let mut weights = vec![0f64; self.accounts.len()];
+        let mut weights = vec![0f64; pool.len()];
         for (i, entry) in entries.iter().enumerate() {
             if let Some((gate, weight)) = entry {
                 if has_healthy && *gate >= self.soft_limit {
@@ -2292,23 +2233,133 @@ impl AppState {
         }
 
         let total: f64 = weights.iter().sum();
-        for (i, acct) in self.accounts.iter().enumerate() {
+        for (i, member) in pool.iter().enumerate() {
             let w = weights[i];
             let share = if total > 0.0 { w / total } else { 0.0 };
-            // Excluded accounts (passthrough, hard-limited) report gate=1.0
+            // Excluded members (passthrough, hard-limited) report gate=1.0
             // (fully gated) since they receive zero traffic.
             let gate = entries[i].map(|(g, _)| g).unwrap_or(1.0);
-            // Weight, share and gate are independent gauges, not a joint invariant —
-            // a torn read across them is harmless for dashboard consumers.
-            acct.last_routing_weight
-                .store(w.to_bits(), Ordering::Relaxed);
-            acct.last_routing_share
-                .store(share.to_bits(), Ordering::Relaxed);
-            acct.last_effective_gate
-                .store(gate.to_bits(), Ordering::Relaxed);
+            let (weight_g, share_g, gate_g) = gauges(member);
+            // Weight, share and gate are independent gauges, not a joint
+            // invariant — a torn read across them is harmless.
+            weight_g.store(w.to_bits(), Ordering::Relaxed);
+            share_g.store(share.to_bits(), Ordering::Relaxed);
+            gate_g.store(gate.to_bits(), Ordering::Relaxed);
+        }
+    }
+}
+
+/// Per-entry representative `(gate, weight)` for metrics gauges, model-agnostic.
+/// Returns `None` for hard-limited members (they contribute zero in any state).
+/// Shared by both the legacy account pool and the unified endpoint pool — only
+/// reads `RateLimitInfo`, so it is pool-agnostic.
+fn metrics_gate_weight(info: &RateLimitInfo, now_epoch: u64, now: Instant) -> Option<(f64, f64)> {
+    // Hard-limited members contribute zero (mirrors routing_candidates filter).
+    if let Some(until) = info.hard_limited_until {
+        if now < until {
+            return None;
         }
     }
 
+    let stale_after_hard_limit = info
+        .hard_limited_until
+        .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
+
+    // 5h gate — same logic as routing_candidates
+    let gate_5h = if stale_after_hard_limit {
+        0.5
+    } else {
+        time_adjusted_utilization(
+            info.utilization_5h,
+            info.reset_5h,
+            info.status_5h.as_deref(),
+            NEAR_RESET_5H_SECS,
+            now_epoch,
+        )
+        .unwrap_or_else(|| {
+            if let Some(util) = info.utilization {
+                util
+            } else if let Some(remaining) = info.remaining_tokens {
+                let limit = info.limit_tokens.unwrap_or(1_000_000);
+                (1.0 - (remaining as f64 / limit as f64)).clamp(0.0, 1.0)
+            } else {
+                0.5
+            }
+        })
+    };
+
+    // 7d gate + waste_risk from a SINGLE representative ClaimWindowData
+    // — utilization, reset and status are read as a coherent triple
+    // from one real claim, not Frankensteined from independently
+    // aggregated maxima/minima across claims.
+    //
+    // Selection precedence:
+    //   1. info.representative_claim if it points to a 7d entry
+    //      (this is the LB's own "binding constraint" signal)
+    //   2. The general "seven_day" claim if present
+    //   3. The model-specific claim with the highest waste_risk
+    //      (worst-case representative for the dashboard)
+    //   4. None → no 7d data, fall back to headroom-only
+    let claim_is_fresh = |c: &&ClaimWindowData| {
+        c.reset.is_some()
+            && time_adjusted_utilization(
+                Some(0.0),
+                c.reset,
+                c.status.as_deref(),
+                NEAR_RESET_7D_SECS,
+                now_epoch,
+            )
+            .is_some()
+    };
+    let representative: Option<&ClaimWindowData> = {
+        let rep_key = info.representative_claim.as_deref();
+        rep_key
+            .filter(|k| k.starts_with("seven_day"))
+            .and_then(|k| info.claims_7d.get(k))
+            .filter(claim_is_fresh)
+            .or_else(|| info.claims_7d.get("seven_day").filter(claim_is_fresh))
+            .or_else(|| {
+                info.claims_7d
+                    .values()
+                    .filter(claim_is_fresh)
+                    .max_by(|a, b| {
+                        let wr_a = waste_risk(a.utilization, a.reset, now_epoch);
+                        let wr_b = waste_risk(b.utilization, b.reset, now_epoch);
+                        wr_a.partial_cmp(&wr_b).unwrap_or(std::cmp::Ordering::Equal)
+                    })
+            })
+    };
+
+    let (gate_7d, wr) = if let Some(claim) = representative {
+        let g = if stale_after_hard_limit {
+            0.5
+        } else {
+            time_adjusted_utilization(
+                Some(0.0),
+                claim.reset,
+                claim.status.as_deref(),
+                NEAR_RESET_7D_SECS,
+                now_epoch,
+            )
+            .unwrap_or(0.0)
+        };
+        let w = waste_risk(claim.utilization, claim.reset, now_epoch);
+        (g, w)
+    } else {
+        // No 7d claim at all — headroom-only
+        let g = if stale_after_hard_limit { 0.5 } else { 0.0 };
+        (g, 0.0)
+    };
+
+    let gate = gate_5h.max(gate_7d);
+    let headroom = (1.0 - gate).max(0.01);
+    let weight = if wr > 0.0 { wr * headroom } else { headroom };
+    let weight = if gate >= 1.0 { 0.0 } else { weight };
+
+    Some((gate, weight))
+}
+
+impl AppState {
     fn routing_weight_publish_ttl(probe_interval_secs: u64) -> u64 {
         const FALLBACK_PUBLISH_INTERVAL_SECS: u64 = 60;
 
@@ -5882,6 +5933,11 @@ struct AcctMetricsSnap {
     last_updated_epoch: Option<u64>,
     overage_in_use: bool,
     overage_utilization: Option<f64>,
+    /// Routing-weight gauges, captured from the source struct's atomics at
+    /// snap time. Snap-carried so the routing-weight emission is pool-agnostic.
+    routing_weight: f64,
+    routing_share: f64,
+    effective_gate: f64,
 }
 
 #[cfg(test)]
@@ -5937,6 +5993,120 @@ fn append_routing_weight_metrics(
     }
 }
 
+/// Build an `AcctMetricsSnap` from the shared (name, rate_info, burn_rate,
+/// counters, gauge atomics) field set common to both `Account` and the unified
+/// `Endpoint`. Pool-agnostic: callers pass field references, so one
+/// implementation serves both the legacy account pool and the endpoint pool.
+#[allow(clippy::too_many_arguments)]
+async fn build_metrics_snap(
+    name: &str,
+    passthrough: bool,
+    rate_info: &RwLock<RateLimitInfo>,
+    burn_rate: &Mutex<BurnRate>,
+    requests: &AtomicU64,
+    token_counters: [&AtomicU64; 4],
+    routing_weight_atomic: &AtomicU64,
+    routing_share_atomic: &AtomicU64,
+    effective_gate_atomic: &AtomicU64,
+    now_epoch: u64,
+    total_headroom: &mut Option<u64>,
+) -> AcctMetricsSnap {
+    let info = rate_info.read().await;
+    let (br_5m, br_1h, br_6h) = burn_rate
+        .lock()
+        .map(|br| (br.rate_5m.value, br.rate_1h.value, br.rate_6h.value))
+        .unwrap_or((0.0, 0.0, 0.0));
+
+    let headroom: Option<u64> = if let Some(rem) = info.remaining_requests {
+        Some(rem)
+    } else if let (Some(util), Some(limit)) = (info.utilization, info.limit_requests) {
+        Some(((1.0 - util) * limit as f64).max(0.0) as u64)
+    } else {
+        None
+    };
+    match (total_headroom.as_mut(), headroom) {
+        (Some(total), Some(h)) => *total += h,
+        _ => *total_headroom = None,
+    }
+
+    let hard_limited_secs = info
+        .hard_limited_until
+        .and_then(|until| until.checked_duration_since(Instant::now()))
+        .map(|d| d.as_secs() as f64)
+        .unwrap_or(0.0);
+    let hard_limited_active = info
+        .hard_limited_until
+        .is_some_and(|until| Instant::now() < until);
+    let stale_after_hard_limit = info
+        .hard_limited_until
+        .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
+
+    let (eff_util, _, _, _) = effective_utilization(&info, now_epoch, "");
+    let projected_throttle_secs = if eff_util < 0.5 || br_1h < 0.01 {
+        None
+    } else {
+        headroom.map(|h| {
+            if h == 0 {
+                0.0
+            } else {
+                (h as f64 / br_1h) * 60.0
+            }
+        })
+    };
+
+    let claims: Vec<ClaimMetricsSnap> = info
+        .claims_7d
+        .iter()
+        .map(|(k, d)| ClaimMetricsSnap {
+            key: k.clone(),
+            utilization: d.utilization,
+            waste_risk: waste_risk(d.utilization, d.reset, now_epoch),
+            reset: d.reset,
+            status: d.status.clone(),
+        })
+        .collect();
+
+    AcctMetricsSnap {
+        name: name.to_string(),
+        passthrough,
+        has_applicable_7d: !claims.is_empty()
+            || info.utilization_7d.is_some()
+            || info.reset_7d.is_some()
+            || info.status_7d.is_some(),
+        utilization: info.utilization,
+        utilization_5h: info.utilization_5h,
+        utilization_7d: info.utilization_7d,
+        reset_5h: info.reset_5h,
+        reset_7d: info.reset_7d,
+        status_5h: info.status_5h.clone(),
+        status_7d: info.status_7d.clone(),
+        stale_after_hard_limit,
+        hard_limited_active,
+        burn_rate: (br_5m, br_1h, br_6h),
+        headroom,
+        remaining_requests: info.remaining_requests,
+        remaining_tokens: info.remaining_tokens,
+        limit_requests: info.limit_requests,
+        limit_tokens: info.limit_tokens,
+        requests_total: requests.load(Ordering::Relaxed),
+        hard_limited_secs,
+        projected_throttle_secs,
+        token_usage: [
+            token_counters[0].load(Ordering::Relaxed),
+            token_counters[1].load(Ordering::Relaxed),
+            token_counters[2].load(Ordering::Relaxed),
+            token_counters[3].load(Ordering::Relaxed),
+        ],
+        claims,
+        last_updated_epoch: info.last_updated_epoch,
+        overage_in_use: info.overage_in_use,
+        overage_utilization: info.overage_utilization,
+        routing_weight: f64::from_bits(routing_weight_atomic.load(Ordering::Relaxed)),
+        routing_share: f64::from_bits(routing_share_atomic.load(Ordering::Relaxed)),
+        effective_gate: f64::from_bits(effective_gate_atomic.load(Ordering::Relaxed)),
+    }
+}
+
 async fn metrics_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::ConnectInfo(client_addr): axum::extract::ConnectInfo<SocketAddr>,
@@ -5957,102 +6127,59 @@ async fn metrics_handler(
 
     // ── Phase 1: Gather data (async — acquires locks) ──────────────
 
-    let mut snaps: Vec<AcctMetricsSnap> = Vec::with_capacity(state.accounts.len());
+    let mut snaps: Vec<AcctMetricsSnap> =
+        Vec::with_capacity(state.accounts.len() + state.endpoints.len());
     let mut total_headroom: Option<u64> = Some(0);
 
     for acct in &state.accounts {
-        let info = acct.rate_info.read().await;
-        let (br_5m, br_1h, br_6h) = acct
-            .burn_rate
-            .lock()
-            .map(|br| (br.rate_5m.value, br.rate_1h.value, br.rate_6h.value))
-            .unwrap_or((0.0, 0.0, 0.0));
-
-        let headroom: Option<u64> = if let Some(rem) = info.remaining_requests {
-            Some(rem)
-        } else if let (Some(util), Some(limit)) = (info.utilization, info.limit_requests) {
-            Some(((1.0 - util) * limit as f64).max(0.0) as u64)
-        } else {
-            None
-        };
-        match (total_headroom.as_mut(), headroom) {
-            (Some(total), Some(h)) => *total += h,
-            _ => total_headroom = None,
-        }
-
-        let hard_limited_secs = info
-            .hard_limited_until
-            .and_then(|until| until.checked_duration_since(Instant::now()))
-            .map(|d| d.as_secs() as f64)
-            .unwrap_or(0.0);
-        let hard_limited_active = info
-            .hard_limited_until
-            .is_some_and(|until| Instant::now() < until);
-        let stale_after_hard_limit = info
-            .hard_limited_until
-            .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
-
-        let (eff_util, _, _, _) = effective_utilization(&info, now_epoch, "");
-        let projected_throttle_secs = if eff_util < 0.5 || br_1h < 0.01 {
-            None
-        } else {
-            headroom.map(|h| {
-                if h == 0 {
-                    0.0
-                } else {
-                    (h as f64 / br_1h) * 60.0
-                }
-            })
-        };
-
-        let claims: Vec<ClaimMetricsSnap> = info
-            .claims_7d
-            .iter()
-            .map(|(k, d)| ClaimMetricsSnap {
-                key: k.clone(),
-                utilization: d.utilization,
-                waste_risk: waste_risk(d.utilization, d.reset, now_epoch),
-                reset: d.reset,
-                status: d.status.clone(),
-            })
-            .collect();
-
-        snaps.push(AcctMetricsSnap {
-            name: acct.name.clone(),
-            passthrough: acct.passthrough,
-            has_applicable_7d: !claims.is_empty()
-                || info.utilization_7d.is_some()
-                || info.reset_7d.is_some()
-                || info.status_7d.is_some(),
-            utilization: info.utilization,
-            utilization_5h: info.utilization_5h,
-            utilization_7d: info.utilization_7d,
-            reset_5h: info.reset_5h,
-            reset_7d: info.reset_7d,
-            status_5h: info.status_5h.clone(),
-            status_7d: info.status_7d.clone(),
-            stale_after_hard_limit,
-            hard_limited_active,
-            burn_rate: (br_5m, br_1h, br_6h),
-            headroom,
-            remaining_requests: info.remaining_requests,
-            remaining_tokens: info.remaining_tokens,
-            limit_requests: info.limit_requests,
-            limit_tokens: info.limit_tokens,
-            requests_total: acct.requests.load(Ordering::Relaxed),
-            hard_limited_secs,
-            projected_throttle_secs,
-            token_usage: [
-                acct.input_tokens.load(Ordering::Relaxed),
-                acct.output_tokens.load(Ordering::Relaxed),
-                acct.cache_creation_tokens.load(Ordering::Relaxed),
-                acct.cache_read_tokens.load(Ordering::Relaxed),
-            ],
-            claims,
-            last_updated_epoch: info.last_updated_epoch,
-            overage_in_use: info.overage_in_use,
-            overage_utilization: info.overage_utilization,
-        });
+        snaps.push(
+            build_metrics_snap(
+                &acct.name,
+                acct.passthrough,
+                &acct.rate_info,
+                &acct.burn_rate,
+                &acct.requests,
+                [
+                    &acct.input_tokens,
+                    &acct.output_tokens,
+                    &acct.cache_creation_tokens,
+                    &acct.cache_read_tokens,
+                ],
+                &acct.last_routing_weight,
+                &acct.last_routing_share,
+                &acct.last_effective_gate,
+                now_epoch,
+                &mut total_headroom,
+            )
+            .await,
+        );
+    }
+    // Parallel pass over the unified endpoint pool. In a real config exactly
+    // one pool is non-empty, so there are no label collisions. OpenAI
+    // endpoints have a stub RateLimitInfo — their gauges read as zero/None,
+    // which is the correct representation for a pool with no rate-limit data.
+    for ep in &state.endpoints {
+        snaps.push(
+            build_metrics_snap(
+                &ep.name,
+                ep.passthrough,
+                &ep.rate_info,
+                &ep.burn_rate,
+                &ep.requests,
+                [
+                    &ep.input_tokens,
+                    &ep.output_tokens,
+                    &ep.cache_creation_tokens,
+                    &ep.cache_read_tokens,
+                ],
+                &ep.last_routing_weight,
+                &ep.last_routing_share,
+                &ep.last_effective_gate,
+                now_epoch,
+                &mut total_headroom,
+            )
+            .await,
+        );
     }
 
     // Extract global maps once (single lock per map, then drop guard)
@@ -6511,30 +6638,28 @@ async fn metrics_handler(
         "Effective routing gate: max(time_adjusted_5h, time_adjusted_7d) with status floors",
     );
 
-    for (acct, s) in state.accounts.iter().zip(snaps.iter()) {
+    // Snap-carried gauges (captured at snap time) — covers both pools.
+    for s in &snaps {
         if s.passthrough {
             continue;
         }
-        let weight = f64::from_bits(acct.last_routing_weight.load(Ordering::Relaxed));
-        let share = f64::from_bits(acct.last_routing_share.load(Ordering::Relaxed));
-        let gate = f64::from_bits(acct.last_effective_gate.load(Ordering::Relaxed));
         prom_gauge(
             &mut buf,
             "anthropic_account_routing_weight",
             &[("account", &s.name)],
-            weight,
+            s.routing_weight,
         );
         prom_gauge(
             &mut buf,
             "anthropic_account_routing_share",
             &[("account", &s.name)],
-            share,
+            s.routing_share,
         );
         prom_gauge(
             &mut buf,
             "anthropic_account_effective_gate",
             &[("account", &s.name)],
-            gate,
+            s.effective_gate,
         );
     }
 
@@ -20058,6 +20183,72 @@ upstream = "https://api.anthropic.com"
             read_share(0),
             read_share(1)
         );
+    }
+
+    /// Unit: refresh_metrics_weights() also populates the unified endpoint
+    /// pool's gauge atomics. Anthropic endpoints get the headroom computation;
+    /// OpenAI endpoints get the fixed (gate 0.0, weight 1.0) representative.
+    #[tokio::test]
+    async fn refresh_metrics_weights_populates_endpoint_pool() {
+        fn anthropic_ep(name: &str) -> Endpoint {
+            Endpoint {
+                name: name.to_string(),
+                protocol: Protocol::Anthropic,
+                base_url: "https://api.anthropic.com".to_string(),
+                token: "sk-ant-api-test".to_string(),
+                passthrough: false,
+                models: vec![],
+                priority: 0,
+                requests: AtomicU64::new(0),
+                rate_info: RwLock::new(RateLimitInfo::default()),
+                burn_rate: Mutex::new(BurnRate::new()),
+                input_tokens: AtomicU64::new(0),
+                output_tokens: AtomicU64::new(0),
+                cache_creation_tokens: AtomicU64::new(0),
+                cache_read_tokens: AtomicU64::new(0),
+                last_routing_weight: AtomicU64::new(0),
+                last_routing_share: AtomicU64::new(0),
+                last_effective_gate: AtomicU64::new(0),
+            }
+        }
+        let mut openai_ep = anthropic_ep("oai");
+        openai_ep.protocol = Protocol::OpenAI;
+
+        let mut state = test_state_with(vec![]);
+        {
+            let st = Arc::get_mut(&mut state).unwrap();
+            st.endpoints.push(anthropic_ep("ep-a"));
+            st.endpoints.push(openai_ep);
+        }
+        let now = AppState::now_epoch();
+        {
+            let mut info = state.endpoints[0].rate_info.write().await;
+            info.utilization_5h = Some(0.20);
+            info.reset_5h = Some(now + 10000);
+            info.utilization = Some(0.20);
+        }
+
+        state.refresh_metrics_weights().await;
+
+        let weight = |i: usize| {
+            f64::from_bits(
+                state.endpoints[i]
+                    .last_routing_weight
+                    .load(Ordering::Relaxed),
+            )
+        };
+        let gate = |i: usize| {
+            f64::from_bits(
+                state.endpoints[i]
+                    .last_effective_gate
+                    .load(Ordering::Relaxed),
+            )
+        };
+        // Anthropic endpoint: positive weight from headroom computation.
+        assert!(weight(0) > 0.0, "anthropic endpoint should have weight");
+        // OpenAI endpoint: fixed representative — gate 0.0, non-zero weight.
+        assert_eq!(gate(1), 0.0, "openai endpoint gate must be the fixed 0.0");
+        assert!(weight(1) > 0.0, "openai endpoint should carry weight");
     }
 
     /// Regression: when SOME accounts are above soft_limit but at least one

--- a/src/main.rs
+++ b/src/main.rs
@@ -8697,14 +8697,15 @@ async fn main() {
         panic!("{msg}");
     }
 
-    // TRANSIENT GUARD (Phase 2a → Phase 2b): routing_candidates produces
-    // EndpointIdx::Unified(i) candidates for any populated [[endpoints]],
-    // but handler dispatch for that variant is not wired until Phase 2b.
-    // Selecting a Unified candidate would panic via `unreachable!()`. Refuse
-    // to start until dispatch lands. This block is deleted by Phase 2b.
+    // TRANSIENT GUARD (removed at the end of Phase 2c): handler dispatch for
+    // EndpointIdx::Unified is now wired in both handlers, but the unified pool
+    // is not yet covered by persistence (save/load_state), metrics, or Redis
+    // sync. Refuse to start with a populated [[endpoints]] config until those
+    // land, so the schema goes straight from "rejected" to "fully working"
+    // with no half-migrated window. This block is deleted by Phase 2c.
     if !config.endpoints.is_empty() {
         panic!(
-            "config: [[endpoints]] is declared ({} entries) but handler dispatch is not yet wired (Phase 2b incoming). Use [[accounts]] / [[upstreams]] for now.",
+            "config: [[endpoints]] is declared ({} entries) but the unified-pool migration is incomplete (persistence/metrics pending, Phase 2c). Use [[accounts]] / [[upstreams]] for now.",
             config.endpoints.len()
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4184,6 +4184,62 @@ enum ForwardOutcome {
     Retry { saw_529: bool, push_skip: bool },
 }
 
+/// Classify an upstream Anthropic response status into a retry decision.
+///
+/// Shared by both `forward_anthropic` and `forward_openai_compat_anthropic`,
+/// whose retry-classification logic is byte-identical. For 429 / 529 / other
+/// 5xx it records hard-limit state, persists, and logs exactly as the prior
+/// inline blocks did, returning `Err(ForwardOutcome::Retry { .. })`. For any
+/// non-retry status (2xx success or 4xx client error) it returns
+/// `Ok(resp)` — handing the response back so the caller can continue.
+async fn classify_retry_status(
+    state: &Arc<AppState>,
+    status: StatusCode,
+    rate_info: &RwLock<RateLimitInfo>,
+    endpoint_name: &str,
+    resp: reqwest::Response,
+) -> Result<reqwest::Response, ForwardOutcome> {
+    // 429 → mark hard-limited and try next account
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        state
+            .mark_hard_limited_for(rate_info, endpoint_name, resp.headers())
+            .await;
+        log_429_details(endpoint_name, resp).await;
+        state.save_state().await;
+        info!(account = endpoint_name, "got 429, rotating to next account");
+        return Err(ForwardOutcome::Retry {
+            saw_529: false,
+            push_skip: true,
+        });
+    }
+
+    // 529 → overloaded, try next account; flag for BEBO retry if all exhausted
+    if status.as_u16() == 529 {
+        state.save_state().await;
+        warn!(account = endpoint_name, "got 529, rotating to next account");
+        return Err(ForwardOutcome::Retry {
+            saw_529: true,
+            push_skip: true,
+        });
+    }
+
+    // Other 5xx → transient, try next account (no BEBO retry)
+    if status.is_server_error() {
+        state.save_state().await;
+        warn!(
+            account = endpoint_name,
+            status = status.as_u16(),
+            "got server error, rotating to next account"
+        );
+        return Err(ForwardOutcome::Retry {
+            saw_529: false,
+            push_skip: true,
+        });
+    }
+
+    Ok(resp)
+}
+
 /// Forward one Anthropic-protocol request to a single endpoint. Pool-agnostic:
 /// reusable for both `AppState.accounts` (legacy) and `AppState.endpoints`
 /// (unified) by passing the endpoint's identity, auth, and shared state in
@@ -4277,7 +4333,7 @@ async fn forward_anthropic(
     };
     upstream_req = upstream_req.body(req_body.clone());
 
-    let mut resp = match upstream_req.send().await {
+    let resp = match upstream_req.send().await {
         Ok(r) => r,
         Err(e) => {
             error!(account = endpoint_name, "upstream request failed: {e}");
@@ -4314,43 +4370,12 @@ async fn forward_anthropic(
     // Update burn rate (after rate-limit headers are parsed)
     state.update_burn_rate(burn_rate, client_id);
 
-    // 429 → mark hard-limited and try next account
-    if status == StatusCode::TOO_MANY_REQUESTS {
-        state
-            .mark_hard_limited_for(rate_info, endpoint_name, resp.headers())
-            .await;
-        log_429_details(endpoint_name, resp).await;
-        state.save_state().await;
-        info!(account = endpoint_name, "got 429, rotating to next account");
-        return ForwardOutcome::Retry {
-            saw_529: false,
-            push_skip: true,
-        };
-    }
-
-    // 529 → overloaded, try next account; flag for BEBO retry if all exhausted
-    if status.as_u16() == 529 {
-        state.save_state().await;
-        warn!(account = endpoint_name, "got 529, rotating to next account");
-        return ForwardOutcome::Retry {
-            saw_529: true,
-            push_skip: true,
-        };
-    }
-
-    // Other 5xx → transient, try next account (no BEBO retry)
-    if status.is_server_error() {
-        state.save_state().await;
-        warn!(
-            account = endpoint_name,
-            status = status.as_u16(),
-            "got server error, rotating to next account"
-        );
-        return ForwardOutcome::Retry {
-            saw_529: false,
-            push_skip: true,
-        };
-    }
+    // Classify 429 / 529 / other 5xx into a retry decision (shared helper).
+    let mut resp = match classify_retry_status(state, status, rate_info, endpoint_name, resp).await
+    {
+        Ok(resp) => resp,
+        Err(outcome) => return outcome,
+    };
 
     // Clear hard limit and burst counter only on a genuine 2xx success.
     // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
@@ -7953,7 +7978,7 @@ async fn forward_openai_compat_anthropic(
         .headers(headers)
         .body(body_str);
 
-    let mut resp = match upstream_req.send().await {
+    let resp = match upstream_req.send().await {
         Ok(r) => r,
         Err(e) => {
             error!(account = endpoint_name, "upstream request failed: {e}");
@@ -7975,42 +8000,12 @@ async fn forward_openai_compat_anthropic(
     // Update burn rate (after rate-limit headers are parsed)
     state.update_burn_rate(burn_rate, client_id);
 
-    if status == StatusCode::TOO_MANY_REQUESTS {
-        state
-            .mark_hard_limited_for(rate_info, endpoint_name, resp.headers())
-            .await;
-        log_429_details(endpoint_name, resp).await;
-        state.save_state().await;
-        info!(account = endpoint_name, "got 429, rotating to next account");
-        return ForwardOutcome::Retry {
-            saw_529: false,
-            push_skip: true,
-        };
-    }
-
-    // 529 → overloaded, try next account; flag for BEBO retry if all exhausted
-    if status.as_u16() == 529 {
-        state.save_state().await;
-        warn!(account = endpoint_name, "got 529, rotating to next account");
-        return ForwardOutcome::Retry {
-            saw_529: true,
-            push_skip: true,
-        };
-    }
-
-    // Other 5xx → transient, try next account (no BEBO retry)
-    if status.is_server_error() {
-        state.save_state().await;
-        warn!(
-            account = endpoint_name,
-            status = status.as_u16(),
-            "got server error, rotating to next account"
-        );
-        return ForwardOutcome::Retry {
-            saw_529: false,
-            push_skip: true,
-        };
-    }
+    // Classify 429 / 529 / other 5xx into a retry decision (shared helper).
+    let mut resp = match classify_retry_status(state, status, rate_info, endpoint_name, resp).await
+    {
+        Ok(resp) => resp,
+        Err(outcome) => return outcome,
+    };
 
     // Clear hard limit and burst counter only on a genuine 2xx success.
     // A 4xx (e.g. invalid_request_error, auth failure) is not evidence

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,6 @@ struct Config {
     /// OpenAI-compatible, distinguished by `protocol`. Replaces [[accounts]]
     /// + [[upstreams]] + fallback_upstream.
     #[serde(default)]
-    #[allow(dead_code)]
-    // Wired into routing in later phases of the unified-endpoints refactor.
     endpoints: Vec<EndpointConfig>,
     accounts: Vec<AccountConfig>,
     /// OpenAI-compatible upstream routes. Requests to /upstream/<name>/... are forwarded.
@@ -120,7 +118,6 @@ struct UpstreamConfig {
 }
 
 #[derive(Deserialize, Clone)]
-#[allow(dead_code)] // Wired into routing in later phases of the unified-endpoints refactor.
 struct EndpointConfig {
     name: String,
     /// Wire format. Default: anthropic (sends to api.anthropic.com via x-api-key).
@@ -503,7 +500,7 @@ struct Upstream {
 ///   1. `routing_candidates()` — short-circuits to a fixed RoutingCandidate.
 ///   2. `is_emergency_brake_active()` — iterates only Anthropic endpoints.
 ///   3. probe loop — skips OpenAI endpoints.
-#[allow(dead_code)]
+#[allow(dead_code)] // fields read by routing in Task 8 (next commit)
 struct Endpoint {
     name: String,
     protocol: Protocol,
@@ -527,7 +524,7 @@ struct Endpoint {
     last_effective_gate: AtomicU64,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // method used by routing_candidates in Task 8 (next commit)
 impl Endpoint {
     /// Check if this endpoint can serve the given model. Empty allowlist = all.
     /// Identical to the historical `Account::serves_model` predicate.
@@ -549,6 +546,11 @@ struct AppState {
     client: Client,
     upstream: String,
     accounts: Vec<Account>,
+    /// Unified endpoints. After Phase 4, this replaces `accounts` and `upstreams`.
+    /// During migration, both sets are populated so consumers can be migrated
+    /// one at a time.
+    #[allow(dead_code)] // read by routing_candidates in Task 8 (next commit)
+    endpoints: Vec<Endpoint>,
     robin: AtomicUsize,
     routing_strategy: RoutingStrategy,
     cooldown: Duration,
@@ -7866,6 +7868,53 @@ async fn main() {
         })
         .collect();
 
+    // Build the unified endpoint vector from the new [[endpoints]] config.
+    // During the migration, the old accounts/upstreams Vecs remain alongside.
+    let endpoints: Vec<Endpoint> = config
+        .endpoints
+        .iter()
+        .map(|ec| {
+            let passthrough = ec.token == "passthrough";
+            let base_url = match ec.protocol {
+                Protocol::Anthropic => ec
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.anthropic.com".to_string()),
+                Protocol::OpenAI => ec.base_url.clone().expect(
+                    "validate_endpoints should have rejected an openai endpoint without base_url",
+                ),
+            };
+            info!(
+                name = ec.name,
+                protocol = ?ec.protocol,
+                base_url = base_url.as_str(),
+                priority = ec.priority,
+                passthrough,
+                models = ?ec.models,
+                "loaded endpoint"
+            );
+            Endpoint {
+                name: ec.name.clone(),
+                protocol: ec.protocol,
+                base_url: base_url.trim_end_matches('/').to_string(),
+                token: ec.token.clone(),
+                passthrough,
+                models: ec.models.clone(),
+                priority: ec.priority,
+                requests: AtomicU64::new(0),
+                rate_info: RwLock::new(RateLimitInfo::default()),
+                burn_rate: Mutex::new(BurnRate::new()),
+                input_tokens: AtomicU64::new(0),
+                output_tokens: AtomicU64::new(0),
+                cache_creation_tokens: AtomicU64::new(0),
+                cache_read_tokens: AtomicU64::new(0),
+                last_routing_weight: AtomicU64::new(0),
+                last_routing_share: AtomicU64::new(0),
+                last_effective_gate: AtomicU64::new(0),
+            }
+        })
+        .collect();
+
     if config.proxy_key.is_some() {
         info!("proxy authentication enabled (x-api-key)");
     } else {
@@ -7981,6 +8030,7 @@ async fn main() {
             .expect("failed to build HTTP client"),
         upstream: config.upstream,
         accounts,
+        endpoints,
         robin: AtomicUsize::new(0),
         routing_strategy,
         cooldown,
@@ -8383,6 +8433,7 @@ token = "sk-ant-test"
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(), // unused in unit tests
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy,
             cooldown: Duration::from_secs(60),
@@ -8508,6 +8559,7 @@ token = "sk-ant-test"
                 .unwrap(),
             upstream: upstream_url.to_string(),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy,
             cooldown: Duration::from_secs(60),
@@ -8610,6 +8662,7 @@ token = "sk-ant-test"
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -10171,6 +10224,7 @@ token = "sk-ant-test"
                 .unwrap(),
             upstream: format!("http://{}", mock_addr),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -11420,6 +11474,7 @@ token = "sk-ant-test"
                 .unwrap(),
             upstream: upstream_url.to_string(),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -12098,6 +12153,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -12201,6 +12257,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -12711,6 +12768,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("acct-a", "sk-ant-api-test-aaa"),
                 make_account("acct-b", "sk-ant-api-test-bbb"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -12784,6 +12842,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("acct-a", "sk-ant-api-test-aaa"),
                 make_account("acct-b", "sk-ant-api-test-bbb"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -13544,6 +13603,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -13614,6 +13674,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14410,6 +14471,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("a", "sk-ant-api-x"),
                 make_account("b", "sk-ant-api-y"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14461,6 +14523,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("a", "sk-ant-api-x"),
                 make_account("b", "sk-ant-api-y"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14513,6 +14576,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("a", "sk-ant-api-x"),
                 make_account("b", "sk-ant-api-y"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14567,6 +14631,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14618,6 +14683,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![acct],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14671,6 +14737,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("a", "sk-ant-api-x"),
                 make_account("b", "sk-ant-api-y"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14728,6 +14795,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("b", "sk-ant-api-y"),
                 make_account("c", "sk-ant-api-z"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14805,6 +14873,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14884,6 +14953,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -14978,6 +15048,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("mystery", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15032,6 +15103,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("known", "sk-ant-api-a"),
                 make_account("unknown", "sk-ant-api-b"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15133,6 +15205,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15212,6 +15285,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15258,6 +15332,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15480,6 +15555,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: mock_url.clone(),
             accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15544,6 +15620,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: mock_url.clone(),
             accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15605,6 +15682,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("a", "sk-ant-api-test-aaa"),
                 make_account("b", "sk-ant-api-test-bbb"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15674,6 +15752,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 make_account("a", "sk-ant-api-test-aaa"),
                 make_account("b", "sk-ant-api-test-bbb"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15740,6 +15819,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: mock_url.clone(),
             accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15801,6 +15881,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: mock_url.clone(),
             accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15913,6 +15994,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             client: Client::new(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -15987,6 +16069,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             client: Client::new(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -16041,6 +16124,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             client: Client::new(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -16765,6 +16849,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             client: Client::new(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -16810,6 +16895,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             client: Client::new(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -16877,6 +16963,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -17021,6 +17108,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -17399,6 +17487,7 @@ upstream = "https://api.anthropic.com"
                 make_account("primary", "sk-ant-api-aaa"),
                 make_account("secondary", "sk-ant-api-bbb"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -17487,6 +17576,7 @@ upstream = "https://api.anthropic.com"
                 make_account("primary", "sk-ant-api-aaa"),
                 make_account("secondary", "sk-ant-api-bbb"),
             ],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -17575,6 +17665,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -17632,6 +17723,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("a", "sk-ant-api-x")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -18102,6 +18194,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: mock_url.clone(),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -18352,6 +18445,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -19371,6 +19465,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: format!("http://{}", mock_addr),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -19509,6 +19604,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: format!("http://{}", mock_addr),
             accounts,
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -19816,6 +19912,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(), // unused — accounts are hard-limited
             accounts: vec![make_account("acct-a", "sk-ant-api-a")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
@@ -19916,6 +20013,7 @@ upstream = "https://api.anthropic.com"
                 .unwrap(),
             upstream: "http://127.0.0.1:1".to_string(),
             accounts: vec![make_account("acct-a", "sk-ant-api-a")],
+            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,13 @@ struct Config {
     proxy_key: Option<String>,
     /// Source IP allowlist. Supports individual IPs and CIDR ranges. None/empty = allow all.
     allowed_ips: Option<Vec<String>>,
+    /// Unified routing endpoints. Each entry is either Anthropic-native or
+    /// OpenAI-compatible, distinguished by `protocol`. Replaces [[accounts]]
+    /// + [[upstreams]] + fallback_upstream.
+    #[serde(default)]
+    #[allow(dead_code)]
+    // Wired into routing in later phases of the unified-endpoints refactor.
+    endpoints: Vec<EndpointConfig>,
     accounts: Vec<AccountConfig>,
     /// OpenAI-compatible upstream routes. Requests to /upstream/<name>/... are forwarded.
     #[serde(default)]
@@ -112,14 +119,29 @@ struct UpstreamConfig {
     priority: u32,
 }
 
+#[derive(Deserialize, Clone)]
+#[allow(dead_code)] // Wired into routing in later phases of the unified-endpoints refactor.
+struct EndpointConfig {
+    name: String,
+    /// Wire format. Default: anthropic (sends to api.anthropic.com via x-api-key).
+    #[serde(default)]
+    protocol: Protocol,
+    /// Override base URL. For protocol = anthropic, defaults to https://api.anthropic.com.
+    /// For protocol = openai, this field is required (validated at startup).
+    base_url: Option<String>,
+    /// Auth credential. "passthrough" (anthropic only) forwards caller's auth headers.
+    token: String,
+    /// Model allowlist (supports "*" suffix wildcards). Empty = all models.
+    #[serde(default)]
+    models: Vec<String>,
+    /// Priority tier (0 = highest). Lower tiers tried first.
+    #[serde(default)]
+    priority: u32,
+}
+
 /// Wire format on config / state: "anthropic" | "openai".
-///
-/// `#[allow(dead_code)]` is transient: removed when Task 2 of the
-/// unified-endpoints plan adds `EndpointConfig` which references this enum
-/// from non-test code.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
-#[allow(dead_code)]
 enum Protocol {
     #[default]
     Anthropic,
@@ -7980,6 +8002,50 @@ mod tests {
     fn protocol_default_is_anthropic() {
         assert_eq!(Protocol::default(), Protocol::Anthropic);
         assert_ne!(Protocol::default(), Protocol::OpenAI);
+    }
+
+    #[test]
+    fn endpoint_config_parses_minimal_anthropic_block() {
+        let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+accounts = []
+
+[[endpoints]]
+name = "primary"
+token = "sk-ant-test"
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.endpoints.len(), 1);
+        assert_eq!(cfg.endpoints[0].name, "primary");
+        assert_eq!(cfg.endpoints[0].protocol, Protocol::Anthropic);
+        assert_eq!(cfg.endpoints[0].base_url, None);
+        assert_eq!(cfg.endpoints[0].token, "sk-ant-test");
+        assert!(cfg.endpoints[0].models.is_empty());
+        assert_eq!(cfg.endpoints[0].priority, 0);
+    }
+
+    #[test]
+    fn endpoint_config_parses_openai_with_base_url() {
+        let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+accounts = []
+
+[[endpoints]]
+name = "gateway"
+protocol = "openai"
+base_url = "https://gateway.example.com"
+token = "sk-test"
+priority = 100
+models = ["claude-opus-*"]
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        let ep = &cfg.endpoints[0];
+        assert_eq!(ep.protocol, Protocol::OpenAI);
+        assert_eq!(ep.base_url.as_deref(), Some("https://gateway.example.com"));
+        assert_eq!(ep.priority, 100);
+        assert_eq!(ep.models, vec!["claude-opus-*".to_string()]);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -3543,6 +3543,27 @@ impl AppState {
             }
         }
 
+        // Unified endpoints — ONLY Protocol::Anthropic. OpenAI endpoints carry a
+        // stub RateLimitInfo (all None) which effective_utilization() resolves to
+        // (0.5, "unknown"); including them would force all_above = false and the
+        // brake could never fire. One of the three named `match protocol` sites.
+        if all_above {
+            for ep in &self.endpoints {
+                if ep.protocol != Protocol::Anthropic {
+                    continue;
+                }
+                let info = ep.rate_info.read().await;
+                let (util, source, _, _) = effective_utilization(&info, now_epoch, "");
+                if source != "unknown" {
+                    any_known = true;
+                }
+                if util < self.emergency_threshold {
+                    all_above = false;
+                    break;
+                }
+            }
+        }
+
         // Fail-open: if no account has real data, don't activate
         all_above && any_known
     }
@@ -14449,6 +14470,46 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert!(
             util0 >= DEFAULT_EMERGENCY_THRESHOLD,
             "util should be >= threshold: {util0}"
+        );
+    }
+
+    #[tokio::test]
+    async fn emergency_brake_fires_when_only_anthropic_above_threshold_with_openai_present() {
+        // 1 anthropic account at utilization 0.95, 1 openai endpoint with stub rate info.
+        // A naive "iterate all endpoints" version sees the openai stub at (0.5, "unknown")
+        // and forces all_above = false → brake never fires. The correct "skip OpenAI"
+        // version excludes it and the brake fires.
+        let acct = make_account("anthropic", "sk-ant");
+        {
+            let mut info = acct.rate_info.write().await;
+            info.utilization = Some(0.95);
+            info.utilization_5h = Some(0.95);
+        }
+        let mut state = test_state_with(vec![acct]);
+        let st = Arc::get_mut(&mut state).expect("uniquely owned");
+        st.endpoints.push(Endpoint {
+            name: "openai".to_string(),
+            protocol: Protocol::OpenAI,
+            base_url: "https://gateway.example".to_string(),
+            token: "sk".to_string(),
+            passthrough: false,
+            models: vec![],
+            priority: 100,
+            requests: AtomicU64::new(0),
+            rate_info: RwLock::new(RateLimitInfo::default()),
+            burn_rate: Mutex::new(BurnRate::new()),
+            input_tokens: AtomicU64::new(0),
+            output_tokens: AtomicU64::new(0),
+            cache_creation_tokens: AtomicU64::new(0),
+            cache_read_tokens: AtomicU64::new(0),
+            last_routing_weight: AtomicU64::new(0),
+            last_routing_share: AtomicU64::new(0),
+            last_effective_gate: AtomicU64::new(0),
+        });
+        st.emergency_threshold = 0.88;
+        assert!(
+            state.is_emergency_brake_active().await,
+            "brake must fire: anthropic is above threshold; openai must not vote"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,6 +493,58 @@ struct Upstream {
     requests: AtomicU64,
 }
 
+/// Unified routing endpoint. Replaces the separate `Account` and `Upstream`
+/// runtime structs (which remain temporarily during the migration). After
+/// Phase 4 cleanup, only this struct survives.
+///
+/// Rate-limit/utilization fields are populated only for `Protocol::Anthropic`.
+/// `Protocol::OpenAI` endpoints carry a stub `RateLimitInfo` (all fields None);
+/// three code sites branch on `protocol` to handle this correctly:
+///   1. `routing_candidates()` — short-circuits to a fixed RoutingCandidate.
+///   2. `is_emergency_brake_active()` — iterates only Anthropic endpoints.
+///   3. probe loop — skips OpenAI endpoints.
+#[allow(dead_code)]
+struct Endpoint {
+    name: String,
+    protocol: Protocol,
+    /// Resolved at startup: api.anthropic.com for Anthropic default, else the
+    /// explicit base_url. No trailing slash.
+    base_url: String,
+    token: String,
+    /// True iff token == "passthrough". Only meaningful for Protocol::Anthropic.
+    passthrough: bool,
+    models: Vec<String>,
+    priority: u32,
+    requests: AtomicU64,
+    rate_info: RwLock<RateLimitInfo>,
+    burn_rate: Mutex<BurnRate>,
+    input_tokens: AtomicU64,
+    output_tokens: AtomicU64,
+    cache_creation_tokens: AtomicU64,
+    cache_read_tokens: AtomicU64,
+    last_routing_weight: AtomicU64,
+    last_routing_share: AtomicU64,
+    last_effective_gate: AtomicU64,
+}
+
+#[allow(dead_code)]
+impl Endpoint {
+    /// Check if this endpoint can serve the given model. Empty allowlist = all.
+    /// Identical to the historical `Account::serves_model` predicate.
+    fn serves_model(&self, model: &str) -> bool {
+        if self.models.is_empty() || model.is_empty() {
+            return true;
+        }
+        self.models.iter().any(|pattern| {
+            if let Some(prefix) = pattern.strip_suffix('*') {
+                model.starts_with(prefix)
+            } else {
+                model == pattern
+            }
+        })
+    }
+}
+
 struct AppState {
     client: Client,
     upstream: String,
@@ -563,29 +615,31 @@ impl Account {
     }
 }
 
-/// A routable endpoint: an Anthropic account or the fallback OpenAI-compatible upstream.
-/// Accounts and the fallback upstream share one priority space so routing order is
-/// decided entirely by tier numbers.
+/// Index into one of the runtime endpoint pools. After Phase 4 cleanup this
+/// collapses to a bare `usize`. Kept as an enum during the migration so
+/// `Account`/`Upstream` consumers and the new `Endpoint` consumer can coexist.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Endpoint {
+enum EndpointIdx {
     Account(usize),
     Upstream(usize),
+    /// Index into AppState.endpoints (new unified pool).
+    #[allow(dead_code)] // constructed by routing_candidates in Task 8
+    Unified(usize),
 }
 
-impl Endpoint {
-    /// The account index, or None if this is an upstream.
+impl EndpointIdx {
     #[cfg(test)]
     fn account(self) -> Option<usize> {
         match self {
-            Endpoint::Account(i) => Some(i),
-            Endpoint::Upstream(_) => None,
+            EndpointIdx::Account(i) => Some(i),
+            _ => None,
         }
     }
 }
 
 #[derive(Clone, Copy, Debug)]
 struct RoutingCandidate {
-    endpoint: Endpoint,
+    endpoint: EndpointIdx,
     /// Effective priority tier — includes the overage penalty when applicable.
     priority: u32,
     gate_5h: f64,
@@ -1617,19 +1671,23 @@ fn classify_hard_limit_sync(
 
 impl AppState {
     /// Display name for an endpoint (account or upstream), for logging.
-    fn endpoint_name(&self, ep: Endpoint) -> &str {
+    fn endpoint_name(&self, ep: EndpointIdx) -> &str {
         match ep {
-            Endpoint::Account(i) => &self.accounts[i].name,
-            Endpoint::Upstream(i) => &self.upstreams[i].name,
+            EndpointIdx::Account(i) => &self.accounts[i].name,
+            EndpointIdx::Upstream(i) => &self.upstreams[i].name,
+            // Phase 2: AppState.endpoints not yet wired. Filled in Task 7.
+            EndpointIdx::Unified(_) => {
+                unreachable!("EndpointIdx::Unified constructed before AppState.endpoints exists")
+            }
         }
     }
 
-    async fn routing_candidates(&self, model: &str, skip: &[Endpoint]) -> Vec<RoutingCandidate> {
+    async fn routing_candidates(&self, model: &str, skip: &[EndpointIdx]) -> Vec<RoutingCandidate> {
         let now = Instant::now();
         let now_epoch = Self::now_epoch();
         let mut candidates: Vec<RoutingCandidate> = Vec::new();
         for (i, acct) in self.accounts.iter().enumerate() {
-            if skip.contains(&Endpoint::Account(i)) {
+            if skip.contains(&EndpointIdx::Account(i)) {
                 trace!(account = acct.name, "pick: skipping, already tried");
                 continue;
             }
@@ -1698,7 +1756,7 @@ impl AppState {
             );
 
             candidates.push(RoutingCandidate {
-                endpoint: Endpoint::Account(i),
+                endpoint: EndpointIdx::Account(i),
                 priority: effective_priority,
                 gate_5h: rw.gate_5h,
                 gate_7d: rw.gate_7d,
@@ -1712,7 +1770,7 @@ impl AppState {
         // The fallback upstream is a first-class routing candidate at its configured
         // priority. It has no rate-limit data: gate 0 (always "healthy"), weight 1.
         if let Some(u_idx) = self.fallback_upstream {
-            if !skip.contains(&Endpoint::Upstream(u_idx)) {
+            if !skip.contains(&EndpointIdx::Upstream(u_idx)) {
                 let upstream = &self.upstreams[u_idx];
                 trace!(
                     upstream = upstream.name,
@@ -1720,7 +1778,7 @@ impl AppState {
                     "pick: candidate (upstream)"
                 );
                 candidates.push(RoutingCandidate {
-                    endpoint: Endpoint::Upstream(u_idx),
+                    endpoint: EndpointIdx::Upstream(u_idx),
                     priority: upstream.priority,
                     gate_5h: 0.0,
                     gate_7d: 0.0,
@@ -2112,7 +2170,7 @@ impl AppState {
         total_weight: f64,
         affinity_key: Option<&str>,
         tier: u32,
-    ) -> Endpoint {
+    ) -> EndpointIdx {
         let picked = match self.routing_strategy {
             RoutingStrategy::DynamicCapacityV1 => {
                 self.pick_dynamic_capacity_v1(effective, total_weight, affinity_key)
@@ -2153,8 +2211,8 @@ impl AppState {
         &self,
         affinity_key: Option<&str>,
         model: &str,
-        skip: &[Endpoint],
-    ) -> Option<Endpoint> {
+        skip: &[EndpointIdx],
+    ) -> Option<EndpointIdx> {
         let candidates = self.routing_candidates(model, skip).await;
         if candidates.is_empty() {
             debug!("pick: no available endpoints");
@@ -2213,7 +2271,7 @@ impl AppState {
         model: &str,
         skip: &[usize],
     ) -> Option<usize> {
-        let skip: Vec<Endpoint> = skip.iter().map(|&i| Endpoint::Account(i)).collect();
+        let skip: Vec<EndpointIdx> = skip.iter().map(|&i| EndpointIdx::Account(i)).collect();
         self.pick_endpoint(affinity_key, model, &skip)
             .await
             .and_then(|ep| ep.account())
@@ -3877,13 +3935,13 @@ async fn proxy_handler(
             );
             tokio::time::sleep(delay).await;
         }
-        let mut skip: Vec<Endpoint> = Vec::new();
+        let mut skip: Vec<EndpointIdx> = Vec::new();
         let mut saw_529 = false;
         // n accounts + 1 fallback upstream is the candidate ceiling.
         for _attempt in 0..(n + 1) {
             let idx = match state.pick_endpoint(affinity, &model, &skip).await {
-                Some(Endpoint::Account(i)) => i,
-                Some(Endpoint::Upstream(u)) => {
+                Some(EndpointIdx::Account(i)) => i,
+                Some(EndpointIdx::Upstream(u)) => {
                     // All account tiers exhausted — route through the fallback upstream.
                     match try_fallback_upstream(
                         &state,
@@ -3898,11 +3956,14 @@ async fn proxy_handler(
                     {
                         Some(resp) => return resp,
                         None => {
-                            skip.push(Endpoint::Upstream(u));
+                            skip.push(EndpointIdx::Upstream(u));
                             continue;
                         }
                     }
                 }
+                Some(EndpointIdx::Unified(_)) => unreachable!(
+                    "EndpointIdx::Unified constructed before routing_candidates wires it"
+                ),
                 None => {
                     warn!("all endpoints exhausted");
                     return (
@@ -4013,7 +4074,7 @@ async fn proxy_handler(
                 log_429_details(&acct.name, resp).await;
                 state.save_state().await;
                 info!(account = acct.name, "got 429, rotating to next account");
-                skip.push(Endpoint::Account(idx));
+                skip.push(EndpointIdx::Account(idx));
                 continue;
             }
 
@@ -4022,7 +4083,7 @@ async fn proxy_handler(
                 state.save_state().await;
                 warn!(account = acct.name, "got 529, rotating to next account");
                 saw_529 = true;
-                skip.push(Endpoint::Account(idx));
+                skip.push(EndpointIdx::Account(idx));
                 continue;
             }
 
@@ -4034,7 +4095,7 @@ async fn proxy_handler(
                     status = status.as_u16(),
                     "got server error, rotating to next account"
                 );
-                skip.push(Endpoint::Account(idx));
+                skip.push(EndpointIdx::Account(idx));
                 continue;
             }
 
@@ -7141,13 +7202,13 @@ async fn openai_chat_handler(
             );
             tokio::time::sleep(delay).await;
         }
-        let mut skip: Vec<Endpoint> = Vec::new();
+        let mut skip: Vec<EndpointIdx> = Vec::new();
         let mut saw_529 = false;
         // n accounts + 1 fallback upstream is the candidate ceiling.
         for _attempt in 0..(n + 1) {
             let idx = match state.pick_endpoint(affinity, &model, &skip).await {
-                Some(Endpoint::Account(i)) => i,
-                Some(Endpoint::Upstream(u)) => {
+                Some(EndpointIdx::Account(i)) => i,
+                Some(EndpointIdx::Upstream(u)) => {
                     // All account tiers exhausted — the upstream is OpenAI-native,
                     // so forward the original request body without translation.
                     match try_fallback_upstream(
@@ -7163,11 +7224,14 @@ async fn openai_chat_handler(
                     {
                         Some(resp) => return resp,
                         None => {
-                            skip.push(Endpoint::Upstream(u));
+                            skip.push(EndpointIdx::Upstream(u));
                             continue;
                         }
                     }
                 }
+                Some(EndpointIdx::Unified(_)) => unreachable!(
+                    "EndpointIdx::Unified constructed before routing_candidates wires it"
+                ),
                 None => {
                     warn!("all endpoints exhausted");
                     return (
@@ -7237,7 +7301,7 @@ async fn openai_chat_handler(
                 log_429_details(&acct.name, resp).await;
                 state.save_state().await;
                 info!(account = acct.name, "got 429, rotating to next account");
-                skip.push(Endpoint::Account(idx));
+                skip.push(EndpointIdx::Account(idx));
                 continue;
             }
 
@@ -7246,7 +7310,7 @@ async fn openai_chat_handler(
                 state.save_state().await;
                 warn!(account = acct.name, "got 529, rotating to next account");
                 saw_529 = true;
-                skip.push(Endpoint::Account(idx));
+                skip.push(EndpointIdx::Account(idx));
                 continue;
             }
 
@@ -7258,7 +7322,7 @@ async fn openai_chat_handler(
                     status = status.as_u16(),
                     "got server error, rotating to next account"
                 );
-                skip.push(Endpoint::Account(idx));
+                skip.push(EndpointIdx::Account(idx));
                 continue;
             }
 
@@ -16678,7 +16742,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         for _ in 0..50 {
             assert_eq!(
                 state.pick_endpoint(None, "", &[]).await,
-                Some(Endpoint::Account(0)),
+                Some(EndpointIdx::Account(0)),
                 "healthy account beats the priority-100 upstream"
             );
         }
@@ -16690,7 +16754,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         }
         assert_eq!(
             state.pick_endpoint(None, "", &[]).await,
-            Some(Endpoint::Upstream(0)),
+            Some(EndpointIdx::Upstream(0)),
             "upstream selected once the account tier is exhausted"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7565,6 +7565,38 @@ async fn openai_chat_handler(
 
 // ── Main ────────────────────────────────────────────────────────────
 
+/// Reject removed config keys with explicit errors. Run after the raw TOML
+/// has been parsed to a `toml::Value`, before strongly-typed deserialization.
+///
+/// `serde` silently drops unknown keys by default; this gives the operator
+/// a clear migration message instead of a silent misconfiguration.
+#[allow(dead_code)] // Wired into main() in Task 4 of the unified-endpoints refactor.
+fn reject_legacy_config_keys(value: &toml::Value) -> Result<(), String> {
+    let table = match value.as_table() {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    if table.contains_key("accounts") {
+        return Err(
+            "config: [[accounts]] is no longer supported — use [[endpoints]] (see CLAUDE.md)"
+                .to_string(),
+        );
+    }
+    if table.contains_key("upstreams") {
+        return Err(
+            "config: [[upstreams]] is no longer supported — use [[endpoints]] with protocol = \"openai\" (see CLAUDE.md)"
+                .to_string(),
+        );
+    }
+    if table.contains_key("fallback_upstream") {
+        return Err(
+            "config: fallback_upstream is no longer supported — set a high priority on the OpenAI endpoint instead (see CLAUDE.md)"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() {
     // Parse config first so debug_log path is available for tracing setup
@@ -8046,6 +8078,72 @@ models = ["claude-opus-*"]
         assert_eq!(ep.base_url.as_deref(), Some("https://gateway.example.com"));
         assert_eq!(ep.priority, 100);
         assert_eq!(ep.models, vec!["claude-opus-*".to_string()]);
+    }
+
+    #[test]
+    fn config_rejects_legacy_accounts_block() {
+        let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[accounts]]
+name = "primary"
+token = "sk-ant-test"
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let err = reject_legacy_config_keys(&value).unwrap_err();
+        assert!(
+            err.contains("accounts"),
+            "error must name 'accounts': {err}"
+        );
+        assert!(
+            err.contains("endpoints"),
+            "error must mention replacement: {err}"
+        );
+    }
+
+    #[test]
+    fn config_rejects_legacy_upstreams_block() {
+        let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[upstreams]]
+name = "fallback"
+base_url = "https://example.com"
+api_key = "key"
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let err = reject_legacy_config_keys(&value).unwrap_err();
+        assert!(err.contains("upstreams"));
+        assert!(err.contains("endpoints"));
+    }
+
+    #[test]
+    fn config_rejects_fallback_upstream_key() {
+        let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+fallback_upstream = "anything"
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let err = reject_legacy_config_keys(&value).unwrap_err();
+        assert!(err.contains("fallback_upstream"));
+        assert!(err.contains("priority"));
+    }
+
+    #[test]
+    fn config_accepts_endpoints_only_schema() {
+        let toml_str = r#"
+listen = "0.0.0.0:8080"
+upstream = "https://api.anthropic.com"
+
+[[endpoints]]
+name = "primary"
+token = "sk-ant-test"
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        assert!(reject_legacy_config_keys(&value).is_ok());
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -8955,19 +8955,6 @@ async fn main() {
         panic!("{msg}");
     }
 
-    // TRANSIENT GUARD (removed at the end of Phase 2c): handler dispatch for
-    // EndpointIdx::Unified is now wired in both handlers, but the unified pool
-    // is not yet covered by persistence (save/load_state), metrics, or Redis
-    // sync. Refuse to start with a populated [[endpoints]] config until those
-    // land, so the schema goes straight from "rejected" to "fully working"
-    // with no half-migrated window. This block is deleted by Phase 2c.
-    if !config.endpoints.is_empty() {
-        panic!(
-            "config: [[endpoints]] is declared ({} entries) but the unified-pool migration is incomplete (persistence/metrics pending, Phase 2c). Use [[accounts]] / [[upstreams]] for now.",
-            config.endpoints.len()
-        );
-    }
-
     // Set up tracing: stderr (info+) always, plus optional debug log file
     {
         use tracing_subscriber::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1008,7 +1008,7 @@ impl AppState {
                     // immediately so the dashboard reflects the account coming
                     // back online without waiting for the next probe cycle.
                     if recovered {
-                        self.signal_hard_limit_recovery(acct).await;
+                        self.signal_hard_limit_recovery(&acct.name).await;
                     }
                 }
                 // else: 5xx/529 — leave account state untouched. Next probe cycle retries.
@@ -1068,6 +1068,184 @@ impl AppState {
             }
             Err(e) => {
                 warn!(account = acct.name, error = %e, "probe failed");
+            }
+        }
+    }
+
+    /// Probe a unified-pool endpoint by index to refresh rate-limit headers.
+    /// Skips `Protocol::OpenAI` endpoints — they expose no Anthropic rate-limit
+    /// headers, so a probe would only burn a request. One of the three named
+    /// `match protocol` sites. Mirrors `probe_account`; Phase 4 collapses the
+    /// two once the legacy Account pool is retired.
+    async fn probe_endpoint_unified(&self, idx: usize, model: &str) {
+        let ep = &self.endpoints[idx];
+        if ep.protocol == Protocol::OpenAI {
+            debug!(endpoint = ep.name, "skipping probe for openai endpoint");
+            return;
+        }
+        if ep.passthrough {
+            debug!(
+                endpoint = ep.name,
+                "skipping probe for passthrough endpoint"
+            );
+            return;
+        }
+
+        // Check if hard-limited — don't waste a request
+        {
+            let info = ep.rate_info.read().await;
+            if let Some(until) = info.hard_limited_until {
+                if Instant::now() < until {
+                    debug!(
+                        endpoint = ep.name,
+                        "skipping probe, endpoint is hard-limited"
+                    );
+                    return;
+                }
+            }
+        }
+
+        // Local freshness check: skip if this model's 7d claim was recently
+        // refreshed. Looks up only the model-specific claim key so probing one
+        // family doesn't block another.
+        let now_epoch = Self::now_epoch();
+        {
+            let info = ep.rate_info.read().await;
+            let family = model_family(model);
+            if !family.is_empty() {
+                let claim_key = format!("seven_day_{}", family);
+                if let Some(claim) = info.claims_7d.get(&claim_key) {
+                    let age = now_epoch.saturating_sub(claim.last_seen);
+                    if age < self.probe_interval_secs / 2 {
+                        trace!(
+                            endpoint = ep.name,
+                            probe_model = model,
+                            claim_key,
+                            age_secs = age,
+                            "probe skipped, model claim is fresh"
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Distributed probe lock: one pod per endpoint+model per interval.
+        if let Some(redis) = &self.redis {
+            let mut conn = redis.clone();
+            let lock_key = format!("alb:probe:{}:{}", ep.name, model);
+            let lock_ttl = self.probe_interval_secs.max(1);
+            let acquired: redis::RedisResult<bool> = redis::cmd("SET")
+                .arg(&lock_key)
+                .arg(1u8)
+                .arg("NX")
+                .arg("EX")
+                .arg(lock_ttl)
+                .query_async(&mut conn)
+                .await;
+            match acquired {
+                Ok(true) => {} // Lock acquired, proceed with probe
+                Ok(false) => {
+                    trace!(
+                        endpoint = ep.name,
+                        probe_model = model,
+                        "probe skipped, another replica is probing"
+                    );
+                    return;
+                }
+                Err(e) => {
+                    // Fail-open: if Redis is down, probe anyway
+                    trace!(endpoint = ep.name, error = %e, "probe lock failed, probing anyway");
+                }
+            }
+        }
+
+        // The unified Endpoint carries its own base URL (the Account pool used
+        // the global self.upstream).
+        let url = format!("{}/v1/messages", ep.base_url);
+        let body = serde_json::json!({
+            "model": model,
+            "max_tokens": 1,
+            "system": [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."}],
+            "messages": [{"role": "user", "content": "."}]
+        });
+
+        let mut req = self
+            .client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("anthropic-version", "2023-06-01")
+            .header("anthropic-beta", OAUTH_BETA_FLAGS.join(","))
+            .header("user-agent", "claude-cli/2.1.2 (external, cli)")
+            .header("x-app", "cli")
+            .header("anthropic-dangerous-direct-browser-access", "true")
+            .json(&body);
+
+        // Inject auth
+        if ep.token.starts_with("sk-ant-api") {
+            req = req.header("x-api-key", &ep.token);
+        } else if ep.token.starts_with("sk-ant-oat") {
+            req = req.header("authorization", format!("Bearer {}", ep.token));
+        } else {
+            req = req.header("x-api-key", &ep.token);
+        }
+
+        match req.send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                self.update_rate_info_for(&ep.rate_info, &ep.name, resp.headers())
+                    .await;
+                if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    self.mark_hard_limited_for(&ep.rate_info, &ep.name, resp.headers())
+                        .await;
+                } else if status.is_success() {
+                    // 2xx only: endpoint is responsive — clear hard limit and
+                    // burst counter. 5xx/529 are upstream errors, not recovery.
+                    let recovered = {
+                        let mut info = ep.rate_info.write().await;
+                        let was_hard_limited = info.hard_limited_until.is_some();
+                        if was_hard_limited {
+                            info.hard_limited_until = None;
+                            debug!(
+                                endpoint = ep.name,
+                                "cleared hard limit after successful probe"
+                            );
+                        }
+                        info.consecutive_burst_429s = 0;
+                        was_hard_limited
+                    };
+                    if recovered {
+                        self.signal_hard_limit_recovery(&ep.name).await;
+                    }
+                }
+                // else: 5xx/529 — leave endpoint state untouched.
+                self.save_state().await;
+                let info = ep.rate_info.read().await;
+                let now_epoch = Self::now_epoch();
+                let (eff_util, constraint, _adj_5h, _adj_7d) =
+                    effective_utilization(&info, now_epoch, model);
+                info!(
+                    endpoint = ep.name,
+                    status = status.as_u16(),
+                    probe_model = model,
+                    utilization = format_args!("{eff_util:.2}"),
+                    util_5h = info
+                        .utilization_5h
+                        .map(|v| format!("{v:.2}"))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    util_7d = info
+                        .utilization_7d
+                        .map(|v| format!("{v:.2}"))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    constraint,
+                    n_claims_7d = info.claims_7d.len(),
+                    "probe complete"
+                );
+            }
+            Err(e) => {
+                warn!(endpoint = ep.name, error = %e, "probe failed");
             }
         }
     }
@@ -2112,10 +2290,13 @@ impl AppState {
     ///
     /// Also refreshes metric gauges and publishes updated routing weights so all
     /// replicas reflect the recovery within the next sync tick.
-    async fn signal_hard_limit_recovery(&self, acct: &Account) {
+    /// Broadcast a hard-limit recovery for an endpoint by name. Pool-agnostic:
+    /// the Redis sentinel key is derived from the name alone, so this serves
+    /// both the legacy Account pool and the unified Endpoint pool.
+    async fn signal_hard_limit_recovery(&self, endpoint_name: &str) {
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
-            let key = format!("alb:hard:{}", acct.name);
+            let key = format!("alb:hard:{}", endpoint_name);
             let now_epoch = Self::now_epoch();
             // Lua CAS: only write the sentinel if the current value is absent,
             // already the sentinel, or an expired hard-limit (epoch <= now).
@@ -2366,7 +2547,20 @@ impl AppState {
     /// Update rate limit info from response headers.
     async fn update_rate_info(&self, idx: usize, headers: &reqwest::header::HeaderMap) {
         let acct = &self.accounts[idx];
-        let mut info = acct.rate_info.write().await;
+        self.update_rate_info_for(&acct.rate_info, &acct.name, headers)
+            .await;
+    }
+
+    /// Pool-agnostic core of `update_rate_info`: parses rate-limit headers into
+    /// the supplied `RateLimitInfo` lock. Shared by the legacy Account pool and
+    /// the unified Endpoint pool (`probe_endpoint_unified`).
+    async fn update_rate_info_for(
+        &self,
+        rate_info: &RwLock<RateLimitInfo>,
+        endpoint_name: &str,
+        headers: &reqwest::header::HeaderMap,
+    ) {
+        let mut info = rate_info.write().await;
 
         // Debug: log all ratelimit headers
         for (name, value) in headers.iter() {
@@ -2374,7 +2568,7 @@ impl AppState {
             if name_str.contains("ratelimit") || name_str.contains("retry") {
                 if let Ok(v) = value.to_str() {
                     tracing::trace!(
-                        account = acct.name,
+                        account = endpoint_name,
                         header = name_str,
                         value = v,
                         "rate-limit header"
@@ -2612,7 +2806,7 @@ impl AppState {
         }
 
         trace!(
-            account = acct.name,
+            account = endpoint_name,
             utilization = ?info.utilization,
             util_7d = ?info.utilization_7d,
             util_5h = ?info.utilization_5h,
@@ -2661,7 +2855,7 @@ impl AppState {
                 .unwrap_or(3600); // default 1h if no reset known
 
             let mut conn = redis.clone();
-            let key = format!("alb:rate:{}", acct.name);
+            let key = format!("alb:rate:{}", endpoint_name);
             tokio::spawn(async move {
                 if let Ok(json) = serde_json::to_string(&rate_data) {
                     use redis::AsyncCommands;
@@ -2677,7 +2871,20 @@ impl AppState {
     /// Mark an account as hard rate-limited (got a 429).
     async fn mark_hard_limited(&self, idx: usize, headers: &reqwest::header::HeaderMap) {
         let acct = &self.accounts[idx];
-        let mut info = acct.rate_info.write().await;
+        self.mark_hard_limited_for(&acct.rate_info, &acct.name, headers)
+            .await;
+    }
+
+    /// Pool-agnostic core of `mark_hard_limited`: applies a 429 cooldown to the
+    /// supplied `RateLimitInfo` lock. Shared by the legacy Account pool and the
+    /// unified Endpoint pool (`probe_endpoint_unified`).
+    async fn mark_hard_limited_for(
+        &self,
+        rate_info: &RwLock<RateLimitInfo>,
+        endpoint_name: &str,
+        headers: &reqwest::header::HeaderMap,
+    ) {
+        let mut info = rate_info.write().await;
 
         let raw_retry_after = headers
             .get("retry-after")
@@ -2739,7 +2946,7 @@ impl AppState {
         info.last_updated_epoch = Some(Self::now_epoch());
 
         warn!(
-            account = acct.name,
+            account = endpoint_name,
             cooldown_secs = cooldown.as_secs(),
             retry_after_raw = ?raw_retry_after,
             burst = is_burst_limit,
@@ -2750,7 +2957,7 @@ impl AppState {
         // Propagate to Redis for cross-replica awareness
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
-            let key = format!("alb:hard:{}", acct.name);
+            let key = format!("alb:hard:{}", endpoint_name);
             let until_epoch = Self::now_epoch()
                 + cooldown.as_secs()
                 + if cooldown.subsec_nanos() > 0 { 1 } else { 0 };
@@ -4225,7 +4432,7 @@ async fn proxy_handler(
             state.save_state().await;
 
             if recovered {
-                state.signal_hard_limit_recovery(acct).await;
+                state.signal_hard_limit_recovery(&acct.name).await;
             }
 
             // Log with capacity info + inject budget status header
@@ -7452,7 +7659,7 @@ async fn openai_chat_handler(
             state.save_state().await;
 
             if recovered {
-                state.signal_hard_limit_recovery(acct).await;
+                state.signal_hard_limit_recovery(&acct.name).await;
             }
 
             // Compute budget pressure status for response header + log
@@ -8266,6 +8473,36 @@ async fn main() {
                 metrics_state.refresh_metrics_weights().await;
                 metrics_state.publish_routing_weights().await;
                 tokio::time::sleep(FALLBACK_INTERVAL).await;
+            }
+        });
+    }
+
+    // Probe loop for the unified endpoint pool. Mirrors the account probe loop;
+    // probe_endpoint_unified internally skips OpenAI endpoints. Metrics weight
+    // refresh stays on the account loop — the unified pool's metrics migration
+    // is a later task.
+    let n_endpoints = state.endpoints.len();
+    if probe_interval > 0 && n_endpoints > 0 {
+        let probe_state = state.clone();
+        tokio::spawn(async move {
+            const PROBE_MODELS: &[&str] =
+                &["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"];
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            info!(
+                interval_secs = probe_interval,
+                "starting unified endpoint utilization probes"
+            );
+            loop {
+                for i in 0..n_endpoints {
+                    let ep = &probe_state.endpoints[i];
+                    for model in PROBE_MODELS {
+                        if ep.serves_model(model) {
+                            probe_state.probe_endpoint_unified(i, model).await;
+                            tokio::time::sleep(Duration::from_secs(2)).await;
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(probe_interval)).await;
             }
         });
     }
@@ -13611,7 +13848,9 @@ data: {\"type\":\"message_stop\"}\n\n";
         state.accounts[0]
             .last_routing_weight
             .store(0u64, Ordering::Relaxed);
-        state.signal_hard_limit_recovery(&state.accounts[0]).await;
+        state
+            .signal_hard_limit_recovery(&state.accounts[0].name)
+            .await;
         // refresh_metrics_weights always writes a value (even zero) — the point
         // is that the method completed without Redis and without panicking.
         let w = f64::from_bits(
@@ -14511,6 +14750,47 @@ data: {\"type\":\"message_stop\"}\n\n";
             state.is_emergency_brake_active().await,
             "brake must fire: anthropic is above threshold; openai must not vote"
         );
+    }
+
+    #[tokio::test]
+    async fn probe_endpoint_unified_skips_openai() {
+        // The mock upstream injects `5h-utilization: 0.25` headers. If the probe
+        // ran, `rate_info.utilization_5h` would become Some(0.25). The OpenAI
+        // skip means the endpoint is never contacted and rate_info stays None.
+        let (mock_url, _h) = spawn_mock_upstream().await;
+        let ep = Endpoint {
+            name: "openai".to_string(),
+            protocol: Protocol::OpenAI,
+            base_url: mock_url,
+            token: "sk-ant-api-test".to_string(),
+            passthrough: false,
+            models: vec![],
+            priority: 100,
+            requests: AtomicU64::new(0),
+            rate_info: RwLock::new(RateLimitInfo::default()),
+            burn_rate: Mutex::new(BurnRate::new()),
+            input_tokens: AtomicU64::new(0),
+            output_tokens: AtomicU64::new(0),
+            cache_creation_tokens: AtomicU64::new(0),
+            cache_read_tokens: AtomicU64::new(0),
+            last_routing_weight: AtomicU64::new(0),
+            last_routing_share: AtomicU64::new(0),
+            last_effective_gate: AtomicU64::new(0),
+        };
+        let mut state = test_state_with(vec![]);
+        Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
+
+        state.probe_endpoint_unified(0, "claude-haiku-4-5").await;
+
+        // rate_info must be untouched: the OpenAI endpoint was skipped, no HTTP
+        // call was made. A naive "probe all endpoints" version would have hit
+        // the mock and set utilization_5h to Some(0.25).
+        let info = state.endpoints[0].rate_info.read().await;
+        assert!(
+            info.utilization_5h.is_none(),
+            "probe must short-circuit for OpenAI endpoints — rate_info must stay untouched"
+        );
+        assert_eq!(state.endpoints[0].requests.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13578,6 +13578,20 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(c.gate, 0.0);
     }
 
+    #[tokio::test]
+    async fn openai_endpoint_with_opus_only_allowlist_excludes_sonnet() {
+        let mut state = test_state_with(vec![]);
+        let st = Arc::get_mut(&mut state).unwrap();
+        let mut ep = make_endpoint("opus-gw", Protocol::OpenAI);
+        ep.models = vec!["claude-opus-*".to_string()];
+        st.endpoints.push(ep);
+
+        let cs_opus = state.routing_candidates("claude-opus-4-7", &[]).await;
+        let cs_sonnet = state.routing_candidates("claude-sonnet-4-6", &[]).await;
+        assert_eq!(cs_opus.len(), 1, "opus must hit the opus-only endpoint");
+        assert_eq!(cs_sonnet.len(), 0, "sonnet must be filtered out");
+    }
+
     // ── Unit: per-client budget ────────────────────────────────────
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -867,6 +867,33 @@ impl AppState {
         }
     }
 
+    /// True if `model`'s 7d claim was refreshed recently enough to skip a probe.
+    ///
+    /// Pure freshness check shared by `probe_account` and `probe_endpoint_unified`.
+    /// Looks up only the model-specific claim key (e.g. `seven_day_opus`), NOT the
+    /// general `seven_day` fallback, so probing one family doesn't suppress another.
+    /// An empty `model_family` (unrecognized model) never counts as fresh.
+    /// "Recent" means the claim's age is under half the probe interval.
+    fn claim_recently_probed(
+        info: &RateLimitInfo,
+        model: &str,
+        probe_interval_secs: u64,
+        now_epoch: u64,
+    ) -> bool {
+        let family = model_family(model);
+        if family.is_empty() {
+            return false;
+        }
+        let claim_key = format!("seven_day_{}", family);
+        match info.claims_7d.get(&claim_key) {
+            Some(claim) => {
+                let age = now_epoch.saturating_sub(claim.last_seen);
+                age < probe_interval_secs / 2
+            }
+            None => false,
+        }
+    }
+
     /// Fire a minimal request (max_tokens=1) to refresh rate limit headers for an account.
     /// The `model` parameter controls which model is probed, rotating across families
     /// so that per-model 7d utilization claims get populated for each family.
@@ -895,27 +922,16 @@ impl AppState {
         }
 
         // Local freshness check: skip if this model's 7d claim was recently refreshed.
-        // Looks up only the model-specific claim key (e.g. "seven_day_opus"), NOT the
-        // general "seven_day" fallback, so probing one family doesn't block another.
         let now_epoch = Self::now_epoch();
         {
             let info = acct.rate_info.read().await;
-            let family = model_family(model);
-            if !family.is_empty() {
-                let claim_key = format!("seven_day_{}", family);
-                if let Some(claim) = info.claims_7d.get(&claim_key) {
-                    let age = now_epoch.saturating_sub(claim.last_seen);
-                    if age < self.probe_interval_secs / 2 {
-                        trace!(
-                            account = acct.name,
-                            probe_model = model,
-                            claim_key,
-                            age_secs = age,
-                            "probe skipped, model claim is fresh"
-                        );
-                        return;
-                    }
-                }
+            if Self::claim_recently_probed(&info, model, self.probe_interval_secs, now_epoch) {
+                trace!(
+                    account = acct.name,
+                    probe_model = model,
+                    "probe skipped, model claim is fresh"
+                );
+                return;
             }
         }
 
@@ -1105,31 +1121,21 @@ impl AppState {
             }
         }
 
-        // Local freshness check: skip if this model's 7d claim was recently
-        // refreshed. Looks up only the model-specific claim key so probing one
-        // family doesn't block another.
+        // Local freshness check: skip if this model's 7d claim was recently refreshed.
         let now_epoch = Self::now_epoch();
         {
             let info = ep.rate_info.read().await;
-            let family = model_family(model);
-            if !family.is_empty() {
-                let claim_key = format!("seven_day_{}", family);
-                if let Some(claim) = info.claims_7d.get(&claim_key) {
-                    let age = now_epoch.saturating_sub(claim.last_seen);
-                    if age < self.probe_interval_secs / 2 {
-                        trace!(
-                            endpoint = ep.name,
-                            probe_model = model,
-                            claim_key,
-                            age_secs = age,
-                            "probe skipped, model claim is fresh"
-                        );
-                        return;
-                    }
-                }
+            if Self::claim_recently_probed(&info, model, self.probe_interval_secs, now_epoch) {
+                trace!(
+                    endpoint = ep.name,
+                    probe_model = model,
+                    "probe skipped, model claim is fresh"
+                );
+                return;
             }
         }
 
+        // Phase 4: this Redis probe-lock block is duplicated from probe_account; the two probe functions collapse in Phase 4.
         // Distributed probe lock: one pod per endpoint+model per interval.
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
@@ -1170,25 +1176,28 @@ impl AppState {
             "messages": [{"role": "user", "content": "."}]
         });
 
-        let mut req = self
-            .client
-            .post(&url)
-            .header("content-type", "application/json")
-            .header("anthropic-version", "2023-06-01")
-            .header("anthropic-beta", OAUTH_BETA_FLAGS.join(","))
-            .header("user-agent", "claude-cli/2.1.2 (external, cli)")
-            .header("x-app", "cli")
-            .header("anthropic-dangerous-direct-browser-access", "true")
-            .json(&body);
+        // Build headers in a HeaderMap so auth injection can reuse the shared
+        // `inject_account_auth` (token-prefix dispatch + OAuth beta-flag merge)
+        // instead of a hand-rolled copy.
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+        headers.insert(
+            "anthropic-beta",
+            HeaderValue::from_str(&OAUTH_BETA_FLAGS.join(",")).unwrap(),
+        );
+        headers.insert(
+            "user-agent",
+            HeaderValue::from_static("claude-cli/2.1.2 (external, cli)"),
+        );
+        headers.insert("x-app", HeaderValue::from_static("cli"));
+        headers.insert(
+            "anthropic-dangerous-direct-browser-access",
+            HeaderValue::from_static("true"),
+        );
+        inject_account_auth(&mut headers, &ep.token, ep.passthrough);
 
-        // Inject auth
-        if ep.token.starts_with("sk-ant-api") {
-            req = req.header("x-api-key", &ep.token);
-        } else if ep.token.starts_with("sk-ant-oat") {
-            req = req.header("authorization", format!("Bearer {}", ep.token));
-        } else {
-            req = req.header("x-api-key", &ep.token);
-        }
+        let req = self.client.post(&url).headers(headers).json(&body);
 
         match req.send().await {
             Ok(resp) => {
@@ -1224,6 +1233,14 @@ impl AppState {
                 let now_epoch = Self::now_epoch();
                 let (eff_util, constraint, _adj_5h, _adj_7d) =
                     effective_utilization(&info, now_epoch, model);
+                // Only compute routing weight on 2xx — non-success responses leave
+                // the endpoint state either mutated (429 → hard-limited) or untouched
+                // (5xx), and the pre-response weight no longer reflects reality.
+                let rw = if status.is_success() {
+                    compute_routing_weight(&info, model, now_epoch, false)
+                } else {
+                    None
+                };
                 info!(
                     endpoint = ep.name,
                     status = status.as_u16(),
@@ -1241,6 +1258,27 @@ impl AppState {
                         .unwrap_or("-"),
                     constraint,
                     n_claims_7d = info.claims_7d.len(),
+                    gate_5h = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.gate_5h))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    gate_7d = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.gate_7d))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    waste_risk = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.wr))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    weight = rw
+                        .as_ref()
+                        .map(|r| format!("{:.4}", r.weight))
+                        .as_deref()
+                        .unwrap_or("-"),
+                    weight_source = rw.as_ref().map(|r| r.source).unwrap_or("-"),
                     "probe complete"
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3077,7 +3077,7 @@ fn log_usage(req_id: &str, client_id: &str, model: &str, account: &str, usage: &
 #[allow(clippy::too_many_arguments)]
 async fn finalize_stream(
     state: &AppState,
-    endpoint_idx: usize,
+    ep: &Endpoint,
     req_id: &str,
     client_id: &str,
     model: &str,
@@ -3096,7 +3096,7 @@ async fn finalize_stream(
     let usage = TokenUsage::from_sse_text(&text);
     let elapsed_ms = request_start.elapsed().as_millis() as u64;
     if !usage.is_empty() {
-        state.record_usage(endpoint_idx, client_id, &usage).await;
+        state.record_usage(ep, client_id, &usage).await;
         log_usage(req_id, client_id, model, acct_name, &usage);
     } else {
         let reason = if upstream_error {
@@ -3159,7 +3159,7 @@ async fn finalize_stream(
 #[allow(clippy::too_many_arguments)]
 async fn finalize_non_stream(
     state: &AppState,
-    endpoint_idx: usize,
+    ep: &Endpoint,
     req_id: &str,
     client_id: &str,
     model: &str,
@@ -3173,7 +3173,7 @@ async fn finalize_non_stream(
     openai_compat: bool,
 ) {
     if !usage.is_empty() {
-        state.record_usage(endpoint_idx, client_id, usage).await;
+        state.record_usage(ep, client_id, usage).await;
         log_usage(req_id, client_id, model, acct_name, usage);
     }
     let mut log = serde_json::json!({
@@ -3199,12 +3199,24 @@ async fn finalize_non_stream(
 }
 
 impl AppState {
+    /// Recover the index of an endpoint borrowed from `self.endpoints`.
+    ///
+    /// `pick_endpoint` hands callers an `&Endpoint`; a detached streaming task
+    /// (which owns only a cloned `Arc<AppState>`) cannot carry that borrow
+    /// across the `tokio::spawn` boundary, so it re-derives the endpoint by
+    /// index. `Vec` storage is contiguous, so the index is the pointer offset.
+    /// Caller contract: `ep` must point into `self.endpoints`.
+    fn endpoint_index(&self, ep: &Endpoint) -> usize {
+        let base = self.endpoints.as_ptr() as usize;
+        let here = ep as *const Endpoint as usize;
+        (here - base) / std::mem::size_of::<Endpoint>()
+    }
+
     /// Record token usage for an endpoint and client.
-    async fn record_usage(&self, endpoint_idx: usize, client_id: &str, usage: &TokenUsage) {
+    async fn record_usage(&self, ep: &Endpoint, client_id: &str, usage: &TokenUsage) {
         if usage.is_empty() {
             return;
         }
-        let ep = &self.endpoints[endpoint_idx];
         ep.input_tokens
             .fetch_add(usage.input_tokens, Ordering::Relaxed);
         ep.output_tokens
@@ -3848,7 +3860,6 @@ async fn forward_anthropic(
     body_bytes: &bytes::Bytes,
     oauth_body_bytes: &bytes::Bytes,
     ep: &Endpoint,
-    endpoint_idx: usize,
     req_id: &str,
     client_id: &str,
     client_ver: &str,
@@ -4045,6 +4056,9 @@ async fn forward_anthropic(
         // Streaming: tee the byte stream to accumulate SSE text for usage extraction
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
         let state_clone = state.clone();
+        // The detached task can't carry the `ep` borrow across the spawn
+        // boundary; capture the index and re-borrow from the owned `Arc`.
+        let endpoint_idx = state.endpoint_index(ep);
         let client_id_clone = client_id.to_owned();
         let acct_name = endpoint_name.to_owned();
         let model_clone = model.to_owned();
@@ -4078,7 +4092,7 @@ async fn forward_anthropic(
             // Parse accumulated SSE data for usage
             finalize_stream(
                 &state_clone,
-                endpoint_idx,
+                &state_clone.endpoints[endpoint_idx],
                 &req_id_clone,
                 &client_id_clone,
                 &model_clone,
@@ -4112,7 +4126,7 @@ async fn forward_anthropic(
         }
         finalize_non_stream(
             state,
-            endpoint_idx,
+            ep,
             req_id,
             client_id,
             model,
@@ -4295,7 +4309,6 @@ async fn proxy_handler(
                                     &body_bytes,
                                     &oauth_body_bytes,
                                     ep,
-                                    i,
                                     &req_id,
                                     &client_id,
                                     &client_ver,
@@ -7157,7 +7170,6 @@ async fn forward_openai_compat_anthropic(
     state: &Arc<AppState>,
     parts: &axum::http::request::Parts,
     ep: &Endpoint,
-    endpoint_idx: usize,
     anthropic_body: &serde_json::Value,
     oauth_anthropic_body: &serde_json::Value,
     req_id: &str,
@@ -7356,6 +7368,9 @@ async fn forward_openai_compat_anthropic(
     if is_streaming {
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
         let state_clone = state.clone();
+        // The detached task can't carry the `ep` borrow across the spawn
+        // boundary; capture the index and re-borrow from the owned `Arc`.
+        let endpoint_idx = state.endpoint_index(ep);
         let client_id_clone = client_id.to_owned();
         let acct_name = endpoint_name.to_owned();
         let model_clone = model.to_owned();
@@ -7441,7 +7456,7 @@ async fn forward_openai_compat_anthropic(
             // Extract and record token usage from accumulated SSE data
             finalize_stream(
                 &state_clone,
-                endpoint_idx,
+                &state_clone.endpoints[endpoint_idx],
                 &req_id_clone,
                 &client_id_clone,
                 &model_clone,
@@ -7504,7 +7519,7 @@ async fn forward_openai_compat_anthropic(
     let usage = TokenUsage::from_response_body(&anthropic_resp);
     finalize_non_stream(
         state,
-        endpoint_idx,
+        ep,
         req_id,
         client_id,
         model,
@@ -7670,7 +7685,6 @@ async fn openai_chat_handler(
                                     &state,
                                     &parts,
                                     ep,
-                                    i,
                                     &anthropic_body,
                                     &oauth_anthropic_body,
                                     &req_id,
@@ -12043,7 +12057,9 @@ data: {\"type\":\"message_stop\"}\n\n";
             cache_creation_input_tokens: 20,
             cache_read_input_tokens: 30,
         };
-        state.record_usage(0, "test-client", &usage).await;
+        state
+            .record_usage(&state.endpoints[0], "test-client", &usage)
+            .await;
 
         assert_eq!(state.endpoints[0].input_tokens.load(Ordering::Relaxed), 100);
         assert_eq!(state.endpoints[0].output_tokens.load(Ordering::Relaxed), 50);
@@ -12072,7 +12088,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
         };
-        state.record_usage(0, "-", &usage).await;
+        state.record_usage(&state.endpoints[0], "-", &usage).await;
 
         // Account gets updated
         assert_eq!(state.endpoints[0].input_tokens.load(Ordering::Relaxed), 100);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2178,6 +2178,11 @@ impl AppState {
         for (i, ep) in self.endpoints.iter().enumerate() {
             match ep.protocol {
                 Protocol::OpenAI => {
+                    // NOTE: unlike persistence / stats / Redis sync (which all
+                    // `continue` on Protocol::OpenAI), metrics intentionally
+                    // emits OpenAI endpoints with a fixed (gate 0.0,
+                    // weight 1.0) — an OpenAI endpoint is a real routing
+                    // candidate and belongs on dashboards.
                     endpoint_entries[i] = Some((0.0, 1.0));
                 }
                 Protocol::Anthropic => {
@@ -6021,7 +6026,7 @@ struct ClaimMetricsSnap {
 
 #[allow(dead_code)]
 #[derive(Default, Clone)]
-struct AcctMetricsSnap {
+struct EndpointMetricsSnap {
     name: String,
     passthrough: bool,
     has_applicable_7d: bool,
@@ -6059,7 +6064,7 @@ struct AcctMetricsSnap {
 fn append_routing_weight_metrics(
     buf: &mut String,
     accounts: &[Account],
-    snaps: &[AcctMetricsSnap],
+    snaps: &[EndpointMetricsSnap],
 ) {
     prom_header(
         buf,
@@ -6108,7 +6113,7 @@ fn append_routing_weight_metrics(
     }
 }
 
-/// Build an `AcctMetricsSnap` from the shared (name, rate_info, burn_rate,
+/// Build an `EndpointMetricsSnap` from the shared (name, rate_info, burn_rate,
 /// counters, gauge atomics) field set common to both `Account` and the unified
 /// `Endpoint`. Pool-agnostic: callers pass field references, so one
 /// implementation serves both the legacy account pool and the endpoint pool.
@@ -6125,7 +6130,7 @@ async fn build_metrics_snap(
     effective_gate_atomic: &AtomicU64,
     now_epoch: u64,
     total_headroom: &mut Option<u64>,
-) -> AcctMetricsSnap {
+) -> EndpointMetricsSnap {
     let info = rate_info.read().await;
     let (br_5m, br_1h, br_6h) = burn_rate
         .lock()
@@ -6181,7 +6186,7 @@ async fn build_metrics_snap(
         })
         .collect();
 
-    AcctMetricsSnap {
+    EndpointMetricsSnap {
         name: name.to_string(),
         passthrough,
         has_applicable_7d: !claims.is_empty()
@@ -6242,7 +6247,7 @@ async fn metrics_handler(
 
     // ── Phase 1: Gather data (async — acquires locks) ──────────────
 
-    let mut snaps: Vec<AcctMetricsSnap> =
+    let mut snaps: Vec<EndpointMetricsSnap> =
         Vec::with_capacity(state.accounts.len() + state.endpoints.len());
     let mut total_headroom: Option<u64> = Some(0);
 
@@ -19319,7 +19324,7 @@ upstream = "https://api.anthropic.com"
         append_routing_weight_metrics(
             &mut buf,
             &[acct],
-            &[AcctMetricsSnap {
+            &[EndpointMetricsSnap {
                 name: "acct-a".to_string(),
                 ..Default::default()
             }],
@@ -19352,7 +19357,7 @@ upstream = "https://api.anthropic.com"
         append_routing_weight_metrics(
             &mut buf,
             &[acct],
-            &[AcctMetricsSnap {
+            &[EndpointMetricsSnap {
                 name: "acct-a".to_string(),
                 ..Default::default()
             }],
@@ -19408,7 +19413,7 @@ upstream = "https://api.anthropic.com"
             &mut buf,
             &state.accounts,
             &[
-                AcctMetricsSnap {
+                EndpointMetricsSnap {
                     name: "passthrough".to_string(),
                     passthrough: true,
                     utilization: Some(0.20),
@@ -19416,7 +19421,7 @@ upstream = "https://api.anthropic.com"
                     reset_5h: Some(now_epoch + 10000),
                     ..Default::default()
                 },
-                AcctMetricsSnap {
+                EndpointMetricsSnap {
                     name: "api".to_string(),
                     utilization: Some(0.40),
                     utilization_5h: Some(0.40),
@@ -20730,7 +20735,7 @@ upstream = "https://api.anthropic.com"
             &mut buf,
             &state.accounts,
             &[
-                AcctMetricsSnap {
+                EndpointMetricsSnap {
                     name: "healthy".to_string(),
                     utilization: Some(0.30),
                     utilization_5h: Some(0.30),
@@ -20738,7 +20743,7 @@ upstream = "https://api.anthropic.com"
                     status_5h: Some("allowed".to_string()),
                     ..Default::default()
                 },
-                AcctMetricsSnap {
+                EndpointMetricsSnap {
                     name: "soft-limited".to_string(),
                     utilization: Some(0.95),
                     utilization_5h: Some(0.95),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3196,19 +3196,6 @@ async fn finalize_non_stream(
 }
 
 impl AppState {
-    /// Recover the index of an endpoint borrowed from `self.endpoints`.
-    ///
-    /// `pick_endpoint` hands callers an `&Endpoint`; a detached streaming task
-    /// (which owns only a cloned `Arc<AppState>`) cannot carry that borrow
-    /// across the `tokio::spawn` boundary, so it re-derives the endpoint by
-    /// index. `Vec` storage is contiguous, so the index is the pointer offset.
-    /// Caller contract: `ep` must point into `self.endpoints`.
-    fn endpoint_index(&self, ep: &Endpoint) -> usize {
-        let base = self.endpoints.as_ptr() as usize;
-        let here = ep as *const Endpoint as usize;
-        (here - base) / std::mem::size_of::<Endpoint>()
-    }
-
     /// Record token usage for an endpoint and client.
     async fn record_usage(&self, ep: &Endpoint, client_id: &str, usage: &TokenUsage) {
         if usage.is_empty() {
@@ -3850,6 +3837,11 @@ async fn classify_retry_status(
 /// Forward one Anthropic-protocol request to a single `Endpoint`. The caller
 /// passes the picked endpoint and its pool index (used for `skip` and usage
 /// accounting).
+/// `ep` is the endpoint to forward to; `endpoint_idx` is its index in
+/// `state.endpoints`. Both are required: the streaming path spawns a
+/// detached 'static task that must re-borrow the endpoint from a cloned
+/// Arc<AppState> — a borrowed &Endpoint cannot cross the spawn boundary,
+/// so the task captures the Copy `endpoint_idx` and re-indexes.
 #[allow(clippy::too_many_arguments)]
 async fn forward_anthropic(
     state: &Arc<AppState>,
@@ -3857,6 +3849,7 @@ async fn forward_anthropic(
     body_bytes: &bytes::Bytes,
     oauth_body_bytes: &bytes::Bytes,
     ep: &Endpoint,
+    endpoint_idx: usize,
     req_id: &str,
     client_id: &str,
     client_ver: &str,
@@ -4054,8 +4047,7 @@ async fn forward_anthropic(
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
         let state_clone = state.clone();
         // The detached task can't carry the `ep` borrow across the spawn
-        // boundary; capture the index and re-borrow from the owned `Arc`.
-        let endpoint_idx = state.endpoint_index(ep);
+        // boundary; capture the Copy index and re-borrow from the owned `Arc`.
         let client_id_clone = client_id.to_owned();
         let acct_name = endpoint_name.to_owned();
         let model_clone = model.to_owned();
@@ -4086,10 +4078,12 @@ async fn forward_anthropic(
                     }
                 }
             }
-            // Parse accumulated SSE data for usage
+            // Parse accumulated SSE data for usage. The detached task only
+            // holds a cloned Arc<AppState>; re-index it to recover &Endpoint.
+            let ep = &state_clone.endpoints[endpoint_idx];
             finalize_stream(
                 &state_clone,
-                &state_clone.endpoints[endpoint_idx],
+                ep,
                 &req_id_clone,
                 &client_id_clone,
                 &model_clone,
@@ -4306,6 +4300,7 @@ async fn proxy_handler(
                                     &body_bytes,
                                     &oauth_body_bytes,
                                     ep,
+                                    i,
                                     &req_id,
                                     &client_id,
                                     &client_ver,
@@ -7160,11 +7155,17 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
 /// Anthropic response back to OpenAI format. Structurally similar to
 /// `forward_anthropic`, but intentionally kept separate: it speaks OpenAI on
 /// both edges (request body already translated, response translated back).
+/// `ep` is the endpoint to forward to; `endpoint_idx` is its index in
+/// `state.endpoints`. Both are required: the streaming path spawns a
+/// detached 'static task that must re-borrow the endpoint from a cloned
+/// Arc<AppState> — a borrowed &Endpoint cannot cross the spawn boundary,
+/// so the task captures the Copy `endpoint_idx` and re-indexes.
 #[allow(clippy::too_many_arguments)]
 async fn forward_openai_compat_anthropic(
     state: &Arc<AppState>,
     parts: &axum::http::request::Parts,
     ep: &Endpoint,
+    endpoint_idx: usize,
     anthropic_body: &serde_json::Value,
     oauth_anthropic_body: &serde_json::Value,
     req_id: &str,
@@ -7364,8 +7365,7 @@ async fn forward_openai_compat_anthropic(
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
         let state_clone = state.clone();
         // The detached task can't carry the `ep` borrow across the spawn
-        // boundary; capture the index and re-borrow from the owned `Arc`.
-        let endpoint_idx = state.endpoint_index(ep);
+        // boundary; capture the Copy index and re-borrow from the owned `Arc`.
         let client_id_clone = client_id.to_owned();
         let acct_name = endpoint_name.to_owned();
         let model_clone = model.to_owned();
@@ -7448,10 +7448,12 @@ async fn forward_openai_compat_anthropic(
                 client_gone = true;
             }
 
-            // Extract and record token usage from accumulated SSE data
+            // Extract and record token usage from accumulated SSE data. The
+            // detached task only holds a cloned Arc<AppState>; re-index it.
+            let ep = &state_clone.endpoints[endpoint_idx];
             finalize_stream(
                 &state_clone,
-                &state_clone.endpoints[endpoint_idx],
+                ep,
                 &req_id_clone,
                 &client_id_clone,
                 &model_clone,
@@ -7680,6 +7682,7 @@ async fn openai_chat_handler(
                                     &state,
                                     &parts,
                                     ep,
+                                    i,
                                     &anthropic_body,
                                     &oauth_anthropic_body,
                                     &req_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21773,4 +21773,76 @@ upstream = "https://api.anthropic.com"
             "response must be OpenAI-shaped after round-trip translation"
         );
     }
+    #[tokio::test]
+    async fn proxy_handler_translates_to_openai_endpoint() {
+        // Mock OpenAI upstream: capture the request body to assert it was
+        // translated to OpenAI shape, then return an OpenAI-format response.
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<serde_json::Value>(1);
+        let app = Router::new().fallback(any(move |req: Request<Body>| {
+            let tx = tx.clone();
+            async move {
+                let bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+                let _ = tx.send(v).await;
+                (
+                    StatusCode::OK,
+                    axum::Json(serde_json::json!({
+                        "id": "chatcmpl-x",
+                        "object": "chat.completion",
+                        "model": "claude-opus-4-7",
+                        "choices": [{
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "hi back"},
+                            "finish_reason": "stop"
+                        }],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+                    })),
+                )
+                    .into_response()
+            }
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let mut state = test_state_with(vec![]);
+        let mut ep = make_endpoint("openai-gw", Protocol::OpenAI);
+        ep.base_url = format!("http://{}", upstream_addr);
+        Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
+
+        let proxy_app = Router::new().fallback(any(proxy_handler)).with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                proxy_app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let _ = client
+            .post(format!("http://{}/v1/messages", proxy_addr))
+            .json(&serde_json::json!({
+                "model": "claude-opus-4-7",
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "hi"}],
+            }))
+            .send()
+            .await
+            .unwrap();
+
+        let received = rx.recv().await.expect("upstream must receive a request");
+        assert!(
+            received.get("messages").is_some(),
+            "translated request must have OpenAI `messages` field"
+        );
+        assert_eq!(received["model"], "claude-opus-4-7");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21647,4 +21647,70 @@ upstream = "https://api.anthropic.com"
             "should return None when account is hard-limited"
         );
     }
+
+    // ── Unified endpoint: fallback retry semantics ─────────────────
+
+    #[tokio::test]
+    async fn try_fallback_upstream_unified_returns_none_on_429() {
+        // Mock upstream returns 429
+        let app = Router::new().fallback(any(|| async {
+            (StatusCode::TOO_MANY_REQUESTS, "rate limited").into_response()
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let mut state = test_state_with(vec![]);
+        let mut ep = make_endpoint("rl-gw", Protocol::OpenAI);
+        ep.base_url = format!("http://{}", addr);
+        Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
+
+        let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+        let result = try_fallback_upstream_unified(
+            &state,
+            body,
+            "req-1",
+            "client-1",
+            "claude-opus-4-7",
+            0,
+            false,
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "429 must return None for retry, not Response"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_fallback_upstream_unified_returns_none_on_500() {
+        let app = Router::new().fallback(any(|| async {
+            (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response()
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let mut state = test_state_with(vec![]);
+        let mut ep = make_endpoint("broken", Protocol::OpenAI);
+        ep.base_url = format!("http://{}", addr);
+        Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
+
+        let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+        let result = try_fallback_upstream_unified(
+            &state,
+            body,
+            "req-1",
+            "client-1",
+            "claude-opus-4-7",
+            0,
+            false,
+        )
+        .await;
+        assert!(result.is_none(), "500 must return None for retry");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7878,6 +7878,431 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
     events
 }
 
+/// Forward one OpenAI-compat request to a single Anthropic-protocol endpoint.
+/// The caller has already translated the OpenAI request into `anthropic_body`
+/// (plus the OAuth variant `oauth_anthropic_body`); this helper picks the right
+/// variant by token prefix, forwards to `base_url`, and translates the Anthropic
+/// response back to OpenAI format. Pool-agnostic: reusable for both
+/// `AppState.accounts` (legacy) and `AppState.endpoints` (unified) by passing
+/// the endpoint's identity, auth, and shared state in explicitly. Behavior is
+/// byte-for-byte equivalent to the prior inline Account block in
+/// `openai_chat_handler` — only the `EndpointIdx::X(i)` value used for `skip`
+/// is chosen by the caller, since this helper does not know which pool it's
+/// serving. Structurally similar to `forward_anthropic`, but intentionally
+/// kept separate: it speaks OpenAI on both edges (request body already
+/// translated, response translated back).
+#[allow(clippy::too_many_arguments)]
+async fn forward_openai_compat_anthropic(
+    state: &Arc<AppState>,
+    parts: &axum::http::request::Parts,
+    base_url: &str,
+    token: &str,
+    passthrough: bool,
+    endpoint_name: &str,
+    usage_target: UsageTarget,
+    requests_counter: &AtomicU64,
+    rate_info: &RwLock<RateLimitInfo>,
+    burn_rate: &Mutex<BurnRate>,
+    anthropic_body: &serde_json::Value,
+    oauth_anthropic_body: &serde_json::Value,
+    req_id: &str,
+    client_id: &str,
+    client_ver: &str,
+    client_ip: &std::net::IpAddr,
+    agent_id: &str,
+    session_id: &str,
+    model: &str,
+    is_streaming: bool,
+    request_start: std::time::Instant,
+) -> ForwardOutcome {
+    let url = format!("{base_url}/v1/messages");
+
+    let mut headers = parts.headers.clone();
+    headers.remove("host");
+    if !passthrough {
+        headers.remove("authorization");
+        headers.remove("x-api-key");
+    }
+    headers.remove("content-length"); // body size changes after translation
+    headers.remove("accept-encoding"); // we need plaintext to translate the response
+
+    // Inject required Anthropic headers
+    headers.insert("content-type", HeaderValue::from_static("application/json"));
+    headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+
+    // Auth injection
+    inject_account_auth(&mut headers, token, passthrough);
+
+    // Use OAuth variant (with CC system prompt) for OAuth tokens
+    let req_body = if token.starts_with("sk-ant-oat") {
+        oauth_anthropic_body
+    } else {
+        anthropic_body
+    };
+    let body_str = req_body.to_string();
+    debug!(
+        account = endpoint_name,
+        model = %model,
+        body_len = body_str.len(),
+        "openai-compat: upstream request"
+    );
+
+    let upstream_req = state
+        .client
+        .request(reqwest::Method::POST, &url)
+        .headers(headers)
+        .body(body_str);
+
+    let mut resp = match upstream_req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            error!(account = endpoint_name, "upstream request failed: {e}");
+            // Preserve original behavior: transport errors retry without
+            // adding the endpoint to the skip list.
+            return ForwardOutcome::Retry {
+                saw_529: false,
+                push_skip: false,
+            };
+        }
+    };
+
+    let status = resp.status();
+    requests_counter.fetch_add(1, Ordering::Relaxed);
+    state
+        .update_rate_info_for(rate_info, endpoint_name, resp.headers())
+        .await;
+
+    // Update burn rate (after rate-limit headers are parsed)
+    state.update_burn_rate(burn_rate, client_id);
+
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        state
+            .mark_hard_limited_for(rate_info, endpoint_name, resp.headers())
+            .await;
+        log_429_details(endpoint_name, resp).await;
+        state.save_state().await;
+        info!(account = endpoint_name, "got 429, rotating to next account");
+        return ForwardOutcome::Retry {
+            saw_529: false,
+            push_skip: true,
+        };
+    }
+
+    // 529 → overloaded, try next account; flag for BEBO retry if all exhausted
+    if status.as_u16() == 529 {
+        state.save_state().await;
+        warn!(account = endpoint_name, "got 529, rotating to next account");
+        return ForwardOutcome::Retry {
+            saw_529: true,
+            push_skip: true,
+        };
+    }
+
+    // Other 5xx → transient, try next account (no BEBO retry)
+    if status.is_server_error() {
+        state.save_state().await;
+        warn!(
+            account = endpoint_name,
+            status = status.as_u16(),
+            "got server error, rotating to next account"
+        );
+        return ForwardOutcome::Retry {
+            saw_529: false,
+            push_skip: true,
+        };
+    }
+
+    // Clear hard limit and burst counter only on a genuine 2xx success.
+    // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
+    // that the rate-limit window has drained — don't clobber state on
+    // client errors.
+    let recovered = if status.is_success() {
+        let mut info = rate_info.write().await;
+        let was = info.hard_limited_until.is_some();
+        info.hard_limited_until = None;
+        info.consecutive_burst_429s = 0;
+        was
+    } else {
+        false
+    };
+
+    // Persist state after updating rate-limit state so completed 4xx
+    // responses and other terminal outcomes aren't dropped on restart.
+    state.save_state().await;
+
+    if recovered {
+        state.signal_hard_limit_recovery(endpoint_name).await;
+    }
+
+    // Compute budget pressure status for response header + log
+    let budget_status = {
+        let info = rate_info.read().await;
+        let (eff_util, constraint, _adj_5h, _adj_7d) =
+            effective_utilization(&info, AppState::now_epoch(), model);
+        info!(
+            req_id,
+            client = %client_ip,
+            client_id = %client_id,
+            ver = %client_ver,
+            agent = %agent_id,
+            session = %session_id,
+            model = %model,
+            account = endpoint_name,
+            status = status.as_u16(),
+            utilization = format_args!("{eff_util:.2}"),
+            util_5h = info.utilization_5h.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
+            util_7d = info.utilization_7d.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
+            constraint,
+            openai_compat = true,
+            stream = is_streaming,
+            "proxied (openai-compat)"
+        );
+        compute_pressure_status(eff_util, client_id, state)
+    };
+
+    // Non-2xx: log error detail, translate to OpenAI error format, return
+    if !status.is_success() {
+        let error_body = resp.bytes().await.unwrap_or_default();
+        let error_msg = serde_json::from_slice::<serde_json::Value>(&error_body)
+            .ok()
+            .and_then(|v| {
+                v.pointer("/error/message")
+                    .and_then(|m| m.as_str())
+                    .map(String::from)
+            });
+        warn!(
+            account = endpoint_name,
+            model = %model,
+            status = status.as_u16(),
+            error_message = ?error_msg,
+            "openai-compat: upstream error"
+        );
+
+        // Translate Anthropic error to OpenAI error format so clients
+        // (LiteLLM, etc.) can parse the actual error message.
+        let openai_error =
+            if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&error_body) {
+                // Anthropic: {"type":"error","error":{"type":"...","message":"..."}}
+                let msg = parsed
+                    .pointer("/error/message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown upstream error");
+                let err_type = parsed
+                    .pointer("/error/type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("api_error");
+                serde_json::json!({
+                    "error": {
+                        "message": msg,
+                        "type": err_type,
+                        "param": null,
+                        "code": null
+                    }
+                })
+            } else {
+                let raw = String::from_utf8_lossy(&error_body);
+                serde_json::json!({
+                    "error": {
+                        "message": raw.as_ref(),
+                        "type": "api_error",
+                        "param": null,
+                        "code": null
+                    }
+                })
+            };
+
+        let response = Response::builder()
+            .status(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY))
+            .header("content-type", "application/json")
+            .header("x-budget-status", budget_status)
+            .body(Body::from(
+                serde_json::to_vec(&openai_error).unwrap_or_default(),
+            ))
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+            });
+        return ForwardOutcome::Done(response);
+    }
+
+    if is_streaming {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
+        let state_clone = state.clone();
+        let client_id_clone = client_id.to_owned();
+        let acct_name = endpoint_name.to_owned();
+        let model_clone = model.to_owned();
+        let client_ip_str = client_ip.to_string();
+        let agent_clone = agent_id.to_owned();
+        let session_clone = session_id.to_owned();
+        let req_id_clone = req_id.to_owned();
+        let status_code = status.as_u16();
+
+        tokio::spawn(async move {
+            let mut buffer: Vec<u8> = Vec::new();
+            let mut raw_sse: Vec<u8> = Vec::new();
+            let mut ctx = StreamContext::default();
+            let mut sent_done = false;
+
+            let mut client_gone = false;
+            let mut upstream_error = false;
+
+            loop {
+                match resp.chunk().await {
+                    Ok(Some(chunk)) => {
+                        buffer.extend_from_slice(&chunk);
+                        raw_sse.extend_from_slice(&chunk);
+
+                        while let Some(pos) = buffer.windows(2).position(|w| w == b"\n\n") {
+                            let event = String::from_utf8_lossy(&buffer[..pos]).into_owned();
+                            buffer.drain(..pos + 2);
+
+                            if event.trim().is_empty() {
+                                continue;
+                            }
+
+                            if let Some(translated) = translate_sse_event(&event, &mut ctx) {
+                                if translated.trim() == "data: [DONE]" {
+                                    sent_done = true;
+                                }
+                                if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {
+                                    client_gone = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if client_gone {
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        upstream_error = true;
+                        warn!(req_id = req_id_clone, error = %e, "upstream SSE read failed");
+                        break;
+                    }
+                }
+            }
+
+            // Process any remaining data in buffer (skip if upstream errored)
+            if !upstream_error && !buffer.is_empty() {
+                let remaining = String::from_utf8_lossy(&buffer).into_owned();
+                if !remaining.trim().is_empty() {
+                    if let Some(translated) = translate_sse_event(&remaining, &mut ctx) {
+                        if translated.trim() == "data: [DONE]" {
+                            sent_done = true;
+                        }
+                        if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {
+                            client_gone = true;
+                        }
+                    }
+                }
+            }
+
+            // Ensure [DONE] is always sent (skip on upstream error — would fake clean completion)
+            if !sent_done
+                && !client_gone
+                && !upstream_error
+                && tx
+                    .send(Ok(bytes::Bytes::from("data: [DONE]\n\n")))
+                    .await
+                    .is_err()
+            {
+                client_gone = true;
+            }
+
+            // Extract and record token usage from accumulated SSE data
+            finalize_stream(
+                &state_clone,
+                usage_target,
+                &req_id_clone,
+                &client_id_clone,
+                &model_clone,
+                &acct_name,
+                &client_ip_str,
+                &agent_clone,
+                &session_clone,
+                status_code,
+                &raw_sse,
+                request_start,
+                client_gone,
+                upstream_error,
+                true,
+            )
+            .await;
+        });
+
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "text/event-stream")
+            .header("cache-control", "no-cache")
+            .header("connection", "keep-alive")
+            .header("x-budget-status", budget_status)
+            .body(Body::from_stream(ReceiverStream::new(rx)))
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+            });
+        return ForwardOutcome::Done(response);
+    }
+
+    // Non-streaming: buffer, translate, return
+    let resp_bytes = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            error!("failed to read upstream response: {e}");
+            return ForwardOutcome::Done(
+                (StatusCode::BAD_GATEWAY, "failed to read upstream response").into_response(),
+            );
+        }
+    };
+
+    let anthropic_resp: serde_json::Value = match serde_json::from_slice(&resp_bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .header("x-budget-status", budget_status)
+                .body(Body::from(resp_bytes))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+                });
+            return ForwardOutcome::Done(response);
+        }
+    };
+
+    let openai_resp = translate_anthropic_to_openai(&anthropic_resp);
+
+    // Extract and record token usage from non-streaming response
+    let usage = TokenUsage::from_response_body(&anthropic_resp);
+    finalize_non_stream(
+        state,
+        usage_target,
+        req_id,
+        client_id,
+        model,
+        endpoint_name,
+        &client_ip.to_string(),
+        agent_id,
+        session_id,
+        status.as_u16(),
+        &usage,
+        request_start.elapsed().as_millis() as u64,
+        true,
+    )
+    .await;
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .header("x-budget-status", budget_status)
+        .body(Body::from(
+            serde_json::to_vec(&openai_resp).unwrap_or_default(),
+        ))
+        .unwrap_or_else(|_| {
+            (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+        });
+    ForwardOutcome::Done(response)
+}
+
 async fn openai_chat_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::ConnectInfo(client_addr): axum::extract::ConnectInfo<SocketAddr>,
@@ -8003,9 +8428,61 @@ async fn openai_chat_handler(
         let mut saw_529 = false;
         // n accounts + 1 fallback upstream is the candidate ceiling.
         for _attempt in 0..(n + 1) {
-            let idx = match state.pick_endpoint(affinity, &model, &skip).await {
-                Some(EndpointIdx::Account(i)) => i,
-                Some(EndpointIdx::Upstream(u)) => {
+            let picked = match state.pick_endpoint(affinity, &model, &skip).await {
+                Some(e) => e,
+                None => {
+                    warn!("all endpoints exhausted");
+                    return (
+                        StatusCode::TOO_MANY_REQUESTS,
+                        "all upstream endpoints exhausted",
+                    )
+                        .into_response();
+                }
+            };
+            match picked {
+                EndpointIdx::Account(i) => {
+                    let acct = &state.accounts[i];
+                    match forward_openai_compat_anthropic(
+                        &state,
+                        &parts,
+                        &state.upstream,
+                        &acct.token,
+                        acct.passthrough,
+                        &acct.name,
+                        UsageTarget::Account(i),
+                        &acct.requests,
+                        &acct.rate_info,
+                        &acct.burn_rate,
+                        &anthropic_body,
+                        &oauth_anthropic_body,
+                        &req_id,
+                        &client_id,
+                        &client_ver,
+                        &client_ip,
+                        &agent_id,
+                        &session_id,
+                        &model,
+                        is_streaming,
+                        request_start,
+                    )
+                    .await
+                    {
+                        ForwardOutcome::Done(resp) => return resp,
+                        ForwardOutcome::Retry {
+                            saw_529: this_529,
+                            push_skip,
+                        } => {
+                            if this_529 {
+                                saw_529 = true;
+                            }
+                            if push_skip {
+                                skip.push(EndpointIdx::Account(i));
+                            }
+                            continue;
+                        }
+                    }
+                }
+                EndpointIdx::Upstream(u) => {
                     // All account tiers exhausted — the upstream is OpenAI-native,
                     // so forward the original request body without translation.
                     match try_fallback_upstream(
@@ -8026,395 +8503,72 @@ async fn openai_chat_handler(
                         }
                     }
                 }
-                Some(EndpointIdx::Unified(_)) => unreachable!(
-                    "Phase 2b: handler dispatch for EndpointIdx::Unified is not yet wired; the startup guard in main() rejects [[endpoints]] configs until this branch lands."
-                ),
-                None => {
-                    warn!("all endpoints exhausted");
-                    return (
-                        StatusCode::TOO_MANY_REQUESTS,
-                        "all upstream endpoints exhausted",
-                    )
-                        .into_response();
-                }
-            };
-
-            let acct = &state.accounts[idx];
-            let url = format!("{}/v1/messages", state.upstream);
-
-            let mut headers = parts.headers.clone();
-            headers.remove("host");
-            if !acct.passthrough {
-                headers.remove("authorization");
-                headers.remove("x-api-key");
-            }
-            headers.remove("content-length"); // body size changes after translation
-            headers.remove("accept-encoding"); // we need plaintext to translate the response
-
-            // Inject required Anthropic headers
-            headers.insert("content-type", HeaderValue::from_static("application/json"));
-            headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
-
-            // Auth injection
-            inject_account_auth(&mut headers, &acct.token, acct.passthrough);
-
-            // Use OAuth variant (with CC system prompt) for OAuth tokens
-            let req_body = if acct.token.starts_with("sk-ant-oat") {
-                &oauth_anthropic_body
-            } else {
-                &anthropic_body
-            };
-            let body_str = req_body.to_string();
-            debug!(
-                account = acct.name,
-                model = %model,
-                body_len = body_str.len(),
-                "openai-compat: upstream request"
-            );
-
-            let upstream_req = state
-                .client
-                .request(reqwest::Method::POST, &url)
-                .headers(headers)
-                .body(body_str);
-
-            let mut resp = match upstream_req.send().await {
-                Ok(r) => r,
-                Err(e) => {
-                    error!(account = acct.name, "upstream request failed: {e}");
-                    continue;
-                }
-            };
-
-            let status = resp.status();
-            acct.requests.fetch_add(1, Ordering::Relaxed);
-            state.update_rate_info(idx, resp.headers()).await;
-
-            // Update burn rate (after rate-limit headers are parsed)
-            state.update_burn_rate(&acct.burn_rate, &client_id);
-
-            if status == StatusCode::TOO_MANY_REQUESTS {
-                state.mark_hard_limited(idx, resp.headers()).await;
-                log_429_details(&acct.name, resp).await;
-                state.save_state().await;
-                info!(account = acct.name, "got 429, rotating to next account");
-                skip.push(EndpointIdx::Account(idx));
-                continue;
-            }
-
-            // 529 → overloaded, try next account; flag for BEBO retry if all exhausted
-            if status.as_u16() == 529 {
-                state.save_state().await;
-                warn!(account = acct.name, "got 529, rotating to next account");
-                saw_529 = true;
-                skip.push(EndpointIdx::Account(idx));
-                continue;
-            }
-
-            // Other 5xx → transient, try next account (no BEBO retry)
-            if status.is_server_error() {
-                state.save_state().await;
-                warn!(
-                    account = acct.name,
-                    status = status.as_u16(),
-                    "got server error, rotating to next account"
-                );
-                skip.push(EndpointIdx::Account(idx));
-                continue;
-            }
-
-            // Clear hard limit and burst counter only on a genuine 2xx success.
-            // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
-            // that the rate-limit window has drained — don't clobber state on
-            // client errors.
-            let recovered = if status.is_success() {
-                let mut info = acct.rate_info.write().await;
-                let was = info.hard_limited_until.is_some();
-                info.hard_limited_until = None;
-                info.consecutive_burst_429s = 0;
-                was
-            } else {
-                false
-            };
-
-            // Persist state after updating rate-limit state so completed 4xx
-            // responses and other terminal outcomes aren't dropped on restart.
-            state.save_state().await;
-
-            if recovered {
-                state.signal_hard_limit_recovery(&acct.name).await;
-            }
-
-            // Compute budget pressure status for response header + log
-            let budget_status = {
-                let info = acct.rate_info.read().await;
-                let (eff_util, constraint, _adj_5h, _adj_7d) =
-                    effective_utilization(&info, AppState::now_epoch(), &model);
-                info!(
-                    req_id,
-                    client = %client_ip,
-                    client_id = %client_id,
-                    ver = %client_ver,
-                    agent = %agent_id,
-                    session = %session_id,
-                    model = %model,
-                    account = acct.name,
-                    status = status.as_u16(),
-                    utilization = format_args!("{eff_util:.2}"),
-                    util_5h = info.utilization_5h.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
-                    util_7d = info.utilization_7d.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
-                    constraint,
-                    openai_compat = true,
-                    stream = is_streaming,
-                    "proxied (openai-compat)"
-                );
-                compute_pressure_status(eff_util, &client_id, &state)
-            };
-
-            // Non-2xx: log error detail, translate to OpenAI error format, return
-            if !status.is_success() {
-                let error_body = resp.bytes().await.unwrap_or_default();
-                let error_msg = serde_json::from_slice::<serde_json::Value>(&error_body)
-                    .ok()
-                    .and_then(|v| {
-                        v.pointer("/error/message")
-                            .and_then(|m| m.as_str())
-                            .map(String::from)
-                    });
-                warn!(
-                    account = acct.name,
-                    model = %model,
-                    status = status.as_u16(),
-                    error_message = ?error_msg,
-                    "openai-compat: upstream error"
-                );
-
-                // Translate Anthropic error to OpenAI error format so clients
-                // (LiteLLM, etc.) can parse the actual error message.
-                let openai_error =
-                    if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&error_body) {
-                        // Anthropic: {"type":"error","error":{"type":"...","message":"..."}}
-                        let msg = parsed
-                            .pointer("/error/message")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unknown upstream error");
-                        let err_type = parsed
-                            .pointer("/error/type")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("api_error");
-                        serde_json::json!({
-                            "error": {
-                                "message": msg,
-                                "type": err_type,
-                                "param": null,
-                                "code": null
-                            }
-                        })
-                    } else {
-                        let raw = String::from_utf8_lossy(&error_body);
-                        serde_json::json!({
-                            "error": {
-                                "message": raw.as_ref(),
-                                "type": "api_error",
-                                "param": null,
-                                "code": null
-                            }
-                        })
-                    };
-
-                return Response::builder()
-                    .status(
-                        StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
-                    )
-                    .header("content-type", "application/json")
-                    .header("x-budget-status", budget_status)
-                    .body(Body::from(
-                        serde_json::to_vec(&openai_error).unwrap_or_default(),
-                    ))
-                    .unwrap_or_else(|_| {
-                        (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
-                    });
-            }
-
-            if is_streaming {
-                let (tx, rx) =
-                    tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
-                let state_clone = state.clone();
-                let client_id_clone = client_id.clone();
-                let acct_name = acct.name.clone();
-                let model_clone = model.clone();
-                let client_ip_str = client_ip.to_string();
-                let agent_clone = agent_id.clone();
-                let session_clone = session_id.clone();
-
-                tokio::spawn(async move {
-                    let mut buffer: Vec<u8> = Vec::new();
-                    let mut raw_sse: Vec<u8> = Vec::new();
-                    let mut ctx = StreamContext::default();
-                    let mut sent_done = false;
-
-                    let mut client_gone = false;
-                    let mut upstream_error = false;
-
-                    loop {
-                        match resp.chunk().await {
-                            Ok(Some(chunk)) => {
-                                buffer.extend_from_slice(&chunk);
-                                raw_sse.extend_from_slice(&chunk);
-
-                                while let Some(pos) = buffer.windows(2).position(|w| w == b"\n\n") {
-                                    let event =
-                                        String::from_utf8_lossy(&buffer[..pos]).into_owned();
-                                    buffer.drain(..pos + 2);
-
-                                    if event.trim().is_empty() {
-                                        continue;
-                                    }
-
-                                    if let Some(translated) = translate_sse_event(&event, &mut ctx)
-                                    {
-                                        if translated.trim() == "data: [DONE]" {
-                                            sent_done = true;
-                                        }
-                                        if tx
-                                            .send(Ok(bytes::Bytes::from(translated)))
-                                            .await
-                                            .is_err()
-                                        {
-                                            client_gone = true;
-                                            break;
-                                        }
-                                    }
-                                }
-                                if client_gone {
-                                    break;
-                                }
-                            }
-                            Ok(None) => break,
-                            Err(e) => {
-                                upstream_error = true;
-                                warn!(req_id, error = %e, "upstream SSE read failed");
-                                break;
-                            }
-                        }
-                    }
-
-                    // Process any remaining data in buffer (skip if upstream errored)
-                    if !upstream_error && !buffer.is_empty() {
-                        let remaining = String::from_utf8_lossy(&buffer).into_owned();
-                        if !remaining.trim().is_empty() {
-                            if let Some(translated) = translate_sse_event(&remaining, &mut ctx) {
-                                if translated.trim() == "data: [DONE]" {
-                                    sent_done = true;
-                                }
-                                if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {
-                                    client_gone = true;
-                                }
-                            }
-                        }
-                    }
-
-                    // Ensure [DONE] is always sent (skip on upstream error — would fake clean completion)
-                    if !sent_done
-                        && !client_gone
-                        && !upstream_error
-                        && tx
-                            .send(Ok(bytes::Bytes::from("data: [DONE]\n\n")))
+                EndpointIdx::Unified(i) => {
+                    let ep = &state.endpoints[i];
+                    match ep.protocol {
+                        Protocol::Anthropic => {
+                            match forward_openai_compat_anthropic(
+                                &state,
+                                &parts,
+                                &ep.base_url,
+                                &ep.token,
+                                ep.passthrough,
+                                &ep.name,
+                                UsageTarget::Unified(i),
+                                &ep.requests,
+                                &ep.rate_info,
+                                &ep.burn_rate,
+                                &anthropic_body,
+                                &oauth_anthropic_body,
+                                &req_id,
+                                &client_id,
+                                &client_ver,
+                                &client_ip,
+                                &agent_id,
+                                &session_id,
+                                &model,
+                                is_streaming,
+                                request_start,
+                            )
                             .await
-                            .is_err()
-                    {
-                        client_gone = true;
+                            {
+                                ForwardOutcome::Done(resp) => return resp,
+                                ForwardOutcome::Retry {
+                                    saw_529: this_529,
+                                    push_skip,
+                                } => {
+                                    if this_529 {
+                                        saw_529 = true;
+                                    }
+                                    if push_skip {
+                                        skip.push(EndpointIdx::Unified(i));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        Protocol::OpenAI => {
+                            match try_fallback_upstream_unified(
+                                &state,
+                                &body_bytes,
+                                &req_id,
+                                &client_id,
+                                &model,
+                                i,
+                                false,
+                            )
+                            .await
+                            {
+                                Some(resp) => return resp,
+                                None => {
+                                    skip.push(EndpointIdx::Unified(i));
+                                    continue;
+                                }
+                            }
+                        }
                     }
-
-                    // Extract and record token usage from accumulated SSE data
-                    finalize_stream(
-                        &state_clone,
-                        UsageTarget::Account(idx),
-                        &req_id,
-                        &client_id_clone,
-                        &model_clone,
-                        &acct_name,
-                        &client_ip_str,
-                        &agent_clone,
-                        &session_clone,
-                        status.as_u16(),
-                        &raw_sse,
-                        request_start,
-                        client_gone,
-                        upstream_error,
-                        true,
-                    )
-                    .await;
-                });
-
-                return Response::builder()
-                    .status(StatusCode::OK)
-                    .header("content-type", "text/event-stream")
-                    .header("cache-control", "no-cache")
-                    .header("connection", "keep-alive")
-                    .header("x-budget-status", budget_status)
-                    .body(Body::from_stream(ReceiverStream::new(rx)))
-                    .unwrap_or_else(|_| {
-                        (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
-                    });
+                }
             }
-
-            // Non-streaming: buffer, translate, return
-            let resp_bytes = match resp.bytes().await {
-                Ok(b) => b,
-                Err(e) => {
-                    error!("failed to read upstream response: {e}");
-                    return (StatusCode::BAD_GATEWAY, "failed to read upstream response")
-                        .into_response();
-                }
-            };
-
-            let anthropic_resp: serde_json::Value = match serde_json::from_slice(&resp_bytes) {
-                Ok(v) => v,
-                Err(_) => {
-                    return Response::builder()
-                        .status(StatusCode::OK)
-                        .header("content-type", "application/json")
-                        .header("x-budget-status", budget_status)
-                        .body(Body::from(resp_bytes))
-                        .unwrap_or_else(|_| {
-                            (StatusCode::INTERNAL_SERVER_ERROR, "response build error")
-                                .into_response()
-                        });
-                }
-            };
-
-            let openai_resp = translate_anthropic_to_openai(&anthropic_resp);
-
-            // Extract and record token usage from non-streaming response
-            let usage = TokenUsage::from_response_body(&anthropic_resp);
-            finalize_non_stream(
-                &state,
-                UsageTarget::Account(idx),
-                &req_id,
-                &client_id,
-                &model,
-                &acct.name,
-                &client_ip.to_string(),
-                &agent_id,
-                &session_id,
-                status.as_u16(),
-                &usage,
-                request_start.elapsed().as_millis() as u64,
-                true,
-            )
-            .await;
-
-            return Response::builder()
-                .status(StatusCode::OK)
-                .header("content-type", "application/json")
-                .header("x-budget-status", budget_status)
-                .body(Body::from(
-                    serde_json::to_vec(&openai_resp).unwrap_or_default(),
-                ))
-                .unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
-                });
         }
         if !saw_529 {
             break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8423,145 +8423,135 @@ async fn openai_chat_handler(
         let mut saw_529 = false;
         // n accounts + 1 fallback upstream is the candidate ceiling.
         for _attempt in 0..(n + 1) {
-            let picked = match state.pick_endpoint(affinity, &model, &skip).await {
-                Some(e) => e,
-                None => {
-                    warn!("all endpoints exhausted");
-                    return (
-                        StatusCode::TOO_MANY_REQUESTS,
-                        "all upstream endpoints exhausted",
-                    )
-                        .into_response();
-                }
-            };
-            match picked {
-                EndpointIdx::Account(i) => {
-                    let acct = &state.accounts[i];
-                    match forward_openai_compat_anthropic(
-                        &state,
-                        &parts,
-                        &state.upstream,
-                        &acct.token,
-                        acct.passthrough,
-                        &acct.name,
-                        UsageTarget::Account(i),
-                        &acct.requests,
-                        &acct.rate_info,
-                        &acct.burn_rate,
-                        &anthropic_body,
-                        &oauth_anthropic_body,
-                        &req_id,
-                        &client_id,
-                        &client_ver,
-                        &client_ip,
-                        &agent_id,
-                        &session_id,
-                        &model,
-                        is_streaming,
-                        request_start,
-                    )
-                    .await
-                    {
-                        ForwardOutcome::Done(resp) => return resp,
-                        ForwardOutcome::Retry {
-                            saw_529: this_529,
-                            push_skip,
-                        } => {
-                            if this_529 {
-                                saw_529 = true;
+            // Pick the next candidate. Anthropic-protocol branches (accounts or
+            // unified Anthropic) resolve to a `(ForwardOutcome, EndpointIdx)`
+            // pair; OpenAI-protocol branches (`try_fallback_upstream*`) handle
+            // their `Option<Response>` inline by `return`/`continue`-ing.
+            let (outcome, picked_idx): (ForwardOutcome, EndpointIdx) =
+                match state.pick_endpoint(affinity, &model, &skip).await {
+                    Some(EndpointIdx::Account(i)) => {
+                        let acct = &state.accounts[i];
+                        let out = forward_openai_compat_anthropic(
+                            &state,
+                            &parts,
+                            &state.upstream,
+                            &acct.token,
+                            acct.passthrough,
+                            &acct.name,
+                            UsageTarget::Account(i),
+                            &acct.requests,
+                            &acct.rate_info,
+                            &acct.burn_rate,
+                            &anthropic_body,
+                            &oauth_anthropic_body,
+                            &req_id,
+                            &client_id,
+                            &client_ver,
+                            &client_ip,
+                            &agent_id,
+                            &session_id,
+                            &model,
+                            is_streaming,
+                            request_start,
+                        )
+                        .await;
+                        (out, EndpointIdx::Account(i))
+                    }
+                    Some(EndpointIdx::Upstream(u)) => {
+                        // All account tiers exhausted — the upstream is OpenAI-native,
+                        // so forward the original request body without translation.
+                        match try_fallback_upstream(
+                            &state,
+                            &body_bytes,
+                            &req_id,
+                            &client_id,
+                            &model,
+                            u,
+                            false,
+                        )
+                        .await
+                        {
+                            Some(resp) => return resp,
+                            None => {
+                                skip.push(EndpointIdx::Upstream(u));
+                                continue;
                             }
-                            if push_skip {
-                                skip.push(EndpointIdx::Account(i));
-                            }
-                            continue;
                         }
                     }
-                }
-                EndpointIdx::Upstream(u) => {
-                    // All account tiers exhausted — the upstream is OpenAI-native,
-                    // so forward the original request body without translation.
-                    match try_fallback_upstream(
-                        &state,
-                        &body_bytes,
-                        &req_id,
-                        &client_id,
-                        &model,
-                        u,
-                        false,
-                    )
-                    .await
-                    {
-                        Some(resp) => return resp,
-                        None => {
-                            skip.push(EndpointIdx::Upstream(u));
-                            continue;
-                        }
-                    }
-                }
-                EndpointIdx::Unified(i) => {
-                    let ep = &state.endpoints[i];
-                    match ep.protocol {
-                        Protocol::Anthropic => {
-                            match forward_openai_compat_anthropic(
-                                &state,
-                                &parts,
-                                &ep.base_url,
-                                &ep.token,
-                                ep.passthrough,
-                                &ep.name,
-                                UsageTarget::Unified(i),
-                                &ep.requests,
-                                &ep.rate_info,
-                                &ep.burn_rate,
-                                &anthropic_body,
-                                &oauth_anthropic_body,
-                                &req_id,
-                                &client_id,
-                                &client_ver,
-                                &client_ip,
-                                &agent_id,
-                                &session_id,
-                                &model,
-                                is_streaming,
-                                request_start,
-                            )
-                            .await
-                            {
-                                ForwardOutcome::Done(resp) => return resp,
-                                ForwardOutcome::Retry {
-                                    saw_529: this_529,
-                                    push_skip,
-                                } => {
-                                    if this_529 {
-                                        saw_529 = true;
-                                    }
-                                    if push_skip {
+                    Some(EndpointIdx::Unified(i)) => {
+                        let ep = &state.endpoints[i];
+                        match ep.protocol {
+                            Protocol::Anthropic => {
+                                let out = forward_openai_compat_anthropic(
+                                    &state,
+                                    &parts,
+                                    &ep.base_url,
+                                    &ep.token,
+                                    ep.passthrough,
+                                    &ep.name,
+                                    UsageTarget::Unified(i),
+                                    &ep.requests,
+                                    &ep.rate_info,
+                                    &ep.burn_rate,
+                                    &anthropic_body,
+                                    &oauth_anthropic_body,
+                                    &req_id,
+                                    &client_id,
+                                    &client_ver,
+                                    &client_ip,
+                                    &agent_id,
+                                    &session_id,
+                                    &model,
+                                    is_streaming,
+                                    request_start,
+                                )
+                                .await;
+                                (out, EndpointIdx::Unified(i))
+                            }
+                            Protocol::OpenAI => {
+                                match try_fallback_upstream_unified(
+                                    &state,
+                                    &body_bytes,
+                                    &req_id,
+                                    &client_id,
+                                    &model,
+                                    i,
+                                    false,
+                                )
+                                .await
+                                {
+                                    Some(resp) => return resp,
+                                    None => {
                                         skip.push(EndpointIdx::Unified(i));
+                                        continue;
                                     }
-                                    continue;
-                                }
-                            }
-                        }
-                        Protocol::OpenAI => {
-                            match try_fallback_upstream_unified(
-                                &state,
-                                &body_bytes,
-                                &req_id,
-                                &client_id,
-                                &model,
-                                i,
-                                false,
-                            )
-                            .await
-                            {
-                                Some(resp) => return resp,
-                                None => {
-                                    skip.push(EndpointIdx::Unified(i));
-                                    continue;
                                 }
                             }
                         }
                     }
+                    None => {
+                        warn!("all endpoints exhausted");
+                        return (
+                            StatusCode::TOO_MANY_REQUESTS,
+                            "all upstream endpoints exhausted",
+                        )
+                            .into_response();
+                    }
+                };
+
+            match outcome {
+                ForwardOutcome::Done(resp) => return resp,
+                ForwardOutcome::Retry {
+                    saw_529: this_529,
+                    push_skip,
+                } => {
+                    if this_529 {
+                        saw_529 = true;
+                    }
+                    if push_skip {
+                        skip.push(picked_idx);
+                    }
+                    continue;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3444,7 +3444,7 @@ fn log_usage(req_id: &str, client_id: &str, model: &str, account: &str, usage: &
 #[allow(clippy::too_many_arguments)]
 async fn finalize_stream(
     state: &AppState,
-    idx: usize,
+    target: UsageTarget,
     req_id: &str,
     client_id: &str,
     model: &str,
@@ -3463,7 +3463,7 @@ async fn finalize_stream(
     let usage = TokenUsage::from_sse_text(&text);
     let elapsed_ms = request_start.elapsed().as_millis() as u64;
     if !usage.is_empty() {
-        state.record_usage(idx, client_id, &usage).await;
+        state.record_usage(target, client_id, &usage).await;
         log_usage(req_id, client_id, model, acct_name, &usage);
     } else {
         let reason = if upstream_error {
@@ -3526,7 +3526,7 @@ async fn finalize_stream(
 #[allow(clippy::too_many_arguments)]
 async fn finalize_non_stream(
     state: &AppState,
-    idx: usize,
+    target: UsageTarget,
     req_id: &str,
     client_id: &str,
     model: &str,
@@ -3540,7 +3540,7 @@ async fn finalize_non_stream(
     openai_compat: bool,
 ) {
     if !usage.is_empty() {
-        state.record_usage(idx, client_id, usage).await;
+        state.record_usage(target, client_id, usage).await;
         log_usage(req_id, client_id, model, acct_name, usage);
     }
     let mut log = serde_json::json!({
@@ -3565,21 +3565,49 @@ async fn finalize_non_stream(
     state.shadow_log(log);
 }
 
+/// Which runtime pool a usage record applies to. During the strangler
+/// migration both pools coexist; after Phase 4 only Unified remains.
+#[derive(Clone, Copy, Debug)]
+enum UsageTarget {
+    /// Index into AppState.accounts (legacy pool).
+    Account(usize),
+    /// Index into AppState.endpoints (unified pool).
+    #[allow(dead_code)]
+    // wired up in Task 9 (forward_anthropic for Unified Anthropic endpoint)
+    Unified(usize),
+}
+
 impl AppState {
-    /// Record token usage for an account and client.
-    async fn record_usage(&self, account_idx: usize, client_id: &str, usage: &TokenUsage) {
+    /// Record token usage for an endpoint and client.
+    async fn record_usage(&self, target: UsageTarget, client_id: &str, usage: &TokenUsage) {
         if usage.is_empty() {
             return;
         }
-        let acct = &self.accounts[account_idx];
-        acct.input_tokens
-            .fetch_add(usage.input_tokens, Ordering::Relaxed);
-        acct.output_tokens
-            .fetch_add(usage.output_tokens, Ordering::Relaxed);
-        acct.cache_creation_tokens
-            .fetch_add(usage.cache_creation_input_tokens, Ordering::Relaxed);
-        acct.cache_read_tokens
-            .fetch_add(usage.cache_read_input_tokens, Ordering::Relaxed);
+        // Resolve the four token-counter atomics from whichever pool.
+        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens) = match target {
+            UsageTarget::Account(i) => {
+                let a = &self.accounts[i];
+                (
+                    &a.input_tokens,
+                    &a.output_tokens,
+                    &a.cache_creation_tokens,
+                    &a.cache_read_tokens,
+                )
+            }
+            UsageTarget::Unified(i) => {
+                let e = &self.endpoints[i];
+                (
+                    &e.input_tokens,
+                    &e.output_tokens,
+                    &e.cache_creation_tokens,
+                    &e.cache_read_tokens,
+                )
+            }
+        };
+        input_tokens.fetch_add(usage.input_tokens, Ordering::Relaxed);
+        output_tokens.fetch_add(usage.output_tokens, Ordering::Relaxed);
+        cache_creation_tokens.fetch_add(usage.cache_creation_input_tokens, Ordering::Relaxed);
+        cache_read_tokens.fetch_add(usage.cache_read_input_tokens, Ordering::Relaxed);
 
         // Per-client tracking
         if client_id != "-" {
@@ -4560,7 +4588,7 @@ async fn proxy_handler(
                     // Parse accumulated SSE data for usage
                     finalize_stream(
                         &state_clone,
-                        idx,
+                        UsageTarget::Account(idx),
                         &req_id,
                         &client_id_clone,
                         &model_clone,
@@ -4593,7 +4621,7 @@ async fn proxy_handler(
                 }
                 finalize_non_stream(
                     &state,
-                    idx,
+                    UsageTarget::Account(idx),
                     &req_id,
                     &client_id,
                     &model,
@@ -7884,7 +7912,7 @@ async fn openai_chat_handler(
                     // Extract and record token usage from accumulated SSE data
                     finalize_stream(
                         &state_clone,
-                        idx,
+                        UsageTarget::Account(idx),
                         &req_id,
                         &client_id_clone,
                         &model_clone,
@@ -7945,7 +7973,7 @@ async fn openai_chat_handler(
             let usage = TokenUsage::from_response_body(&anthropic_resp);
             finalize_non_stream(
                 &state,
-                idx,
+                UsageTarget::Account(idx),
                 &req_id,
                 &client_id,
                 &model,
@@ -12427,7 +12455,9 @@ data: {\"type\":\"message_stop\"}\n\n";
             cache_creation_input_tokens: 20,
             cache_read_input_tokens: 30,
         };
-        state.record_usage(0, "test-client", &usage).await;
+        state
+            .record_usage(UsageTarget::Account(0), "test-client", &usage)
+            .await;
 
         assert_eq!(state.accounts[0].input_tokens.load(Ordering::Relaxed), 100);
         assert_eq!(state.accounts[0].output_tokens.load(Ordering::Relaxed), 50);
@@ -12456,7 +12486,9 @@ data: {\"type\":\"message_stop\"}\n\n";
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
         };
-        state.record_usage(0, "-", &usage).await;
+        state
+            .record_usage(UsageTarget::Account(0), "-", &usage)
+            .await;
 
         // Account gets updated
         assert_eq!(state.accounts[0].input_tokens.load(Ordering::Relaxed), 100);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4902,6 +4902,274 @@ async fn try_fallback_upstream(
     }
 }
 
+/// Forward a request to a `Protocol::OpenAI` endpoint in the unified pool.
+///
+/// Used by `proxy_handler`'s `EndpointIdx::Unified` arm (Task 9). Marked
+/// `#[allow(dead_code)]` until that arm lands in the same series.
+/// Mirrors `try_fallback_upstream` but reads from `state.endpoints` and —
+/// critically — returns `None` on upstream 429/5xx so the retry loop advances
+/// to the next candidate. Other 4xx (e.g. 400, 401) are still returned to the
+/// caller as a final response — retry won't help on client-side errors.
+///
+/// Like the original `try_fallback_upstream`, this only increments the
+/// endpoint's request counter; it does not call `record_usage` (OpenAI-compat
+/// responses don't carry the same usage signal we extract for Anthropic).
+#[allow(dead_code)] // wired in Task 9 (proxy_handler EndpointIdx::Unified dispatch)
+async fn try_fallback_upstream_unified(
+    state: &AppState,
+    body_bytes: &[u8],
+    req_id: &str,
+    client_id: &str,
+    model: &str,
+    endpoint_idx: usize,
+    translate: bool, // true = Anthropic↔OpenAI translation needed
+) -> Option<Response> {
+    let ep = &state.endpoints[endpoint_idx];
+
+    info!(
+        req_id,
+        client_id,
+        model,
+        upstream = ep.name,
+        translate,
+        "fallback: routing to unified OpenAI endpoint"
+    );
+
+    ep.requests.fetch_add(1, Ordering::Relaxed);
+
+    // Parse once to extract streaming flag before potential translation
+    let parsed: serde_json::Value = serde_json::from_slice(body_bytes).ok()?;
+    let is_streaming = parsed
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
+
+    // Build request body
+    let request_body = if translate {
+        let openai_body = translate_anthropic_request_to_openai(&parsed);
+        serde_json::to_vec(&openai_body).ok()?
+    } else {
+        body_bytes.to_vec()
+    };
+
+    let url = format!("{}/v1/chat/completions", ep.base_url);
+
+    let mut resp = match state
+        .client
+        .post(&url)
+        .header("authorization", format!("Bearer {}", ep.token))
+        .header("content-type", "application/json")
+        .body(request_body)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            error!(
+                req_id,
+                upstream = ep.name,
+                error = %e,
+                "fallback: unified OpenAI endpoint request failed"
+            );
+            return None;
+        }
+    };
+
+    let status = resp.status();
+    if !status.is_success() {
+        let err_body = resp
+            .text()
+            .await
+            .unwrap_or_else(|_| "upstream error".to_string());
+        // Retry-eligible: 429 or 5xx → return None so the retry loop advances
+        // to the next candidate. This is the only behavioral difference from
+        // `try_fallback_upstream`.
+        if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+            warn!(
+                req_id,
+                upstream = ep.name,
+                status = status.as_u16(),
+                body = %err_body,
+                "fallback: unified endpoint returned retry-eligible error, advancing"
+            );
+            return None;
+        }
+        warn!(
+            req_id,
+            upstream = ep.name,
+            status = status.as_u16(),
+            body = %err_body,
+            "fallback: unified endpoint returned error"
+        );
+        if translate {
+            // Return error in Anthropic format
+            return Some(
+                Response::builder()
+                    .status(status)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "type": "error",
+                            "error": {
+                                "type": "api_error",
+                                "message": err_body,
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap_or_else(|_| {
+                        (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
+                    }),
+            );
+        }
+        return Some(
+            Response::builder()
+                .status(status)
+                .header("content-type", "application/json")
+                .body(Body::from(err_body))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
+                }),
+        );
+    }
+
+    // Streaming response
+    if is_streaming {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
+        let req_id = req_id.to_string();
+        let upstream_name = ep.name.clone();
+        let translate_response = translate;
+
+        tokio::spawn(async move {
+            let mut buffer: Vec<u8> = Vec::new();
+            let mut ctx = ReverseStreamContext::default();
+            let mut client_gone = false;
+
+            loop {
+                match resp.chunk().await {
+                    Ok(Some(chunk)) => {
+                        if translate_response {
+                            buffer.extend_from_slice(&chunk);
+                            while let Some(pos) = buffer.windows(2).position(|w| w == b"\n\n") {
+                                let event = String::from_utf8_lossy(&buffer[..pos]).into_owned();
+                                buffer.drain(..pos + 2);
+
+                                for line in event.lines() {
+                                    if let Some(data) = line.strip_prefix("data: ") {
+                                        let events =
+                                            translate_openai_sse_to_anthropic(data, &mut ctx);
+                                        for ev in events {
+                                            if tx.send(Ok(bytes::Bytes::from(ev))).await.is_err() {
+                                                client_gone = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                if client_gone {
+                                    break;
+                                }
+                            }
+                        } else if tx.send(Ok(chunk)).await.is_err() {
+                            client_gone = true;
+                        }
+                        if client_gone {
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        warn!(req_id, error = %e, "fallback: unified endpoint SSE read failed");
+                        break;
+                    }
+                }
+            }
+
+            // Flush remaining buffer
+            if translate_response && !buffer.is_empty() && !client_gone {
+                let remaining = String::from_utf8_lossy(&buffer).into_owned();
+                for line in remaining.lines() {
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        let events = translate_openai_sse_to_anthropic(data, &mut ctx);
+                        for ev in events {
+                            if tx.send(Ok(bytes::Bytes::from(ev))).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if client_gone {
+                debug!(req_id, "fallback: client disconnected during stream");
+            }
+            info!(
+                req_id,
+                upstream = upstream_name,
+                "fallback: unified endpoint stream complete"
+            );
+        });
+
+        return Some(
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "text/event-stream")
+                .header("cache-control", "no-cache")
+                .header("connection", "keep-alive")
+                .body(Body::from_stream(
+                    tokio_stream::wrappers::ReceiverStream::new(rx),
+                ))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback stream error").into_response()
+                }),
+        );
+    }
+
+    // Non-streaming response
+    let resp_body = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            error!(req_id, error = %e, "fallback: failed to read unified endpoint response body");
+            return None;
+        }
+    };
+
+    if translate {
+        let openai_resp: serde_json::Value =
+            serde_json::from_slice(&resp_body).unwrap_or(serde_json::json!({}));
+        let anthropic_resp = translate_openai_response_to_anthropic(&openai_resp);
+        info!(
+            req_id,
+            upstream = ep.name,
+            "fallback: unified endpoint translated response"
+        );
+        Some(
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .body(Body::from(anthropic_resp.to_string()))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
+                }),
+        )
+    } else {
+        info!(
+            req_id,
+            upstream = ep.name,
+            "fallback: unified endpoint forwarded response"
+        );
+        Some(
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .body(Body::from(resp_body))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
+                }),
+        )
+    }
+}
+
 // ── Upstream passthrough handler ─────────────────────────────────────
 
 async fn upstream_handler(

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,20 @@ struct UpstreamConfig {
     priority: u32,
 }
 
+/// Wire format on config / state: "anthropic" | "openai".
+///
+/// `#[allow(dead_code)]` is transient: removed when Task 2 of the
+/// unified-endpoints plan adds `EndpointConfig` which references this enum
+/// from non-test code.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+#[allow(dead_code)]
+enum Protocol {
+    #[default]
+    Anthropic,
+    OpenAI,
+}
+
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 enum RoutingStrategy {
     #[default]
@@ -7953,6 +7967,20 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn protocol_deserializes_lowercase_strings() {
+        let p: Protocol = serde_json::from_str(r#""anthropic""#).unwrap();
+        assert_eq!(p, Protocol::Anthropic);
+        let p: Protocol = serde_json::from_str(r#""openai""#).unwrap();
+        assert_eq!(p, Protocol::OpenAI);
+    }
+
+    #[test]
+    fn protocol_default_is_anthropic() {
+        assert_eq!(Protocol::default(), Protocol::Anthropic);
+        assert_ne!(Protocol::default(), Protocol::OpenAI);
+    }
 
     // ── Helpers ──────────────────────────────────────────────────────
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9664,6 +9664,34 @@ token = "sk-ant-test"
         }
     }
 
+    /// Shared fixture for the unified `Endpoint` pool. Callers that need a
+    /// non-default field (priority, token, base_url, models) mutate the
+    /// returned struct.
+    fn make_endpoint(name: &str, protocol: Protocol) -> Endpoint {
+        Endpoint {
+            name: name.to_string(),
+            protocol,
+            base_url: match protocol {
+                Protocol::Anthropic => "https://api.anthropic.com".to_string(),
+                Protocol::OpenAI => "https://gateway.example".to_string(),
+            },
+            token: "sk-test".to_string(),
+            passthrough: false,
+            models: vec![],
+            priority: 0,
+            requests: AtomicU64::new(0),
+            rate_info: RwLock::new(RateLimitInfo::default()),
+            burn_rate: Mutex::new(BurnRate::new()),
+            input_tokens: AtomicU64::new(0),
+            output_tokens: AtomicU64::new(0),
+            cache_creation_tokens: AtomicU64::new(0),
+            cache_read_tokens: AtomicU64::new(0),
+            last_routing_weight: AtomicU64::new(0),
+            last_routing_share: AtomicU64::new(0),
+            last_effective_gate: AtomicU64::new(0),
+        }
+    }
+
     fn test_state_with_strategy(
         accounts: Vec<Account>,
         routing_strategy: RoutingStrategy,
@@ -11584,34 +11612,17 @@ token = "sk-ant-test"
 
     #[tokio::test]
     async fn stats_endpoint_exposes_endpoints_array() {
-        fn make_ep(name: &str, protocol: Protocol) -> Endpoint {
-            Endpoint {
-                name: name.to_string(),
-                protocol,
-                base_url: "https://api.anthropic.com".to_string(),
-                token: "sk-ant-api-test".to_string(),
-                passthrough: false,
-                models: vec![],
-                priority: 5,
-                requests: AtomicU64::new(0),
-                rate_info: RwLock::new(RateLimitInfo::default()),
-                burn_rate: Mutex::new(BurnRate::new()),
-                input_tokens: AtomicU64::new(0),
-                output_tokens: AtomicU64::new(0),
-                cache_creation_tokens: AtomicU64::new(0),
-                cache_read_tokens: AtomicU64::new(0),
-                last_routing_weight: AtomicU64::new(0),
-                last_routing_share: AtomicU64::new(0),
-                last_effective_gate: AtomicU64::new(0),
-            }
-        }
+        let ep = |name: &str, protocol: Protocol| {
+            let mut e = make_endpoint(name, protocol);
+            e.priority = 5;
+            e
+        };
         // Endpoints-only config: legacy accounts pool is empty.
         let mut state = test_state_with(vec![]);
         {
             let st = Arc::get_mut(&mut state).expect("uniquely owned before router build");
-            st.endpoints
-                .push(make_ep("ep-anthropic", Protocol::Anthropic));
-            st.endpoints.push(make_ep("ep-openai", Protocol::OpenAI));
+            st.endpoints.push(ep("ep-anthropic", Protocol::Anthropic));
+            st.endpoints.push(ep("ep-openai", Protocol::OpenAI));
         }
         let addr = serve(build_router(state)).await;
 
@@ -15672,25 +15683,9 @@ data: {\"type\":\"message_stop\"}\n\n";
         }
         let mut state = test_state_with(vec![acct]);
         let st = Arc::get_mut(&mut state).expect("uniquely owned");
-        st.endpoints.push(Endpoint {
-            name: "openai".to_string(),
-            protocol: Protocol::OpenAI,
-            base_url: "https://gateway.example".to_string(),
-            token: "sk".to_string(),
-            passthrough: false,
-            models: vec![],
-            priority: 100,
-            requests: AtomicU64::new(0),
-            rate_info: RwLock::new(RateLimitInfo::default()),
-            burn_rate: Mutex::new(BurnRate::new()),
-            input_tokens: AtomicU64::new(0),
-            output_tokens: AtomicU64::new(0),
-            cache_creation_tokens: AtomicU64::new(0),
-            cache_read_tokens: AtomicU64::new(0),
-            last_routing_weight: AtomicU64::new(0),
-            last_routing_share: AtomicU64::new(0),
-            last_effective_gate: AtomicU64::new(0),
-        });
+        let mut openai_ep = make_endpoint("openai", Protocol::OpenAI);
+        openai_ep.priority = 100;
+        st.endpoints.push(openai_ep);
         st.emergency_threshold = 0.88;
         assert!(
             state.is_emergency_brake_active().await,
@@ -15704,25 +15699,9 @@ data: {\"type\":\"message_stop\"}\n\n";
         // ran, `rate_info.utilization_5h` would become Some(0.25). The OpenAI
         // skip means the endpoint is never contacted and rate_info stays None.
         let (mock_url, _h) = spawn_mock_upstream().await;
-        let ep = Endpoint {
-            name: "openai".to_string(),
-            protocol: Protocol::OpenAI,
-            base_url: mock_url,
-            token: "sk-ant-api-test".to_string(),
-            passthrough: false,
-            models: vec![],
-            priority: 100,
-            requests: AtomicU64::new(0),
-            rate_info: RwLock::new(RateLimitInfo::default()),
-            burn_rate: Mutex::new(BurnRate::new()),
-            input_tokens: AtomicU64::new(0),
-            output_tokens: AtomicU64::new(0),
-            cache_creation_tokens: AtomicU64::new(0),
-            cache_read_tokens: AtomicU64::new(0),
-            last_routing_weight: AtomicU64::new(0),
-            last_routing_share: AtomicU64::new(0),
-            last_effective_gate: AtomicU64::new(0),
-        };
+        let mut ep = make_endpoint("openai", Protocol::OpenAI);
+        ep.base_url = mock_url;
+        ep.priority = 100;
         let mut state = test_state_with(vec![]);
         Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
 
@@ -18340,32 +18319,12 @@ data: {\"type\":\"message_stop\"}\n\n";
     /// Anthropic + OpenAI protocols) neither path may panic.
     #[tokio::test]
     async fn sync_and_publish_handle_endpoint_pool_without_redis() {
-        fn make_ep(name: &str, protocol: Protocol) -> Endpoint {
-            Endpoint {
-                name: name.to_string(),
-                protocol,
-                base_url: "https://api.anthropic.com".to_string(),
-                token: "sk-ant-api-test".to_string(),
-                passthrough: false,
-                models: vec![],
-                priority: 0,
-                requests: AtomicU64::new(0),
-                rate_info: RwLock::new(RateLimitInfo::default()),
-                burn_rate: Mutex::new(BurnRate::new()),
-                input_tokens: AtomicU64::new(0),
-                output_tokens: AtomicU64::new(0),
-                cache_creation_tokens: AtomicU64::new(0),
-                cache_read_tokens: AtomicU64::new(0),
-                last_routing_weight: AtomicU64::new(0),
-                last_routing_share: AtomicU64::new(0),
-                last_effective_gate: AtomicU64::new(0),
-            }
-        }
         let mut state = test_state_with(vec![]);
         {
             let st = Arc::get_mut(&mut state).unwrap();
-            st.endpoints.push(make_ep("ep-a", Protocol::Anthropic));
-            st.endpoints.push(make_ep("ep-oai", Protocol::OpenAI));
+            st.endpoints
+                .push(make_endpoint("ep-a", Protocol::Anthropic));
+            st.endpoints.push(make_endpoint("ep-oai", Protocol::OpenAI));
         }
         // Both paths must be no-ops (redis is None) and must not panic.
         state.sync_from_redis().await;
@@ -19096,34 +19055,12 @@ upstream = "https://api.anthropic.com"
 
     #[tokio::test]
     async fn save_load_roundtrip_unified_endpoints() {
-        fn make_test_endpoint(name: &str) -> Endpoint {
-            Endpoint {
-                name: name.to_string(),
-                protocol: Protocol::Anthropic,
-                base_url: "https://api.anthropic.com".to_string(),
-                token: "sk-ant-api-test".to_string(),
-                passthrough: false,
-                models: vec![],
-                priority: 0,
-                requests: AtomicU64::new(0),
-                rate_info: RwLock::new(RateLimitInfo::default()),
-                burn_rate: Mutex::new(BurnRate::new()),
-                input_tokens: AtomicU64::new(0),
-                output_tokens: AtomicU64::new(0),
-                cache_creation_tokens: AtomicU64::new(0),
-                cache_read_tokens: AtomicU64::new(0),
-                last_routing_weight: AtomicU64::new(0),
-                last_routing_share: AtomicU64::new(0),
-                last_effective_gate: AtomicU64::new(0),
-            }
-        }
-
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let mut state = test_state_with(vec![]);
         {
             let st = Arc::get_mut(&mut state).unwrap();
             st.state_path = tmp.path().to_path_buf();
-            st.endpoints.push(make_test_endpoint("ep1"));
+            st.endpoints.push(make_endpoint("ep1", Protocol::Anthropic));
         }
         let now_epoch = AppState::now_epoch();
         state.endpoints[0].requests.store(7, Ordering::Relaxed);
@@ -19143,7 +19080,7 @@ upstream = "https://api.anthropic.com"
         {
             let st = Arc::get_mut(&mut state2).unwrap();
             st.state_path = tmp.path().to_path_buf();
-            st.endpoints.push(make_test_endpoint("ep1"));
+            st.endpoints.push(make_endpoint("ep1", Protocol::Anthropic));
         }
         state2.load_state().await;
         assert_eq!(state2.endpoints[0].requests.load(Ordering::Relaxed), 7);
@@ -20389,35 +20326,12 @@ upstream = "https://api.anthropic.com"
     /// OpenAI endpoints get the fixed (gate 0.0, weight 1.0) representative.
     #[tokio::test]
     async fn refresh_metrics_weights_populates_endpoint_pool() {
-        fn anthropic_ep(name: &str) -> Endpoint {
-            Endpoint {
-                name: name.to_string(),
-                protocol: Protocol::Anthropic,
-                base_url: "https://api.anthropic.com".to_string(),
-                token: "sk-ant-api-test".to_string(),
-                passthrough: false,
-                models: vec![],
-                priority: 0,
-                requests: AtomicU64::new(0),
-                rate_info: RwLock::new(RateLimitInfo::default()),
-                burn_rate: Mutex::new(BurnRate::new()),
-                input_tokens: AtomicU64::new(0),
-                output_tokens: AtomicU64::new(0),
-                cache_creation_tokens: AtomicU64::new(0),
-                cache_read_tokens: AtomicU64::new(0),
-                last_routing_weight: AtomicU64::new(0),
-                last_routing_share: AtomicU64::new(0),
-                last_effective_gate: AtomicU64::new(0),
-            }
-        }
-        let mut openai_ep = anthropic_ep("oai");
-        openai_ep.protocol = Protocol::OpenAI;
-
         let mut state = test_state_with(vec![]);
         {
             let st = Arc::get_mut(&mut state).unwrap();
-            st.endpoints.push(anthropic_ep("ep-a"));
-            st.endpoints.push(openai_ep);
+            st.endpoints
+                .push(make_endpoint("ep-a", Protocol::Anthropic));
+            st.endpoints.push(make_endpoint("oai", Protocol::OpenAI));
         }
         let now = AppState::now_epoch();
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5475,122 +5475,6 @@ async fn try_fallback_upstream_unified(
     }
 }
 
-// ── Upstream passthrough handler ─────────────────────────────────────
-
-async fn upstream_handler(
-    State(state): State<Arc<AppState>>,
-    axum::extract::ConnectInfo(client_addr): axum::extract::ConnectInfo<SocketAddr>,
-    axum::extract::Path((upstream_name, _rest)): axum::extract::Path<(String, String)>,
-    req: Request<Body>,
-) -> Response {
-    let client_ip = client_addr.ip();
-
-    if !state.is_ip_allowed(&client_ip) {
-        warn!(client = %client_ip, "rejected: IP not in allowlist");
-        return (StatusCode::FORBIDDEN, "forbidden").into_response();
-    }
-
-    if let Some(ref key) = state.proxy_key {
-        let provided = req.headers().get("x-api-key").and_then(|v| v.to_str().ok());
-        if provided != Some(key.as_str()) {
-            warn!(client = %client_ip, "rejected: invalid or missing proxy key");
-            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
-        }
-    }
-
-    let upstream = match state.upstreams.iter().find(|u| u.name == upstream_name) {
-        Some(u) => u,
-        None => {
-            warn!(client = %client_ip, upstream = %upstream_name, "unknown upstream");
-            return (StatusCode::NOT_FOUND, "unknown upstream").into_response();
-        }
-    };
-
-    let (parts, body) = req.into_parts();
-
-    // Extract client identification headers
-    let client_id = state.resolve_client_id(&client_ip, &parts.headers);
-
-    let body_bytes = match axum::body::to_bytes(body, MAX_REQUEST_BODY_BYTES).await {
-        Ok(b) => b,
-        Err(e) => {
-            error!("failed to read request body: {e}");
-            return (StatusCode::BAD_REQUEST, "bad request body").into_response();
-        }
-    };
-
-    // Extract model from request body for logging
-    let model = serde_json::from_slice::<serde_json::Value>(&body_bytes)
-        .ok()
-        .and_then(|v| v.get("model").and_then(|m| m.as_str().map(String::from)))
-        .unwrap_or_default();
-
-    // Build upstream URL: strip /upstream/<name> prefix, forward the rest
-    let path = parts.uri.path();
-    let prefix = format!("/upstream/{}", upstream_name);
-    let remainder = path.strip_prefix(&prefix).unwrap_or("/");
-    let remainder = if remainder.is_empty() { "/" } else { remainder };
-    let query = parts
-        .uri
-        .query()
-        .map(|q| format!("?{}", q))
-        .unwrap_or_default();
-    let url = format!("{}{}{}", upstream.base_url, remainder, query);
-
-    let mut headers = parts.headers.clone();
-    headers.remove("host");
-    headers.remove("authorization");
-    headers.remove("x-api-key");
-    // Inject upstream API key as Bearer token (OpenAI-compatible)
-    headers.insert(
-        "authorization",
-        HeaderValue::from_str(&format!("Bearer {}", upstream.api_key)).unwrap(),
-    );
-
-    let upstream_req = state
-        .client
-        .request(parts.method.clone(), &url)
-        .headers(headers)
-        .body(body_bytes);
-
-    let resp = match upstream_req.send().await {
-        Ok(r) => r,
-        Err(e) => {
-            error!(upstream = upstream.name, error = %e, "upstream request failed");
-            return (StatusCode::BAD_GATEWAY, "upstream request failed").into_response();
-        }
-    };
-
-    let status = resp.status();
-    upstream.requests.fetch_add(1, Ordering::Relaxed);
-
-    info!(
-        client = %client_ip,
-        client_id = %client_id,
-        model = %model,
-        upstream = upstream.name,
-        status = status.as_u16(),
-        total = upstream.requests.load(Ordering::Relaxed),
-        "proxied (upstream)"
-    );
-
-    let resp_status = StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
-    let resp_headers = resp.headers().clone();
-
-    let mut builder = Response::builder().status(resp_status);
-    for (k, v) in resp_headers.iter() {
-        if k == "transfer-encoding" {
-            continue;
-        }
-        builder = builder.header(k, v);
-    }
-    builder
-        .body(Body::from_stream(resp.bytes_stream()))
-        .unwrap_or_else(|_| {
-            (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
-        })
-}
-
 // ── Stats endpoint ──────────────────────────────────────────────────
 
 /// Build one `/stats` JSON entry from the shared (name, priority, rate_info,
@@ -9295,7 +9179,6 @@ async fn main() {
             "/v1/chat/completions",
             axum::routing::post(openai_chat_handler),
         )
-        .route("/upstream/{name}/{*rest}", any(upstream_handler))
         .fallback(any(proxy_handler))
         .with_state(state.clone());
 
@@ -9878,7 +9761,6 @@ token = "sk-ant-test"
                 "/v1/chat/completions",
                 axum::routing::post(openai_chat_handler),
             )
-            .route("/upstream/{name}/{*rest}", any(upstream_handler))
             .fallback(any(proxy_handler))
             .with_state(state)
     }
@@ -11643,65 +11525,6 @@ token = "sk-ant-test"
         assert_eq!(endpoints[0]["priority"], 5);
         assert_eq!(endpoints[1]["name"], "ep-openai");
         assert_eq!(endpoints[1]["protocol"], "openai");
-    }
-
-    #[tokio::test]
-    async fn upstream_handler_forwards_to_named_upstream() {
-        let (mock_url, _handle) = spawn_mock_upstream().await;
-        let (app, _state) = test_app(&mock_url, None);
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(
-                listener,
-                app.into_make_service_with_connect_info::<SocketAddr>(),
-            )
-            .await
-            .unwrap();
-        });
-
-        let client = Client::new();
-        let resp = client
-            .post(format!("http://{}/upstream/mock/v1/chat/completions", addr))
-            .header("content-type", "application/json")
-            .body(r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#)
-            .send()
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), reqwest::StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn upstream_handler_rejects_unknown_upstream() {
-        let (mock_url, _handle) = spawn_mock_upstream().await;
-        let (app, _state) = test_app(&mock_url, None);
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(
-                listener,
-                app.into_make_service_with_connect_info::<SocketAddr>(),
-            )
-            .await
-            .unwrap();
-        });
-
-        let client = Client::new();
-        let resp = client
-            .post(format!(
-                "http://{}/upstream/nonexistent/v1/chat/completions",
-                addr
-            ))
-            .header("content-type", "application/json")
-            .body("{}")
-            .send()
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
     }
 
     // ── Unit: OpenAI request translation ────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ use tracing::{debug, error, info, trace, warn};
 #[derive(Deserialize, Clone)]
 struct Config {
     listen: String,
-    upstream: String,
     #[allow(dead_code)]
     strategy: Option<String>,
     rate_limit_cooldown_secs: Option<u64>,
@@ -39,14 +38,11 @@ struct Config {
     /// Source IP allowlist. Supports individual IPs and CIDR ranges. None/empty = allow all.
     allowed_ips: Option<Vec<String>>,
     /// Unified routing endpoints. Each entry is either Anthropic-native or
-    /// OpenAI-compatible, distinguished by `protocol`. Replaces [[accounts]]
-    /// + [[upstreams]] + fallback_upstream.
+    /// OpenAI-compatible, distinguished by `protocol`. The sole endpoint pool —
+    /// the legacy [[accounts]] / [[upstreams]] / fallback_upstream keys are
+    /// rejected at startup by `reject_legacy_config_keys`.
     #[serde(default)]
     endpoints: Vec<EndpointConfig>,
-    accounts: Vec<AccountConfig>,
-    /// OpenAI-compatible upstream routes. Requests to /upstream/<name>/... are forwarded.
-    #[serde(default)]
-    upstreams: Vec<UpstreamConfig>,
     /// IP-to-client-name mapping. Falls back to x-client-id header, then "-".
     #[serde(default)]
     client_names: HashMap<String, String>,
@@ -81,40 +77,10 @@ struct Config {
     /// Path for debug log file. When set, writes debug-level logs to this file while
     /// keeping info-level on stderr. For investigating cache/auth behavior.
     debug_log: Option<String>,
-    /// Name of an [[upstreams]] entry to use as fallback when all accounts are exhausted.
-    /// The upstream receives OpenAI-format requests; Anthropic↔OpenAI translation is automatic.
-    fallback_upstream: Option<String>,
     /// Priority penalty added to an account's effective priority tier while it is
     /// serving via Anthropic overage (paid extra usage). Keeps free subscription
     /// capacity preferred over paid overage. Default: 10.
     overage_penalty: Option<u32>,
-}
-
-#[derive(Deserialize, Clone)]
-struct AccountConfig {
-    name: String,
-    /// Auth token. Use "passthrough" to forward caller's auth headers as-is.
-    token: String,
-    /// Optional model allowlist. If set, this account only serves these models.
-    /// Supports exact names ("claude-sonnet-4-6") and prefixes ("claude-opus-*").
-    #[serde(default)]
-    models: Vec<String>,
-    /// Priority tier (0 = highest). Lower tiers are tried first; higher tiers
-    /// only receive traffic when all lower tiers are exhausted. Default: 0.
-    #[serde(default)]
-    priority: u32,
-}
-
-#[derive(Deserialize, Clone)]
-struct UpstreamConfig {
-    name: String,
-    base_url: String,
-    api_key: String,
-    /// Priority tier (0 = highest) used when this upstream is the `fallback_upstream`
-    /// and participates in unified endpoint routing. Set high (e.g. 100) so the
-    /// upstream is tried only after all account tiers are exhausted. Default: 0.
-    #[serde(default)]
-    priority: u32,
 }
 
 #[derive(Deserialize, Clone)]
@@ -451,48 +417,7 @@ fn compute_pressure_status(effective_util: f64, client_id: &str, state: &AppStat
     status
 }
 
-struct Account {
-    name: String,
-    token: String,
-    passthrough: bool,
-    /// Model allowlist — empty means all models allowed.
-    models: Vec<String>,
-    /// Priority tier (0 = highest). Lower tiers are tried first.
-    priority: u32,
-    requests: AtomicU64,
-    rate_info: RwLock<RateLimitInfo>,
-    /// Per-account burn rate tracker (requests per minute EWMA)
-    burn_rate: Mutex<BurnRate>,
-    // Token usage counters (atomic for lock-free concurrent updates)
-    input_tokens: AtomicU64,
-    output_tokens: AtomicU64,
-    cache_creation_tokens: AtomicU64,
-    cache_read_tokens: AtomicU64,
-    /// Representative routing weight (f64 stored as u64 bits). Refreshed by
-    /// `refresh_metrics_weights()` once per probe cycle. Backs the
-    /// `anthropic_account_routing_weight` Prometheus gauge.
-    last_routing_weight: AtomicU64,
-    /// Representative routing share (weight/total, 0.0-1.0, f64 as bits).
-    /// Refreshed by `refresh_metrics_weights()` once per probe cycle. Backs
-    /// the `anthropic_account_routing_share` Prometheus gauge.
-    last_routing_share: AtomicU64,
-    /// Effective routing gate (f64 as bits): max(gate_5h, gate_7d) after
-    /// time-adjustment and status floors. Refreshed by `refresh_metrics_weights()`.
-    last_effective_gate: AtomicU64,
-}
-
-struct Upstream {
-    name: String,
-    base_url: String,
-    api_key: String,
-    /// Priority tier when this upstream participates in unified routing as the fallback.
-    priority: u32,
-    requests: AtomicU64,
-}
-
-/// Unified routing endpoint. Replaces the separate `Account` and `Upstream`
-/// runtime structs (which remain temporarily during the migration). After
-/// Phase 4 cleanup, only this struct survives.
+/// Unified routing endpoint — the sole runtime endpoint pool.
 ///
 /// Rate-limit/utilization fields are populated only for `Protocol::Anthropic`.
 /// `Protocol::OpenAI` endpoints carry a stub `RateLimitInfo` (all fields None);
@@ -500,7 +425,6 @@ struct Upstream {
 ///   1. `routing_candidates()` — short-circuits to a fixed RoutingCandidate.
 ///   2. `is_emergency_brake_active()` — iterates only Anthropic endpoints.
 ///   3. probe loop — skips OpenAI endpoints.
-#[allow(dead_code)] // probe loop, emergency-brake reads in later phases
 struct Endpoint {
     name: String,
     protocol: Protocol,
@@ -543,11 +467,7 @@ impl Endpoint {
 
 struct AppState {
     client: Client,
-    upstream: String,
-    accounts: Vec<Account>,
-    /// Unified endpoints. After Phase 4, this replaces `accounts` and `upstreams`.
-    /// During migration, both sets are populated so consumers can be migrated
-    /// one at a time.
+    /// Unified routing endpoints — the sole endpoint pool.
     endpoints: Vec<Endpoint>,
     robin: AtomicUsize,
     routing_strategy: RoutingStrategy,
@@ -555,7 +475,6 @@ struct AppState {
     state_path: PathBuf,
     proxy_key: Option<String>,
     allowed_ips: Vec<IpAllowEntry>,
-    upstreams: Vec<Upstream>,
     client_names: HashMap<String, String>,
     auto_cache: bool,
     /// Per-client token usage: client_id → [input, output, cache_creation, cache_read]
@@ -591,51 +510,13 @@ struct AppState {
     instance_id: u16,
     /// Probe interval in seconds. Used for freshness check and distributed lock TTL.
     probe_interval_secs: u64,
-    /// Index into `upstreams` for the fallback when all accounts are exhausted.
-    /// The upstream receives OpenAI-format requests; format translation is automatic.
-    fallback_upstream: Option<usize>,
-    /// Priority penalty added to an account's effective priority while it serves
+    /// Priority penalty added to an endpoint's effective priority while it serves
     /// via overage. Default: 10.
     overage_penalty: u32,
 }
 
-impl Account {
-    /// Check if this account can serve the given model.
-    fn serves_model(&self, model: &str) -> bool {
-        if self.models.is_empty() || model.is_empty() {
-            return true; // no filter or no model = allow all
-        }
-        self.models.iter().any(|pattern| {
-            if let Some(prefix) = pattern.strip_suffix('*') {
-                model.starts_with(prefix)
-            } else {
-                model == pattern
-            }
-        })
-    }
-}
-
-/// Index into one of the runtime endpoint pools. After Phase 4 cleanup this
-/// collapses to a bare `usize`. Kept as an enum during the migration so
-/// `Account`/`Upstream` consumers and the new `Endpoint` consumer can coexist.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum EndpointIdx {
-    Account(usize),
-    Upstream(usize),
-    /// Index into AppState.endpoints (new unified pool).
-    #[allow(dead_code)] // constructed by routing_candidates in Task 8
-    Unified(usize),
-}
-
-impl EndpointIdx {
-    #[cfg(test)]
-    fn account(self) -> Option<usize> {
-        match self {
-            EndpointIdx::Account(i) => Some(i),
-            _ => None,
-        }
-    }
-}
+/// Index into `AppState.endpoints` — the sole runtime endpoint pool.
+type EndpointIdx = usize;
 
 #[derive(Clone, Copy, Debug)]
 struct RoutingCandidate {
@@ -857,12 +738,8 @@ impl AppState {
             }
         }
 
-        // In practice exactly one pool is non-empty; persist both for safety.
-        // Accounts are always Anthropic. Skip OpenAI endpoints — their
-        // rate_info is a permanent stub with no state worth persisting.
-        for acct in &self.accounts {
-            endpoints.push(persist_one(&acct.name, &acct.requests, &acct.rate_info, now).await);
-        }
+        // Skip OpenAI endpoints — their rate_info is a permanent stub with no
+        // state worth persisting.
         for ep in &self.endpoints {
             if ep.protocol == Protocol::OpenAI {
                 continue;
@@ -889,7 +766,7 @@ impl AppState {
 
     /// True if `model`'s 7d claim was refreshed recently enough to skip a probe.
     ///
-    /// Pure freshness check shared by `probe_account` and `probe_endpoint_unified`.
+    /// Pure freshness check used by `probe_endpoint`.
     /// Looks up only the model-specific claim key (e.g. `seven_day_opus`), NOT the
     /// general `seven_day` fallback, so probing one family doesn't suppress another.
     /// An empty `model_family` (unrecognized model) never counts as fresh.
@@ -914,206 +791,13 @@ impl AppState {
         }
     }
 
-    /// Fire a minimal request (max_tokens=1) to refresh rate limit headers for an account.
-    /// The `model` parameter controls which model is probed, rotating across families
-    /// so that per-model 7d utilization claims get populated for each family.
-    async fn probe_account(&self, idx: usize, model: &str) {
-        let acct = &self.accounts[idx];
-        if acct.passthrough {
-            debug!(
-                account = acct.name,
-                "skipping probe for passthrough account"
-            );
-            return;
-        }
-
-        // Check if hard-limited — don't waste a request
-        {
-            let info = acct.rate_info.read().await;
-            if let Some(until) = info.hard_limited_until {
-                if Instant::now() < until {
-                    debug!(
-                        account = acct.name,
-                        "skipping probe, account is hard-limited"
-                    );
-                    return;
-                }
-            }
-        }
-
-        // Local freshness check: skip if this model's 7d claim was recently refreshed.
-        let now_epoch = Self::now_epoch();
-        {
-            let info = acct.rate_info.read().await;
-            if Self::claim_recently_probed(&info, model, self.probe_interval_secs, now_epoch) {
-                trace!(
-                    account = acct.name,
-                    probe_model = model,
-                    "probe skipped, model claim is fresh"
-                );
-                return;
-            }
-        }
-
-        // Distributed probe lock: one pod per account+model per interval.
-        // TTL = full configured interval so the lock covers the entire
-        // dedup window (no early-rollover race).
-        if let Some(redis) = &self.redis {
-            let mut conn = redis.clone();
-            let lock_key = format!("alb:probe:{}:{}", acct.name, model);
-            let lock_ttl = self.probe_interval_secs.max(1);
-            let acquired: redis::RedisResult<bool> = redis::cmd("SET")
-                .arg(&lock_key)
-                .arg(1u8)
-                .arg("NX")
-                .arg("EX")
-                .arg(lock_ttl)
-                .query_async(&mut conn)
-                .await;
-            match acquired {
-                Ok(true) => {} // Lock acquired, proceed with probe
-                Ok(false) => {
-                    trace!(
-                        account = acct.name,
-                        probe_model = model,
-                        "probe skipped, another replica is probing"
-                    );
-                    return;
-                }
-                Err(e) => {
-                    // Fail-open: if Redis is down, probe anyway
-                    trace!(account = acct.name, error = %e, "probe lock failed, probing anyway");
-                }
-            }
-        }
-
-        let url = format!("{}/v1/messages", self.upstream);
-        let body = serde_json::json!({
-            "model": model,
-            "max_tokens": 1,
-            "system": [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."}],
-            "messages": [{"role": "user", "content": "."}]
-        });
-
-        let mut req = self
-            .client
-            .post(&url)
-            .header("content-type", "application/json")
-            .header("anthropic-version", "2023-06-01")
-            .header("anthropic-beta", OAUTH_BETA_FLAGS.join(","))
-            .header("user-agent", "claude-cli/2.1.2 (external, cli)")
-            .header("x-app", "cli")
-            .header("anthropic-dangerous-direct-browser-access", "true")
-            .json(&body);
-
-        // Inject auth
-        if acct.token.starts_with("sk-ant-api") {
-            req = req.header("x-api-key", &acct.token);
-        } else if acct.token.starts_with("sk-ant-oat") {
-            req = req.header("authorization", format!("Bearer {}", acct.token));
-        } else {
-            req = req.header("x-api-key", &acct.token);
-        }
-
-        match req.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                self.update_rate_info(idx, resp.headers()).await;
-                if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                    self.mark_hard_limited(idx, resp.headers()).await;
-                } else if status.is_success() {
-                    // 2xx only: account is responsive, clear hard limit and burst counter
-                    // so pick_account stops treating rate data as stale.
-                    // 5xx/529 are upstream errors, not proof the account recovered —
-                    // clearing the hard limit on those would flood a saturated account
-                    // during an Anthropic incident.
-                    let recovered = {
-                        let mut info = acct.rate_info.write().await;
-                        let was_hard_limited = info.hard_limited_until.is_some();
-                        if was_hard_limited {
-                            info.hard_limited_until = None;
-                            debug!(
-                                account = acct.name,
-                                "cleared hard limit after successful probe"
-                            );
-                        }
-                        info.consecutive_burst_429s = 0;
-                        was_hard_limited
-                    };
-                    // Recovery is a sparse, high-impact event — refresh metrics
-                    // immediately so the dashboard reflects the account coming
-                    // back online without waiting for the next probe cycle.
-                    if recovered {
-                        self.signal_hard_limit_recovery(&acct.name).await;
-                    }
-                }
-                // else: 5xx/529 — leave account state untouched. Next probe cycle retries.
-                self.save_state().await;
-                let info = acct.rate_info.read().await;
-                let now_epoch = Self::now_epoch();
-                let (eff_util, constraint, _adj_5h, _adj_7d) =
-                    effective_utilization(&info, now_epoch, model);
-                // Only compute routing weight on 2xx — non-success responses leave
-                // the account state either mutated (429 → hard-limited) or untouched
-                // (5xx), and the pre-response weight no longer reflects reality.
-                let rw = if status.is_success() {
-                    compute_routing_weight(&info, model, now_epoch, false)
-                } else {
-                    None
-                };
-                info!(
-                    account = acct.name,
-                    status = status.as_u16(),
-                    probe_model = model,
-                    utilization = format_args!("{eff_util:.2}"),
-                    util_5h = info
-                        .utilization_5h
-                        .map(|v| format!("{v:.2}"))
-                        .as_deref()
-                        .unwrap_or("-"),
-                    util_7d = info
-                        .utilization_7d
-                        .map(|v| format!("{v:.2}"))
-                        .as_deref()
-                        .unwrap_or("-"),
-                    constraint,
-                    n_claims_7d = info.claims_7d.len(),
-                    gate_5h = rw
-                        .as_ref()
-                        .map(|r| format!("{:.4}", r.gate_5h))
-                        .as_deref()
-                        .unwrap_or("-"),
-                    gate_7d = rw
-                        .as_ref()
-                        .map(|r| format!("{:.4}", r.gate_7d))
-                        .as_deref()
-                        .unwrap_or("-"),
-                    waste_risk = rw
-                        .as_ref()
-                        .map(|r| format!("{:.4}", r.wr))
-                        .as_deref()
-                        .unwrap_or("-"),
-                    weight = rw
-                        .as_ref()
-                        .map(|r| format!("{:.4}", r.weight))
-                        .as_deref()
-                        .unwrap_or("-"),
-                    weight_source = rw.as_ref().map(|r| r.source).unwrap_or("-"),
-                    "probe complete"
-                );
-            }
-            Err(e) => {
-                warn!(account = acct.name, error = %e, "probe failed");
-            }
-        }
-    }
-
-    /// Probe a unified-pool endpoint by index to refresh rate-limit headers.
-    /// Skips `Protocol::OpenAI` endpoints — they expose no Anthropic rate-limit
-    /// headers, so a probe would only burn a request. One of the three named
-    /// `match protocol` sites. Mirrors `probe_account`; Phase 4 collapses the
-    /// two once the legacy Account pool is retired.
-    async fn probe_endpoint_unified(&self, idx: usize, model: &str) {
+    /// Fire a minimal request (max_tokens=1) to refresh rate-limit headers for
+    /// the endpoint at `idx`. The `model` parameter controls which model is
+    /// probed, rotating across families so that per-model 7d utilization claims
+    /// get populated for each family. Skips `Protocol::OpenAI` endpoints — they
+    /// expose no Anthropic rate-limit headers, so a probe would only burn a
+    /// request. One of the three named `match protocol` sites.
+    async fn probe_endpoint(&self, idx: usize, model: &str) {
         let ep = &self.endpoints[idx];
         if ep.protocol == Protocol::OpenAI {
             debug!(endpoint = ep.name, "skipping probe for openai endpoint");
@@ -1155,7 +839,6 @@ impl AppState {
             }
         }
 
-        // Phase 4: this Redis probe-lock block is duplicated from probe_account; the two probe functions collapse in Phase 4.
         // Distributed probe lock: one pod per endpoint+model per interval.
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
@@ -1329,19 +1012,12 @@ impl AppState {
         let now_instant = Instant::now();
 
         for pa in &persisted.endpoints {
-            // Distribute each persisted entry to whichever pool holds a
-            // matching name: legacy accounts first, then unified endpoints.
+            // Match each persisted entry to the endpoint with the same name.
             let restore_target: Option<(&AtomicU64, &RwLock<RateLimitInfo>)> = self
-                .accounts
+                .endpoints
                 .iter()
-                .find(|a| a.name == pa.name)
-                .map(|a| (&a.requests, &a.rate_info))
-                .or_else(|| {
-                    self.endpoints
-                        .iter()
-                        .find(|e| e.name == pa.name)
-                        .map(|e| (&e.requests, &e.rate_info))
-                });
+                .find(|e| e.name == pa.name)
+                .map(|e| (&e.requests, &e.rate_info));
             if let Some((requests, rate_info)) = restore_target {
                 requests.store(pa.requests_total, Ordering::Relaxed);
                 let mut info = rate_info.write().await;
@@ -1765,10 +1441,10 @@ fn effective_utilization(
     }
 }
 
-/// Computed routing weight for a single account+model. Extracted so both
-/// `routing_candidates()` (real requests) and `probe_account()` (periodic probes)
-/// use identical logic. Returns `None` when the account's 7d claim is actively
-/// rejected (caller should skip it).
+/// Computed routing weight for a single endpoint+model. Extracted so both
+/// `routing_candidates()` (real requests) and `probe_endpoint()` (periodic
+/// probes) use identical logic. Returns `None` when the endpoint's 7d claim is
+/// actively rejected (caller should skip it).
 struct RoutingWeight {
     gate_5h: f64,
     gate_7d: f64,
@@ -1919,129 +1595,17 @@ fn classify_hard_limit_sync(
 }
 
 impl AppState {
-    /// Display name for an endpoint (account, upstream, or unified pool), for logging.
+    /// Display name for an endpoint, for logging.
     fn endpoint_name(&self, ep: EndpointIdx) -> &str {
-        match ep {
-            EndpointIdx::Account(i) => &self.accounts[i].name,
-            EndpointIdx::Upstream(i) => &self.upstreams[i].name,
-            EndpointIdx::Unified(i) => &self.endpoints[i].name,
-        }
+        &self.endpoints[ep].name
     }
 
     async fn routing_candidates(&self, model: &str, skip: &[EndpointIdx]) -> Vec<RoutingCandidate> {
         let now = Instant::now();
         let now_epoch = Self::now_epoch();
         let mut candidates: Vec<RoutingCandidate> = Vec::new();
-        for (i, acct) in self.accounts.iter().enumerate() {
-            if skip.contains(&EndpointIdx::Account(i)) {
-                trace!(account = acct.name, "pick: skipping, already tried");
-                continue;
-            }
-            if !acct.serves_model(model) {
-                trace!(
-                    account = acct.name,
-                    model = model,
-                    "pick: skipping, model not in allowlist"
-                );
-                continue;
-            }
-
-            let info = acct.rate_info.read().await;
-
-            if let Some(until) = info.hard_limited_until {
-                if now < until {
-                    trace!(
-                        account = acct.name,
-                        hard_limited_secs = until.duration_since(now).as_secs(),
-                        "pick: skipping hard-limited account"
-                    );
-                    continue;
-                }
-            }
-
-            // Detect stale data: hard limit expired but no fresh response since.
-            // mark_hard_limited poisons remaining_tokens/requests and update_rate_info
-            // on the 429 stores high utilization + "rejected" statuses. Without this
-            // check, those stale values prevent the account from ever being selected
-            // again — only probes can refresh the data, and they run infrequently.
-            let stale_after_hard_limit = info
-                .hard_limited_until
-                .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
-
-            let rw = match compute_routing_weight(&info, model, now_epoch, stale_after_hard_limit) {
-                Some(rw) => rw,
-                None => {
-                    trace!(
-                        account = acct.name,
-                        model = model,
-                        "pick: skipping, 7d claim rejected"
-                    );
-                    continue;
-                }
-            };
-
-            // Effective priority: an account serving via paid overage is demoted by
-            // `overage_penalty` so free subscription capacity is always preferred.
-            let effective_priority = if rw.overage_active {
-                acct.priority.saturating_add(self.overage_penalty)
-            } else {
-                acct.priority
-            };
-
-            trace!(
-                account = acct.name,
-                gate_5h = format!("{:.4}", rw.gate_5h),
-                gate_7d = format!("{:.4}", rw.gate_7d),
-                gate = format!("{:.4}", rw.gate),
-                waste_risk = format!("{:.4}", rw.wr),
-                weight = format!("{:.4}", rw.weight),
-                source = rw.source,
-                priority = effective_priority,
-                overage = rw.overage_active,
-                "pick: candidate"
-            );
-
-            candidates.push(RoutingCandidate {
-                endpoint: EndpointIdx::Account(i),
-                priority: effective_priority,
-                gate_5h: rw.gate_5h,
-                gate_7d: rw.gate_7d,
-                gate: rw.gate,
-                wr: rw.wr,
-                weight: rw.weight,
-                source: rw.source,
-            });
-        }
-
-        // The fallback upstream is a first-class routing candidate at its configured
-        // priority. It has no rate-limit data: gate 0 (always "healthy"), weight 1.
-        if let Some(u_idx) = self.fallback_upstream {
-            if !skip.contains(&EndpointIdx::Upstream(u_idx)) {
-                let upstream = &self.upstreams[u_idx];
-                trace!(
-                    upstream = upstream.name,
-                    priority = upstream.priority,
-                    "pick: candidate (upstream)"
-                );
-                candidates.push(RoutingCandidate {
-                    endpoint: EndpointIdx::Upstream(u_idx),
-                    priority: upstream.priority,
-                    gate_5h: 0.0,
-                    gate_7d: 0.0,
-                    gate: 0.0,
-                    wr: 0.0,
-                    weight: 1.0,
-                    source: "upstream",
-                });
-            }
-        }
-
-        // Unified endpoints. During the migration, both the old `accounts`+`upstreams`
-        // pools and the new `endpoints` pool are enumerated. The deployed config will
-        // populate only one side at a time — both populated is a configuration error
-        // caught elsewhere.
         for (i, ep) in self.endpoints.iter().enumerate() {
-            if skip.contains(&EndpointIdx::Unified(i)) {
+            if skip.contains(&i) {
                 continue;
             }
             if !ep.serves_model(model) {
@@ -2058,7 +1622,7 @@ impl AppState {
                         "pick: candidate (openai, fixed)"
                     );
                     candidates.push(RoutingCandidate {
-                        endpoint: EndpointIdx::Unified(i),
+                        endpoint: i,
                         priority: ep.priority,
                         gate_5h: 0.0,
                         gate_7d: 0.0,
@@ -2112,7 +1676,7 @@ impl AppState {
                         "pick: candidate (anthropic)"
                     );
                     candidates.push(RoutingCandidate {
-                        endpoint: EndpointIdx::Unified(i),
+                        endpoint: i,
                         priority: effective_priority,
                         gate_5h: rw.gate_5h,
                         gate_7d: rw.gate_7d,
@@ -2157,24 +1721,13 @@ impl AppState {
         let now_epoch = Self::now_epoch();
         let now = Instant::now();
 
-        // Collect (gate, weight) per account. None = excluded entirely
+        // Collect (gate, weight) per endpoint. None = excluded entirely
         // (passthrough or hard-limited — never weighted in any condition).
-        let mut entries: Vec<Option<(f64, f64)>> = vec![None; self.accounts.len()];
-
-        for (i, acct) in self.accounts.iter().enumerate() {
-            if acct.passthrough {
-                continue;
-            }
-
-            let info = acct.rate_info.read().await;
-            entries[i] = metrics_gate_weight(&info, now_epoch, now);
-        }
-
-        // Mirror the same computation over the unified endpoint pool. OpenAI
-        // endpoints carry no rate-limit data — their representative weight is
-        // the fixed (gate 0.0, weight 1.0) candidate that routing_candidates
-        // produces. Anthropic endpoints run the identical Anthropic computation.
-        let mut endpoint_entries: Vec<Option<(f64, f64)>> = vec![None; self.endpoints.len()];
+        // OpenAI endpoints carry no rate-limit data — their representative
+        // weight is the fixed (gate 0.0, weight 1.0) candidate that
+        // routing_candidates produces. Anthropic endpoints run the identical
+        // Anthropic computation.
+        let mut entries: Vec<Option<(f64, f64)>> = vec![None; self.endpoints.len()];
         for (i, ep) in self.endpoints.iter().enumerate() {
             match ep.protocol {
                 Protocol::OpenAI => {
@@ -2183,51 +1736,32 @@ impl AppState {
                     // emits OpenAI endpoints with a fixed (gate 0.0,
                     // weight 1.0) — an OpenAI endpoint is a real routing
                     // candidate and belongs on dashboards.
-                    endpoint_entries[i] = Some((0.0, 1.0));
+                    entries[i] = Some((0.0, 1.0));
                 }
                 Protocol::Anthropic => {
                     if ep.passthrough {
                         continue;
                     }
                     let info = ep.rate_info.read().await;
-                    endpoint_entries[i] = metrics_gate_weight(&info, now_epoch, now);
+                    entries[i] = metrics_gate_weight(&info, now_epoch, now);
                 }
             }
         }
 
-        self.store_metrics_weights(&entries, &self.accounts, |a| {
-            (
-                &a.last_routing_weight,
-                &a.last_routing_share,
-                &a.last_effective_gate,
-            )
-        });
-        self.store_metrics_weights(&endpoint_entries, &self.endpoints, |e| {
-            (
-                &e.last_routing_weight,
-                &e.last_routing_share,
-                &e.last_effective_gate,
-            )
-        });
+        self.store_metrics_weights(&entries);
     }
 
-    /// Normalize per-entry (gate, weight) pairs into the three gauge atomics
-    /// of each pool member, applying pick_account's graceful soft-limit
-    /// degradation. Pool-agnostic: works for both `Account` and `Endpoint`
-    /// since the gauge atomics share field names.
-    fn store_metrics_weights<T>(
-        &self,
-        entries: &[Option<(f64, f64)>],
-        pool: &[T],
-        gauges: impl Fn(&T) -> (&AtomicU64, &AtomicU64, &AtomicU64),
-    ) {
-        // Mirror pick_account's graceful-degradation: only filter soft-limited
+    /// Normalize per-endpoint (gate, weight) pairs into the three gauge atomics
+    /// of each endpoint, applying pick_endpoint's graceful soft-limit
+    /// degradation.
+    fn store_metrics_weights(&self, entries: &[Option<(f64, f64)>]) {
+        // Mirror pick_endpoint's graceful-degradation: only filter soft-limited
         // members when at least one healthy member exists in the pool.
         let has_healthy = entries
             .iter()
             .any(|e| matches!(e, Some((gate, _)) if *gate < self.soft_limit));
 
-        let mut weights = vec![0f64; pool.len()];
+        let mut weights = vec![0f64; self.endpoints.len()];
         for (i, entry) in entries.iter().enumerate() {
             if let Some((gate, weight)) = entry {
                 if has_healthy && *gate >= self.soft_limit {
@@ -2238,18 +1772,19 @@ impl AppState {
         }
 
         let total: f64 = weights.iter().sum();
-        for (i, member) in pool.iter().enumerate() {
+        for (i, ep) in self.endpoints.iter().enumerate() {
             let w = weights[i];
             let share = if total > 0.0 { w / total } else { 0.0 };
             // Excluded members (passthrough, hard-limited) report gate=1.0
             // (fully gated) since they receive zero traffic.
             let gate = entries[i].map(|(g, _)| g).unwrap_or(1.0);
-            let (weight_g, share_g, gate_g) = gauges(member);
             // Weight, share and gate are independent gauges, not a joint
             // invariant — a torn read across them is harmless.
-            weight_g.store(w.to_bits(), Ordering::Relaxed);
-            share_g.store(share.to_bits(), Ordering::Relaxed);
-            gate_g.store(gate.to_bits(), Ordering::Relaxed);
+            ep.last_routing_weight.store(w.to_bits(), Ordering::Relaxed);
+            ep.last_routing_share
+                .store(share.to_bits(), Ordering::Relaxed);
+            ep.last_effective_gate
+                .store(gate.to_bits(), Ordering::Relaxed);
         }
     }
 }
@@ -2400,16 +1935,8 @@ impl AppState {
                 }
             });
         };
-        for acct in &self.accounts {
-            publish(
-                &acct.name,
-                &acct.last_routing_weight,
-                &acct.last_routing_share,
-                &acct.last_effective_gate,
-            );
-        }
-        // Parallel pass over the unified endpoint pool. OpenAI endpoints are
-        // skipped — sync_from_redis only reads weights for Anthropic targets.
+        // OpenAI endpoints are skipped — sync_from_redis only reads weights
+        // for Anthropic targets.
         for ep in &self.endpoints {
             if ep.protocol == Protocol::OpenAI {
                 continue;
@@ -2678,30 +2205,16 @@ impl AppState {
         None
     }
 
-    /// Test-only convenience: `pick_endpoint` restricted to account results.
+    /// Test-only convenience: parse rate-limit headers into endpoint `idx`.
     #[cfg(test)]
-    async fn pick_account(
-        &self,
-        affinity_key: Option<&str>,
-        model: &str,
-        skip: &[usize],
-    ) -> Option<usize> {
-        let skip: Vec<EndpointIdx> = skip.iter().map(|&i| EndpointIdx::Account(i)).collect();
-        self.pick_endpoint(affinity_key, model, &skip)
-            .await
-            .and_then(|ep| ep.account())
-    }
-
-    /// Update rate limit info from response headers.
     async fn update_rate_info(&self, idx: usize, headers: &reqwest::header::HeaderMap) {
-        let acct = &self.accounts[idx];
-        self.update_rate_info_for(&acct.rate_info, &acct.name, headers)
+        let ep = &self.endpoints[idx];
+        self.update_rate_info_for(&ep.rate_info, &ep.name, headers)
             .await;
     }
 
-    /// Pool-agnostic core of `update_rate_info`: parses rate-limit headers into
-    /// the supplied `RateLimitInfo` lock. Shared by the legacy Account pool and
-    /// the unified Endpoint pool (`probe_endpoint_unified`).
+    /// Parse rate-limit headers from a response into the supplied
+    /// `RateLimitInfo` lock.
     async fn update_rate_info_for(
         &self,
         rate_info: &RwLock<RateLimitInfo>,
@@ -3016,16 +2529,15 @@ impl AppState {
         }
     }
 
-    /// Mark an account as hard rate-limited (got a 429).
+    /// Test-only convenience: mark endpoint `idx` as hard rate-limited.
+    #[cfg(test)]
     async fn mark_hard_limited(&self, idx: usize, headers: &reqwest::header::HeaderMap) {
-        let acct = &self.accounts[idx];
-        self.mark_hard_limited_for(&acct.rate_info, &acct.name, headers)
+        let ep = &self.endpoints[idx];
+        self.mark_hard_limited_for(&ep.rate_info, &ep.name, headers)
             .await;
     }
 
-    /// Pool-agnostic core of `mark_hard_limited`: applies a 429 cooldown to the
-    /// supplied `RateLimitInfo` lock. Shared by the legacy Account pool and the
-    /// unified Endpoint pool (`probe_endpoint_unified`).
+    /// Apply a 429 cooldown to the supplied `RateLimitInfo` lock.
     async fn mark_hard_limited_for(
         &self,
         rate_info: &RwLock<RateLimitInfo>,
@@ -3145,9 +2657,8 @@ impl AppState {
         let now_epoch = Self::now_epoch();
         let now_instant = Instant::now();
 
-        // Unified sync target list. Spans both the legacy account pool and the
-        // unified endpoint pool — in a real config exactly one is non-empty.
-        // OpenAI endpoints are skipped: they carry no Anthropic rate-limit data.
+        // Sync target list over the endpoint pool. OpenAI endpoints are
+        // skipped: they carry no Anthropic rate-limit data.
         struct SyncTarget<'a> {
             name: &'a str,
             rate_info: &'a RwLock<RateLimitInfo>,
@@ -3156,15 +2667,6 @@ impl AppState {
             gate: &'a AtomicU64,
         }
         let mut targets: Vec<SyncTarget<'_>> = Vec::new();
-        for a in &self.accounts {
-            targets.push(SyncTarget {
-                name: &a.name,
-                rate_info: &a.rate_info,
-                weight: &a.last_routing_weight,
-                share: &a.last_routing_share,
-                gate: &a.last_effective_gate,
-            });
-        }
         for e in &self.endpoints {
             if e.protocol == Protocol::OpenAI {
                 continue;
@@ -3575,7 +3077,7 @@ fn log_usage(req_id: &str, client_id: &str, model: &str, account: &str, usage: &
 #[allow(clippy::too_many_arguments)]
 async fn finalize_stream(
     state: &AppState,
-    target: UsageTarget,
+    endpoint_idx: usize,
     req_id: &str,
     client_id: &str,
     model: &str,
@@ -3594,7 +3096,7 @@ async fn finalize_stream(
     let usage = TokenUsage::from_sse_text(&text);
     let elapsed_ms = request_start.elapsed().as_millis() as u64;
     if !usage.is_empty() {
-        state.record_usage(target, client_id, &usage).await;
+        state.record_usage(endpoint_idx, client_id, &usage).await;
         log_usage(req_id, client_id, model, acct_name, &usage);
     } else {
         let reason = if upstream_error {
@@ -3657,7 +3159,7 @@ async fn finalize_stream(
 #[allow(clippy::too_many_arguments)]
 async fn finalize_non_stream(
     state: &AppState,
-    target: UsageTarget,
+    endpoint_idx: usize,
     req_id: &str,
     client_id: &str,
     model: &str,
@@ -3671,7 +3173,7 @@ async fn finalize_non_stream(
     openai_compat: bool,
 ) {
     if !usage.is_empty() {
-        state.record_usage(target, client_id, usage).await;
+        state.record_usage(endpoint_idx, client_id, usage).await;
         log_usage(req_id, client_id, model, acct_name, usage);
     }
     let mut log = serde_json::json!({
@@ -3696,47 +3198,21 @@ async fn finalize_non_stream(
     state.shadow_log(log);
 }
 
-/// Which runtime pool a usage record applies to. During the strangler
-/// migration both pools coexist; after Phase 4 only Unified remains.
-#[derive(Clone, Copy, Debug)]
-enum UsageTarget {
-    /// Index into AppState.accounts (legacy pool).
-    Account(usize),
-    /// Index into AppState.endpoints (unified pool).
-    Unified(usize),
-}
-
 impl AppState {
     /// Record token usage for an endpoint and client.
-    async fn record_usage(&self, target: UsageTarget, client_id: &str, usage: &TokenUsage) {
+    async fn record_usage(&self, endpoint_idx: usize, client_id: &str, usage: &TokenUsage) {
         if usage.is_empty() {
             return;
         }
-        // Resolve the four token-counter atomics from whichever pool.
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens) = match target {
-            UsageTarget::Account(i) => {
-                let a = &self.accounts[i];
-                (
-                    &a.input_tokens,
-                    &a.output_tokens,
-                    &a.cache_creation_tokens,
-                    &a.cache_read_tokens,
-                )
-            }
-            UsageTarget::Unified(i) => {
-                let e = &self.endpoints[i];
-                (
-                    &e.input_tokens,
-                    &e.output_tokens,
-                    &e.cache_creation_tokens,
-                    &e.cache_read_tokens,
-                )
-            }
-        };
-        input_tokens.fetch_add(usage.input_tokens, Ordering::Relaxed);
-        output_tokens.fetch_add(usage.output_tokens, Ordering::Relaxed);
-        cache_creation_tokens.fetch_add(usage.cache_creation_input_tokens, Ordering::Relaxed);
-        cache_read_tokens.fetch_add(usage.cache_read_input_tokens, Ordering::Relaxed);
+        let ep = &self.endpoints[endpoint_idx];
+        ep.input_tokens
+            .fetch_add(usage.input_tokens, Ordering::Relaxed);
+        ep.output_tokens
+            .fetch_add(usage.output_tokens, Ordering::Relaxed);
+        ep.cache_creation_tokens
+            .fetch_add(usage.cache_creation_input_tokens, Ordering::Relaxed);
+        ep.cache_read_tokens
+            .fetch_add(usage.cache_read_input_tokens, Ordering::Relaxed);
 
         // Per-client tracking
         if client_id != "-" {
@@ -3868,9 +3344,11 @@ impl AppState {
         self.operators.iter().any(|op| op == client_id)
     }
 
-    /// Check if all model-compatible accounts exceed this client's utilization limit.
-    /// Returns Ok(()) if no limit configured or at least one account is below the limit.
-    /// Returns Err(retry_after_secs) if all accounts exceed the limit.
+    /// Check if all model-compatible endpoints exceed this client's utilization limit.
+    /// Returns Ok(()) if no limit configured or at least one endpoint is below the limit.
+    /// Returns Err(retry_after_secs) if all endpoints exceed the limit.
+    /// OpenAI endpoints carry no rate-limit data and are skipped — they neither
+    /// gate nor relieve the limit (mirrors `is_emergency_brake_active`).
     async fn check_utilization_limit(&self, client_id: &str, model: &str) -> Result<(), u64> {
         let limit = match self.client_utilization_limits.get(client_id) {
             Some(&limit) => limit,
@@ -3883,15 +3361,18 @@ impl AppState {
         let mut any_compatible = false;
         let mut any_known = false;
 
-        for acct in &self.accounts {
-            if !acct.serves_model(model) {
+        for ep in &self.endpoints {
+            if ep.protocol != Protocol::Anthropic {
+                continue;
+            }
+            if !ep.serves_model(model) {
                 continue;
             }
             any_compatible = true;
-            let info = acct.rate_info.read().await;
+            let info = ep.rate_info.read().await;
             let (util, source, _, _) = effective_utilization(&info, now_epoch, model);
             if source == "unknown" {
-                all_above = false; // fail-open: unknown account may have capacity
+                all_above = false; // fail-open: unknown endpoint may have capacity
                 break;
             }
             any_known = true;
@@ -3905,7 +3386,7 @@ impl AppState {
                 "7d" => resolve_7d_claim(&info, model)
                     .and_then(|c| c.reset)
                     .or(info.reset_7d),
-                _ => info.reset_5h.or(info.reset_7d), // unified/legacy best-effort
+                _ => info.reset_5h.or(info.reset_7d), // unified best-effort
             };
             if let Some(r) = reset_epoch {
                 if r > now_epoch {
@@ -3923,8 +3404,8 @@ impl AppState {
         }
     }
 
-    /// Check if all accounts are above the emergency threshold.
-    /// Fail-open: returns false if all accounts return (0.5, "unknown") — no data.
+    /// Check if all endpoints are above the emergency threshold.
+    /// Fail-open: returns false if all endpoints return (0.5, "unknown") — no data.
     async fn is_emergency_brake_active(&self) -> bool {
         if !self.emergency_brake {
             return false;
@@ -3933,8 +3414,15 @@ impl AppState {
         let mut all_above = true;
         let mut any_known = false;
 
-        for acct in &self.accounts {
-            let info = acct.rate_info.read().await;
+        // ONLY Protocol::Anthropic endpoints. OpenAI endpoints carry a stub
+        // RateLimitInfo (all None) which effective_utilization() resolves to
+        // (0.5, "unknown"); including them would force all_above = false and the
+        // brake could never fire. One of the three named `match protocol` sites.
+        for ep in &self.endpoints {
+            if ep.protocol != Protocol::Anthropic {
+                continue;
+            }
+            let info = ep.rate_info.read().await;
             let (util, source, _, _) = effective_utilization(&info, now_epoch, "");
             if source != "unknown" {
                 any_known = true;
@@ -3945,28 +3433,7 @@ impl AppState {
             }
         }
 
-        // Unified endpoints — ONLY Protocol::Anthropic. OpenAI endpoints carry a
-        // stub RateLimitInfo (all None) which effective_utilization() resolves to
-        // (0.5, "unknown"); including them would force all_above = false and the
-        // brake could never fire. One of the three named `match protocol` sites.
-        if all_above {
-            for ep in &self.endpoints {
-                if ep.protocol != Protocol::Anthropic {
-                    continue;
-                }
-                let info = ep.rate_info.read().await;
-                let (util, source, _, _) = effective_utilization(&info, now_epoch, "");
-                if source != "unknown" {
-                    any_known = true;
-                }
-                if util < self.emergency_threshold {
-                    all_above = false;
-                    break;
-                }
-            }
-        }
-
-        // Fail-open: if no account has real data, don't activate
+        // Fail-open: if no endpoint has real data, don't activate
         all_above && any_known
     }
 
@@ -4371,27 +3838,17 @@ async fn classify_retry_status(
     Ok(resp)
 }
 
-/// Forward one Anthropic-protocol request to a single endpoint. Pool-agnostic:
-/// reusable for both `AppState.accounts` (legacy) and `AppState.endpoints`
-/// (unified) by passing the endpoint's identity, auth, and shared state in
-/// explicitly. Behavior is byte-for-byte equivalent to the prior inline block
-/// in `proxy_handler` — only the `EndpointIdx::X(i)` value used for `skip` is
-/// chosen by the caller, since this helper does not know which pool it's
-/// serving.
+/// Forward one Anthropic-protocol request to a single `Endpoint`. The caller
+/// passes the picked endpoint and its pool index (used for `skip` and usage
+/// accounting).
 #[allow(clippy::too_many_arguments)]
 async fn forward_anthropic(
     state: &Arc<AppState>,
     parts: &axum::http::request::Parts,
     body_bytes: &bytes::Bytes,
     oauth_body_bytes: &bytes::Bytes,
-    base_url: &str,
-    token: &str,
-    passthrough: bool,
-    endpoint_name: &str,
-    usage_target: UsageTarget,
-    requests_counter: &AtomicU64,
-    rate_info: &RwLock<RateLimitInfo>,
-    burn_rate: &Mutex<BurnRate>,
+    ep: &Endpoint,
+    endpoint_idx: usize,
     req_id: &str,
     client_id: &str,
     client_ver: &str,
@@ -4401,9 +3858,13 @@ async fn forward_anthropic(
     model: &str,
     request_start: std::time::Instant,
 ) -> ForwardOutcome {
+    let token = ep.token.as_str();
+    let passthrough = ep.passthrough;
+    let endpoint_name = ep.name.as_str();
+    let rate_info = &ep.rate_info;
     let url = format!(
         "{}{}",
-        base_url,
+        ep.base_url,
         parts
             .uri
             .path_and_query()
@@ -4478,7 +3939,7 @@ async fn forward_anthropic(
     };
 
     let status = resp.status();
-    requests_counter.fetch_add(1, Ordering::Relaxed);
+    ep.requests.fetch_add(1, Ordering::Relaxed);
 
     // Debug: dump all response headers
     if tracing::enabled!(tracing::Level::DEBUG) {
@@ -4499,7 +3960,7 @@ async fn forward_anthropic(
         .await;
 
     // Update burn rate (after rate-limit headers are parsed)
-    state.update_burn_rate(burn_rate, client_id);
+    state.update_burn_rate(&ep.burn_rate, client_id);
 
     // Classify 429 / 529 / other 5xx into a retry decision (shared helper).
     let mut resp = match classify_retry_status(state, status, rate_info, endpoint_name, resp).await
@@ -4550,7 +4011,7 @@ async fn forward_anthropic(
             util_7d = info.utilization_7d.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
             constraint,
             overage = info.overage_in_use,
-            total = requests_counter.load(Ordering::Relaxed),
+            total = ep.requests.load(Ordering::Relaxed),
             "proxied"
         );
         compute_pressure_status(eff_util, client_id, state)
@@ -4617,7 +4078,7 @@ async fn forward_anthropic(
             // Parse accumulated SSE data for usage
             finalize_stream(
                 &state_clone,
-                usage_target,
+                endpoint_idx,
                 &req_id_clone,
                 &client_id_clone,
                 &model_clone,
@@ -4651,7 +4112,7 @@ async fn forward_anthropic(
         }
         finalize_non_stream(
             state,
-            usage_target,
+            endpoint_idx,
             req_id,
             client_id,
             model,
@@ -4804,74 +4265,27 @@ async fn proxy_handler(
         return resp;
     }
 
-    let n = state.accounts.len();
+    let n = state.endpoints.len();
     for retry_round in 0..=MAX_529_RETRIES {
         if retry_round > 0 {
             let delay = RETRY_529_BASE_DELAY * 2u32.pow(retry_round - 1);
             warn!(
                 retry_round = retry_round,
                 delay_ms = delay.as_millis() as u64,
-                "529 backoff: retrying all accounts"
+                "529 backoff: retrying all endpoints"
             );
             tokio::time::sleep(delay).await;
         }
         let mut skip: Vec<EndpointIdx> = Vec::new();
         let mut saw_529 = false;
-        // n accounts + 1 fallback upstream is the candidate ceiling.
-        for _attempt in 0..(n + 1) {
-            // Pick the next candidate. Each branch resolves the call to
-            // `forward_anthropic` (Anthropic-protocol endpoints — accounts or
-            // unified Anthropic) or `try_fallback_upstream*` (OpenAI-protocol).
+        for _attempt in 0..n {
+            // Pick the next endpoint and dispatch by protocol:
+            // `forward_anthropic` (Anthropic) or `try_fallback_upstream`
+            // (OpenAI). The latter handles its `Option<Response>` inline by
+            // `return`/`continue`-ing.
             let (outcome, picked_idx): (ForwardOutcome, EndpointIdx) =
                 match state.pick_endpoint(affinity, &model, &skip).await {
-                    Some(EndpointIdx::Account(i)) => {
-                        let acct = &state.accounts[i];
-                        let out = forward_anthropic(
-                            &state,
-                            &parts,
-                            &body_bytes,
-                            &oauth_body_bytes,
-                            &state.upstream,
-                            &acct.token,
-                            acct.passthrough,
-                            &acct.name,
-                            UsageTarget::Account(i),
-                            &acct.requests,
-                            &acct.rate_info,
-                            &acct.burn_rate,
-                            &req_id,
-                            &client_id,
-                            &client_ver,
-                            &client_ip,
-                            &agent_id,
-                            &session_id,
-                            &model,
-                            request_start,
-                        )
-                        .await;
-                        (out, EndpointIdx::Account(i))
-                    }
-                    Some(EndpointIdx::Upstream(u)) => {
-                        // All account tiers exhausted — route through the fallback upstream.
-                        match try_fallback_upstream(
-                            &state,
-                            &body_bytes,
-                            &req_id,
-                            &client_id,
-                            &model,
-                            u,
-                            true,
-                        )
-                        .await
-                        {
-                            Some(resp) => return resp,
-                            None => {
-                                skip.push(EndpointIdx::Upstream(u));
-                                continue;
-                            }
-                        }
-                    }
-                    Some(EndpointIdx::Unified(i)) => {
+                    Some(i) => {
                         let ep = &state.endpoints[i];
                         match ep.protocol {
                             Protocol::Anthropic => {
@@ -4880,14 +4294,8 @@ async fn proxy_handler(
                                     &parts,
                                     &body_bytes,
                                     &oauth_body_bytes,
-                                    &ep.base_url,
-                                    &ep.token,
-                                    ep.passthrough,
-                                    &ep.name,
-                                    UsageTarget::Unified(i),
-                                    &ep.requests,
-                                    &ep.rate_info,
-                                    &ep.burn_rate,
+                                    ep,
+                                    i,
                                     &req_id,
                                     &client_id,
                                     &client_ver,
@@ -4898,10 +4306,10 @@ async fn proxy_handler(
                                     request_start,
                                 )
                                 .await;
-                                (out, EndpointIdx::Unified(i))
+                                (out, i)
                             }
                             Protocol::OpenAI => {
-                                match try_fallback_upstream_unified(
+                                match try_fallback_upstream(
                                     &state,
                                     &body_bytes,
                                     &req_id,
@@ -4914,7 +4322,7 @@ async fn proxy_handler(
                                 {
                                     Some(resp) => return resp,
                                     None => {
-                                        skip.push(EndpointIdx::Unified(i));
+                                        skip.push(i);
                                         continue;
                                     }
                                 }
@@ -4958,269 +4366,19 @@ async fn proxy_handler(
 
 // ── Fallback upstream handler ────────────────────────────────────────
 
-/// Forward a request to the fallback upstream (OpenAI-compatible) when all
-/// accounts are exhausted. For Anthropic-format callers (proxy_handler),
-/// translates the request to OpenAI format and the response back.
-/// For OpenAI-format callers (openai_chat_handler), forwards directly.
+/// Forward a request to a `Protocol::OpenAI` endpoint. For Anthropic-format
+/// callers (`proxy_handler`) it translates the request to OpenAI format and the
+/// response back (`translate = true`); for OpenAI-format callers
+/// (`openai_chat_handler`) it forwards directly (`translate = false`).
+///
+/// Returns `None` on upstream 429/5xx so the retry loop advances to the next
+/// candidate. Other 4xx (e.g. 400, 401) are returned to the caller as a final
+/// response — retry won't help on client-side errors.
+///
+/// Only increments the endpoint's request counter; it does not call
+/// `record_usage` (OpenAI-compat responses don't carry the same usage signal we
+/// extract for Anthropic).
 async fn try_fallback_upstream(
-    state: &AppState,
-    body_bytes: &[u8],
-    req_id: &str,
-    client_id: &str,
-    model: &str,
-    upstream_idx: usize,
-    translate: bool, // true = Anthropic↔OpenAI translation needed
-) -> Option<Response> {
-    let upstream = &state.upstreams[upstream_idx];
-
-    info!(
-        req_id,
-        client_id,
-        model,
-        upstream = upstream.name,
-        translate,
-        "fallback: routing to upstream"
-    );
-
-    upstream.requests.fetch_add(1, Ordering::Relaxed);
-
-    // Parse once to extract streaming flag before potential translation
-    let parsed: serde_json::Value = serde_json::from_slice(body_bytes).ok()?;
-    let is_streaming = parsed
-        .get("stream")
-        .and_then(|s| s.as_bool())
-        .unwrap_or(false);
-
-    // Build request body
-    let request_body = if translate {
-        let openai_body = translate_anthropic_request_to_openai(&parsed);
-        serde_json::to_vec(&openai_body).ok()?
-    } else {
-        body_bytes.to_vec()
-    };
-
-    let url = format!("{}/v1/chat/completions", upstream.base_url);
-
-    let mut resp = match state
-        .client
-        .post(&url)
-        .header("authorization", format!("Bearer {}", upstream.api_key))
-        .header("content-type", "application/json")
-        .body(request_body)
-        .send()
-        .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            error!(
-                req_id,
-                upstream = upstream.name,
-                error = %e,
-                "fallback: upstream request failed"
-            );
-            return None;
-        }
-    };
-
-    let status = resp.status();
-    if !status.is_success() {
-        let err_body = resp
-            .text()
-            .await
-            .unwrap_or_else(|_| "upstream error".to_string());
-        warn!(
-            req_id,
-            upstream = upstream.name,
-            status = status.as_u16(),
-            body = %err_body,
-            "fallback: upstream returned error"
-        );
-        if translate {
-            // Return error in Anthropic format
-            return Some(
-                Response::builder()
-                    .status(status)
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        serde_json::json!({
-                            "type": "error",
-                            "error": {
-                                "type": "api_error",
-                                "message": err_body,
-                            }
-                        })
-                        .to_string(),
-                    ))
-                    .unwrap_or_else(|_| {
-                        (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
-                    }),
-            );
-        }
-        return Some(
-            Response::builder()
-                .status(status)
-                .header("content-type", "application/json")
-                .body(Body::from(err_body))
-                .unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
-                }),
-        );
-    }
-
-    // Streaming response
-    if is_streaming {
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
-        let req_id = req_id.to_string();
-        let upstream_name = upstream.name.clone();
-        let translate_response = translate;
-
-        tokio::spawn(async move {
-            let mut buffer: Vec<u8> = Vec::new();
-            let mut ctx = ReverseStreamContext::default();
-            let mut client_gone = false;
-
-            loop {
-                match resp.chunk().await {
-                    Ok(Some(chunk)) => {
-                        if translate_response {
-                            buffer.extend_from_slice(&chunk);
-                            // Parse SSE events delimited by \n\n
-                            while let Some(pos) = buffer.windows(2).position(|w| w == b"\n\n") {
-                                let event = String::from_utf8_lossy(&buffer[..pos]).into_owned();
-                                buffer.drain(..pos + 2);
-
-                                // Extract data line
-                                for line in event.lines() {
-                                    if let Some(data) = line.strip_prefix("data: ") {
-                                        let events =
-                                            translate_openai_sse_to_anthropic(data, &mut ctx);
-                                        for ev in events {
-                                            if tx.send(Ok(bytes::Bytes::from(ev))).await.is_err() {
-                                                client_gone = true;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                                if client_gone {
-                                    break;
-                                }
-                            }
-                        } else {
-                            // OpenAI format — forward directly
-                            if tx.send(Ok(chunk)).await.is_err() {
-                                client_gone = true;
-                            }
-                        }
-                        if client_gone {
-                            break;
-                        }
-                    }
-                    Ok(None) => break,
-                    Err(e) => {
-                        warn!(req_id, error = %e, "fallback: upstream SSE read failed");
-                        break;
-                    }
-                }
-            }
-
-            // Flush remaining buffer
-            if translate_response && !buffer.is_empty() && !client_gone {
-                let remaining = String::from_utf8_lossy(&buffer).into_owned();
-                for line in remaining.lines() {
-                    if let Some(data) = line.strip_prefix("data: ") {
-                        let events = translate_openai_sse_to_anthropic(data, &mut ctx);
-                        for ev in events {
-                            if tx.send(Ok(bytes::Bytes::from(ev))).await.is_err() {
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if client_gone {
-                debug!(req_id, "fallback: client disconnected during stream");
-            }
-            info!(
-                req_id,
-                upstream = upstream_name,
-                "fallback: stream complete"
-            );
-        });
-
-        return Some(
-            Response::builder()
-                .status(StatusCode::OK)
-                .header("content-type", "text/event-stream")
-                .header("cache-control", "no-cache")
-                .header("connection", "keep-alive")
-                .body(Body::from_stream(
-                    tokio_stream::wrappers::ReceiverStream::new(rx),
-                ))
-                .unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback stream error").into_response()
-                }),
-        );
-    }
-
-    // Non-streaming response
-    let resp_body = match resp.bytes().await {
-        Ok(b) => b,
-        Err(e) => {
-            error!(req_id, error = %e, "fallback: failed to read response body");
-            return None;
-        }
-    };
-
-    if translate {
-        let openai_resp: serde_json::Value =
-            serde_json::from_slice(&resp_body).unwrap_or(serde_json::json!({}));
-        let anthropic_resp = translate_openai_response_to_anthropic(&openai_resp);
-        info!(
-            req_id,
-            upstream = upstream.name,
-            "fallback: translated response"
-        );
-        Some(
-            Response::builder()
-                .status(StatusCode::OK)
-                .header("content-type", "application/json")
-                .body(Body::from(anthropic_resp.to_string()))
-                .unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
-                }),
-        )
-    } else {
-        info!(
-            req_id,
-            upstream = upstream.name,
-            "fallback: forwarded response"
-        );
-        Some(
-            Response::builder()
-                .status(StatusCode::OK)
-                .header("content-type", "application/json")
-                .body(Body::from(resp_body))
-                .unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
-                }),
-        )
-    }
-}
-
-/// Forward a request to a `Protocol::OpenAI` endpoint in the unified pool.
-///
-/// Used by `proxy_handler`'s `EndpointIdx::Unified` arm. Mirrors
-/// `try_fallback_upstream` but reads from `state.endpoints` and — critically —
-/// returns `None` on upstream 429/5xx so the retry loop advances to the next
-/// candidate. Other 4xx (e.g. 400, 401) are still returned to the caller as a
-/// final response — retry won't help on client-side errors.
-///
-/// Like the original `try_fallback_upstream`, this only increments the
-/// endpoint's request counter; it does not call `record_usage` (OpenAI-compat
-/// responses don't carry the same usage signal we extract for Anthropic).
-async fn try_fallback_upstream_unified(
     state: &AppState,
     body_bytes: &[u8],
     req_id: &str,
@@ -5287,8 +4445,7 @@ async fn try_fallback_upstream_unified(
             .await
             .unwrap_or_else(|_| "upstream error".to_string());
         // Retry-eligible: 429 or 5xx → return None so the retry loop advances
-        // to the next candidate. This is the only behavioral difference from
-        // `try_fallback_upstream`.
+        // to the next candidate.
         if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
             warn!(
                 req_id,
@@ -5620,33 +4777,7 @@ async fn stats_handler(
     }
 
     let now_epoch = AppState::now_epoch();
-    let mut out = Vec::new();
     let mut total_headroom: Option<u64> = Some(0);
-    for acct in &state.accounts {
-        out.push(
-            build_stats_entry(
-                &acct.name,
-                acct.passthrough,
-                acct.priority,
-                None,
-                &acct.rate_info,
-                &acct.burn_rate,
-                &acct.requests,
-                [
-                    &acct.input_tokens,
-                    &acct.output_tokens,
-                    &acct.cache_creation_tokens,
-                    &acct.cache_read_tokens,
-                ],
-                now_epoch,
-                &mut total_headroom,
-            )
-            .await,
-        );
-    }
-    // Parallel pass over the unified endpoint pool. Same field shape as the
-    // `accounts` entries, plus a "protocol" field. In a real config exactly
-    // one pool is non-empty.
     let mut endpoint_stats = Vec::new();
     for ep in &state.endpoints {
         let protocol = match ep.protocol {
@@ -5673,14 +4804,6 @@ async fn stats_handler(
             )
             .await,
         );
-    }
-    let mut upstream_stats = Vec::new();
-    for u in &state.upstreams {
-        upstream_stats.push(serde_json::json!({
-            "name": u.name,
-            "base_url": u.base_url,
-            "requests_total": u.requests.load(Ordering::Relaxed),
-        }));
     }
 
     // Per-client usage (tokens + request rates)
@@ -5814,9 +4937,7 @@ async fn stats_handler(
         state.cluster_info_cache.lock().ok().and_then(|g| g.clone());
 
     let mut response = serde_json::json!({
-        "accounts": out,
         "endpoints": endpoint_stats,
-        "upstreams": upstream_stats,
         "client_usage": client_usage,
         "client_budgets": budgets,
         "aggregate": aggregate,
@@ -5947,7 +5068,7 @@ struct EndpointMetricsSnap {
 #[cfg(test)]
 fn append_routing_weight_metrics(
     buf: &mut String,
-    accounts: &[Account],
+    endpoints: &[Endpoint],
     snaps: &[EndpointMetricsSnap],
 ) {
     prom_header(
@@ -5969,13 +5090,13 @@ fn append_routing_weight_metrics(
         "Effective routing gate: max(time_adjusted_5h, time_adjusted_7d) with status floors",
     );
 
-    for (acct, snap) in accounts.iter().zip(snaps.iter()) {
+    for (ep, snap) in endpoints.iter().zip(snaps.iter()) {
         if snap.passthrough {
             continue;
         }
-        let weight = f64::from_bits(acct.last_routing_weight.load(Ordering::Relaxed));
-        let share = f64::from_bits(acct.last_routing_share.load(Ordering::Relaxed));
-        let gate = f64::from_bits(acct.last_effective_gate.load(Ordering::Relaxed));
+        let weight = f64::from_bits(ep.last_routing_weight.load(Ordering::Relaxed));
+        let share = f64::from_bits(ep.last_routing_share.load(Ordering::Relaxed));
+        let gate = f64::from_bits(ep.last_effective_gate.load(Ordering::Relaxed));
         prom_gauge(
             buf,
             "anthropic_account_routing_weight",
@@ -6131,37 +5252,12 @@ async fn metrics_handler(
 
     // ── Phase 1: Gather data (async — acquires locks) ──────────────
 
-    let mut snaps: Vec<EndpointMetricsSnap> =
-        Vec::with_capacity(state.accounts.len() + state.endpoints.len());
+    let mut snaps: Vec<EndpointMetricsSnap> = Vec::with_capacity(state.endpoints.len());
     let mut total_headroom: Option<u64> = Some(0);
 
-    for acct in &state.accounts {
-        snaps.push(
-            build_metrics_snap(
-                &acct.name,
-                acct.passthrough,
-                &acct.rate_info,
-                &acct.burn_rate,
-                &acct.requests,
-                [
-                    &acct.input_tokens,
-                    &acct.output_tokens,
-                    &acct.cache_creation_tokens,
-                    &acct.cache_read_tokens,
-                ],
-                &acct.last_routing_weight,
-                &acct.last_routing_share,
-                &acct.last_effective_gate,
-                now_epoch,
-                &mut total_headroom,
-            )
-            .await,
-        );
-    }
-    // Parallel pass over the unified endpoint pool. In a real config exactly
-    // one pool is non-empty, so there are no label collisions. OpenAI
-    // endpoints have a stub RateLimitInfo — their gauges read as zero/None,
-    // which is the correct representation for a pool with no rate-limit data.
+    // OpenAI endpoints have a stub RateLimitInfo — their gauges read as
+    // zero/None, which is the correct representation for an endpoint with no
+    // rate-limit data.
     for ep in &state.endpoints {
         snaps.push(
             build_metrics_snap(
@@ -6878,22 +5974,6 @@ async fn metrics_handler(
                 limit.saturating_sub(used) as f64,
             );
         }
-    }
-
-    // Upstreams — label is "upstream" (not "name"), no base_url exposed
-    prom_header(
-        &mut buf,
-        "anthropic_upstream_requests_total",
-        "counter",
-        "Requests per upstream",
-    );
-    for u in &state.upstreams {
-        prom_counter(
-            &mut buf,
-            "anthropic_upstream_requests_total",
-            &[("upstream", &u.name)],
-            u.requests.load(Ordering::Relaxed),
-        );
     }
 
     // Cluster (Redis)
@@ -8065,31 +7145,19 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
     events
 }
 
-/// Forward one OpenAI-compat request to a single Anthropic-protocol endpoint.
+/// Forward one OpenAI-compat request to a single Anthropic-protocol `Endpoint`.
 /// The caller has already translated the OpenAI request into `anthropic_body`
 /// (plus the OAuth variant `oauth_anthropic_body`); this helper picks the right
-/// variant by token prefix, forwards to `base_url`, and translates the Anthropic
-/// response back to OpenAI format. Pool-agnostic: reusable for both
-/// `AppState.accounts` (legacy) and `AppState.endpoints` (unified) by passing
-/// the endpoint's identity, auth, and shared state in explicitly. Behavior is
-/// byte-for-byte equivalent to the prior inline Account block in
-/// `openai_chat_handler` — only the `EndpointIdx::X(i)` value used for `skip`
-/// is chosen by the caller, since this helper does not know which pool it's
-/// serving. Structurally similar to `forward_anthropic`, but intentionally
-/// kept separate: it speaks OpenAI on both edges (request body already
-/// translated, response translated back).
+/// variant by token prefix, forwards to the endpoint, and translates the
+/// Anthropic response back to OpenAI format. Structurally similar to
+/// `forward_anthropic`, but intentionally kept separate: it speaks OpenAI on
+/// both edges (request body already translated, response translated back).
 #[allow(clippy::too_many_arguments)]
 async fn forward_openai_compat_anthropic(
     state: &Arc<AppState>,
     parts: &axum::http::request::Parts,
-    base_url: &str,
-    token: &str,
-    passthrough: bool,
-    endpoint_name: &str,
-    usage_target: UsageTarget,
-    requests_counter: &AtomicU64,
-    rate_info: &RwLock<RateLimitInfo>,
-    burn_rate: &Mutex<BurnRate>,
+    ep: &Endpoint,
+    endpoint_idx: usize,
     anthropic_body: &serde_json::Value,
     oauth_anthropic_body: &serde_json::Value,
     req_id: &str,
@@ -8102,7 +7170,11 @@ async fn forward_openai_compat_anthropic(
     is_streaming: bool,
     request_start: std::time::Instant,
 ) -> ForwardOutcome {
-    let url = format!("{base_url}/v1/messages");
+    let token = ep.token.as_str();
+    let passthrough = ep.passthrough;
+    let endpoint_name = ep.name.as_str();
+    let rate_info = &ep.rate_info;
+    let url = format!("{}/v1/messages", ep.base_url);
 
     let mut headers = parts.headers.clone();
     headers.remove("host");
@@ -8154,13 +7226,13 @@ async fn forward_openai_compat_anthropic(
     };
 
     let status = resp.status();
-    requests_counter.fetch_add(1, Ordering::Relaxed);
+    ep.requests.fetch_add(1, Ordering::Relaxed);
     state
         .update_rate_info_for(rate_info, endpoint_name, resp.headers())
         .await;
 
     // Update burn rate (after rate-limit headers are parsed)
-    state.update_burn_rate(burn_rate, client_id);
+    state.update_burn_rate(&ep.burn_rate, client_id);
 
     // Classify 429 / 529 / other 5xx into a retry decision (shared helper).
     let mut resp = match classify_retry_status(state, status, rate_info, endpoint_name, resp).await
@@ -8369,7 +7441,7 @@ async fn forward_openai_compat_anthropic(
             // Extract and record token usage from accumulated SSE data
             finalize_stream(
                 &state_clone,
-                usage_target,
+                endpoint_idx,
                 &req_id_clone,
                 &client_id_clone,
                 &model_clone,
@@ -8432,7 +7504,7 @@ async fn forward_openai_compat_anthropic(
     let usage = TokenUsage::from_response_body(&anthropic_resp);
     finalize_non_stream(
         state,
-        usage_target,
+        endpoint_idx,
         req_id,
         client_id,
         model,
@@ -8570,91 +7642,35 @@ async fn openai_chat_handler(
     let mut oauth_anthropic_body = anthropic_body.clone();
     inject_oauth_system_prompt(&mut oauth_anthropic_body);
 
-    let n = state.accounts.len();
+    let n = state.endpoints.len();
     for retry_round in 0..=MAX_529_RETRIES {
         if retry_round > 0 {
             let delay = RETRY_529_BASE_DELAY * 2u32.pow(retry_round - 1);
             warn!(
                 retry_round = retry_round,
                 delay_ms = delay.as_millis() as u64,
-                "529 backoff: retrying all accounts"
+                "529 backoff: retrying all endpoints"
             );
             tokio::time::sleep(delay).await;
         }
         let mut skip: Vec<EndpointIdx> = Vec::new();
         let mut saw_529 = false;
-        // n accounts + 1 fallback upstream is the candidate ceiling.
-        for _attempt in 0..(n + 1) {
-            // Pick the next candidate. Anthropic-protocol branches (accounts or
-            // unified Anthropic) resolve to a `(ForwardOutcome, EndpointIdx)`
-            // pair; OpenAI-protocol branches (`try_fallback_upstream*`) handle
-            // their `Option<Response>` inline by `return`/`continue`-ing.
+        for _attempt in 0..n {
+            // Pick the next endpoint and dispatch by protocol: Anthropic
+            // endpoints resolve to a `(ForwardOutcome, EndpointIdx)` pair;
+            // OpenAI endpoints handle their `Option<Response>` inline by
+            // `return`/`continue`-ing.
             let (outcome, picked_idx): (ForwardOutcome, EndpointIdx) =
                 match state.pick_endpoint(affinity, &model, &skip).await {
-                    Some(EndpointIdx::Account(i)) => {
-                        let acct = &state.accounts[i];
-                        let out = forward_openai_compat_anthropic(
-                            &state,
-                            &parts,
-                            &state.upstream,
-                            &acct.token,
-                            acct.passthrough,
-                            &acct.name,
-                            UsageTarget::Account(i),
-                            &acct.requests,
-                            &acct.rate_info,
-                            &acct.burn_rate,
-                            &anthropic_body,
-                            &oauth_anthropic_body,
-                            &req_id,
-                            &client_id,
-                            &client_ver,
-                            &client_ip,
-                            &agent_id,
-                            &session_id,
-                            &model,
-                            is_streaming,
-                            request_start,
-                        )
-                        .await;
-                        (out, EndpointIdx::Account(i))
-                    }
-                    Some(EndpointIdx::Upstream(u)) => {
-                        // All account tiers exhausted — the upstream is OpenAI-native,
-                        // so forward the original request body without translation.
-                        match try_fallback_upstream(
-                            &state,
-                            &body_bytes,
-                            &req_id,
-                            &client_id,
-                            &model,
-                            u,
-                            false,
-                        )
-                        .await
-                        {
-                            Some(resp) => return resp,
-                            None => {
-                                skip.push(EndpointIdx::Upstream(u));
-                                continue;
-                            }
-                        }
-                    }
-                    Some(EndpointIdx::Unified(i)) => {
+                    Some(i) => {
                         let ep = &state.endpoints[i];
                         match ep.protocol {
                             Protocol::Anthropic => {
                                 let out = forward_openai_compat_anthropic(
                                     &state,
                                     &parts,
-                                    &ep.base_url,
-                                    &ep.token,
-                                    ep.passthrough,
-                                    &ep.name,
-                                    UsageTarget::Unified(i),
-                                    &ep.requests,
-                                    &ep.rate_info,
-                                    &ep.burn_rate,
+                                    ep,
+                                    i,
                                     &anthropic_body,
                                     &oauth_anthropic_body,
                                     &req_id,
@@ -8668,10 +7684,12 @@ async fn openai_chat_handler(
                                     request_start,
                                 )
                                 .await;
-                                (out, EndpointIdx::Unified(i))
+                                (out, i)
                             }
                             Protocol::OpenAI => {
-                                match try_fallback_upstream_unified(
+                                // The endpoint is OpenAI-native — forward the
+                                // original request body without translation.
+                                match try_fallback_upstream(
                                     &state,
                                     &body_bytes,
                                     &req_id,
@@ -8684,7 +7702,7 @@ async fn openai_chat_handler(
                                 {
                                     Some(resp) => return resp,
                                     None => {
-                                        skip.push(EndpointIdx::Unified(i));
+                                        skip.push(i);
                                         continue;
                                     }
                                 }
@@ -8874,7 +7892,10 @@ async fn main() {
     let routing_strategy = RoutingStrategy::parse(config.strategy.as_deref())
         .unwrap_or_else(|e| panic!("invalid strategy: {e}"));
 
-    assert!(!config.accounts.is_empty(), "at least one account required");
+    assert!(
+        !config.endpoints.is_empty(),
+        "at least one [[endpoints]] entry required"
+    );
 
     // Validate new config fields
     for (client, limit) in &config.client_utilization_limits {
@@ -8919,53 +7940,7 @@ async fn main() {
         info!(count = allowed_ips.len(), "IP allowlist enabled");
     }
 
-    let accounts: Vec<Account> = config
-        .accounts
-        .into_iter()
-        .map(|a| {
-            let passthrough = a.token == "passthrough";
-            if !a.models.is_empty() || a.priority > 0 {
-                info!(name = a.name, passthrough, priority = a.priority, models = ?a.models, "loaded account");
-            } else {
-                info!(name = a.name, passthrough, "loaded account");
-            }
-            Account {
-                name: a.name,
-                passthrough,
-                models: a.models,
-                priority: a.priority,
-                token: a.token,
-                requests: AtomicU64::new(0),
-                rate_info: RwLock::new(RateLimitInfo::default()),
-                burn_rate: Mutex::new(BurnRate::new()),
-                input_tokens: AtomicU64::new(0),
-                output_tokens: AtomicU64::new(0),
-                cache_creation_tokens: AtomicU64::new(0),
-                cache_read_tokens: AtomicU64::new(0),
-                last_routing_weight: AtomicU64::new(0),
-                last_routing_share: AtomicU64::new(0),
-                last_effective_gate: AtomicU64::new(0),
-            }
-        })
-        .collect();
-
-    let upstreams: Vec<Upstream> = config
-        .upstreams
-        .iter()
-        .map(|u| {
-            info!(name = u.name, base_url = u.base_url, "loaded upstream");
-            Upstream {
-                name: u.name.clone(),
-                base_url: u.base_url.clone(),
-                api_key: u.api_key.clone(),
-                priority: u.priority,
-                requests: AtomicU64::new(0),
-            }
-        })
-        .collect();
-
-    // Build the unified endpoint vector from the new [[endpoints]] config.
-    // During the migration, the old accounts/upstreams Vecs remain alongside.
+    // Build the unified endpoint vector from the [[endpoints]] config.
     let endpoints: Vec<Endpoint> = config
         .endpoints
         .iter()
@@ -9019,8 +7994,7 @@ async fn main() {
 
     info!(
         strategy = routing_strategy.as_str(),
-        num_accounts = accounts.len(),
-        num_upstreams = upstreams.len(),
+        num_endpoints = endpoints.len(),
         "routing strategy selected"
     );
 
@@ -9084,48 +8058,11 @@ async fn main() {
         None
     };
 
-    // Resolve fallback_upstream name to index
-    let fallback_upstream_idx = config.fallback_upstream.as_ref().map(|name| {
-        upstreams
-            .iter()
-            .position(|u| u.name == *name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "fallback_upstream '{}' not found in [[upstreams]] — available: {:?}",
-                    name,
-                    upstreams.iter().map(|u| &u.name).collect::<Vec<_>>()
-                )
-            })
-    });
-    if let Some(idx) = fallback_upstream_idx {
-        info!(
-            upstream = upstreams[idx].name,
-            base_url = upstreams[idx].base_url,
-            priority = upstreams[idx].priority,
-            "fallback upstream configured"
-        );
-        // Guardrail: the fallback upstream is a paid endpoint. If its priority is
-        // not strictly above every account's, it shares (or beats) the free tier
-        // and leaks paid traffic. Warn loudly — it should be set high (e.g. 100).
-        let max_acct_priority = accounts.iter().map(|a| a.priority).max().unwrap_or(0);
-        if upstreams[idx].priority <= max_acct_priority {
-            warn!(
-                upstream = upstreams[idx].name,
-                upstream_priority = upstreams[idx].priority,
-                max_account_priority = max_acct_priority,
-                "fallback upstream priority is not above account priorities — it will \
-                 compete with (or preempt) free accounts; set a higher priority"
-            );
-        }
-    }
-
     let state = Arc::new(AppState {
         client: Client::builder()
             .timeout(Duration::from_secs(600))
             .build()
             .expect("failed to build HTTP client"),
-        upstream: config.upstream,
-        accounts,
         endpoints,
         robin: AtomicUsize::new(0),
         routing_strategy,
@@ -9133,7 +8070,6 @@ async fn main() {
         state_path,
         proxy_key: config.proxy_key.clone(),
         allowed_ips,
-        upstreams,
         client_names: config.client_names.clone(),
         auto_cache: config.auto_cache.unwrap_or(true),
         client_usage: Mutex::new(HashMap::new()),
@@ -9158,7 +8094,6 @@ async fn main() {
             RandomState::new().build_hasher().finish() as u16
         },
         probe_interval_secs: config.probe_interval_secs.unwrap_or(300),
-        fallback_upstream: fallback_upstream_idx,
         overage_penalty: config.overage_penalty.unwrap_or(10),
     });
 
@@ -9198,27 +8133,28 @@ async fn main() {
         .await
         .unwrap_or_else(|e| panic!("failed to bind {addr}: {e}"));
 
-    // Spawn periodic probe task
+    // Spawn periodic probe task. `probe_endpoint` internally skips OpenAI
+    // endpoints (they expose no Anthropic rate-limit headers).
     let probe_interval = config.probe_interval_secs.unwrap_or(300);
     if probe_interval > 0 {
         let probe_state = state.clone();
-        let n_accounts = probe_state.accounts.len();
+        let n_endpoints = probe_state.endpoints.len();
         tokio::spawn(async move {
             const PROBE_MODELS: &[&str] =
                 &["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"];
-            // Stagger initial probes: wait 10s then probe all accounts
+            // Stagger initial probes: wait 10s then probe all endpoints
             tokio::time::sleep(Duration::from_secs(10)).await;
             info!(
                 interval_secs = probe_interval,
                 "starting utilization probes"
             );
             loop {
-                for i in 0..n_accounts {
-                    let acct = &probe_state.accounts[i];
-                    // Probe all model families per account per cycle
+                for i in 0..n_endpoints {
+                    let ep = &probe_state.endpoints[i];
+                    // Probe all model families per endpoint per cycle
                     for model in PROBE_MODELS {
-                        if acct.serves_model(model) {
-                            probe_state.probe_account(i, model).await;
+                        if ep.serves_model(model) {
+                            probe_state.probe_endpoint(i, model).await;
                             tokio::time::sleep(Duration::from_secs(2)).await;
                         }
                     }
@@ -9232,8 +8168,8 @@ async fn main() {
             }
         });
     } else {
-        // Probes disabled — but `update_rate_info()` still refreshes data on
-        // every inbound request. Without this fallback ticker the routing
+        // Probes disabled — but `update_rate_info_for()` still refreshes data
+        // on every inbound request. Without this fallback ticker the routing
         // weight gauges would freeze at startup values forever.
         let metrics_state = state.clone();
         tokio::spawn(async move {
@@ -9244,36 +8180,6 @@ async fn main() {
                 metrics_state.refresh_metrics_weights().await;
                 metrics_state.publish_routing_weights().await;
                 tokio::time::sleep(FALLBACK_INTERVAL).await;
-            }
-        });
-    }
-
-    // Probe loop for the unified endpoint pool. Mirrors the account probe loop;
-    // probe_endpoint_unified internally skips OpenAI endpoints. Metrics weight
-    // refresh stays on the account loop — the unified pool's metrics migration
-    // is a later task.
-    let n_endpoints = state.endpoints.len();
-    if probe_interval > 0 && n_endpoints > 0 {
-        let probe_state = state.clone();
-        tokio::spawn(async move {
-            const PROBE_MODELS: &[&str] =
-                &["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"];
-            tokio::time::sleep(Duration::from_secs(10)).await;
-            info!(
-                interval_secs = probe_interval,
-                "starting unified endpoint utilization probes"
-            );
-            loop {
-                for i in 0..n_endpoints {
-                    let ep = &probe_state.endpoints[i];
-                    for model in PROBE_MODELS {
-                        if ep.serves_model(model) {
-                            probe_state.probe_endpoint_unified(i, model).await;
-                            tokio::time::sleep(Duration::from_secs(2)).await;
-                        }
-                    }
-                }
-                tokio::time::sleep(Duration::from_secs(probe_interval)).await;
             }
         });
     }
@@ -9527,9 +8433,15 @@ token = "sk-ant-test"
 
     // ── Helpers ──────────────────────────────────────────────────────
 
-    fn make_account(name: &str, token: &str) -> Account {
-        Account {
+    /// Build an Anthropic-protocol `Endpoint` with the given name and token.
+    /// Token prefix drives auth behavior (`sk-ant-oat*` = OAuth,
+    /// `"passthrough"` = passthrough). Callers that need a non-default field
+    /// (priority, base_url, models) mutate the returned struct.
+    fn mk_endpoint(name: &str, token: &str) -> Endpoint {
+        Endpoint {
             name: name.to_string(),
+            protocol: Protocol::Anthropic,
+            base_url: "https://api.anthropic.com".to_string(),
             token: token.to_string(),
             passthrough: token == "passthrough",
             models: vec![],
@@ -9547,9 +8459,17 @@ token = "sk-ant-test"
         }
     }
 
-    /// Shared fixture for the unified `Endpoint` pool. Callers that need a
-    /// non-default field (priority, token, base_url, models) mutate the
-    /// returned struct.
+    /// Anthropic-protocol `Endpoint` whose `base_url` points at a given
+    /// upstream — for integration tests that forward to a mock server.
+    fn mk_endpoint_at(name: &str, token: &str, base_url: &str) -> Endpoint {
+        let mut ep = mk_endpoint(name, token);
+        ep.base_url = base_url.to_string();
+        ep
+    }
+
+    /// Shared fixture for the `Endpoint` pool, parameterized by protocol.
+    /// Callers that need a non-default field (priority, token, base_url,
+    /// models) mutate the returned struct.
     fn make_endpoint(name: &str, protocol: Protocol) -> Endpoint {
         Endpoint {
             name: name.to_string(),
@@ -9576,7 +8496,7 @@ token = "sk-ant-test"
     }
 
     fn test_state_with_strategy(
-        accounts: Vec<Account>,
+        endpoints: Vec<Endpoint>,
         routing_strategy: RoutingStrategy,
     ) -> Arc<AppState> {
         Arc::new(AppState {
@@ -9584,16 +8504,13 @@ token = "sk-ant-test"
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(), // unused in unit tests
-            accounts,
-            endpoints: vec![],
+            endpoints,
             robin: AtomicUsize::new(0),
             routing_strategy,
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -9612,35 +8529,19 @@ token = "sk-ant-test"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         })
     }
 
-    fn test_state_with(accounts: Vec<Account>) -> Arc<AppState> {
-        test_state_with_strategy(accounts, RoutingStrategy::default())
+    fn test_state_with(endpoints: Vec<Endpoint>) -> Arc<AppState> {
+        test_state_with_strategy(endpoints, RoutingStrategy::default())
     }
 
-    fn test_state_with_soft_limit(accounts: Vec<Account>, soft_limit: f64) -> Arc<AppState> {
-        let mut state = test_state_with(accounts);
+    fn test_state_with_soft_limit(endpoints: Vec<Endpoint>, soft_limit: f64) -> Arc<AppState> {
+        let mut state = test_state_with(endpoints);
         Arc::get_mut(&mut state)
             .expect("test fixture should be uniquely owned")
             .soft_limit = soft_limit;
-        state
-    }
-
-    /// Test state with a single fallback upstream registered at `upstream_priority`.
-    fn test_state_with_fallback(accounts: Vec<Account>, upstream_priority: u32) -> Arc<AppState> {
-        let mut state = test_state_with(accounts);
-        let st = Arc::get_mut(&mut state).expect("test fixture should be uniquely owned");
-        st.upstreams.push(Upstream {
-            name: "fallback".to_string(),
-            base_url: "http://127.0.0.1:1".to_string(),
-            api_key: "test".to_string(),
-            priority: upstream_priority,
-            requests: AtomicU64::new(0),
-        });
-        st.fallback_upstream = Some(0);
         state
     }
 
@@ -9694,38 +8595,31 @@ token = "sk-ant-test"
         resp
     }
 
-    /// Build the full app router against a given upstream URL.
+    /// Build the full app router against a given upstream URL. The two
+    /// Anthropic endpoints both point at `upstream_url` (the mock upstream).
     fn test_app_with_strategy(
         upstream_url: &str,
         proxy_key: Option<String>,
         routing_strategy: RoutingStrategy,
     ) -> (Router, Arc<AppState>) {
-        let accounts = vec![
-            make_account("acct-a", "sk-ant-api-test-aaa"),
-            make_account("acct-b", "sk-ant-api-test-bbb"),
-        ];
+        let mut acct_a = mk_endpoint("acct-a", "sk-ant-api-test-aaa");
+        acct_a.base_url = upstream_url.to_string();
+        let mut acct_b = mk_endpoint("acct-b", "sk-ant-api-test-bbb");
+        acct_b.base_url = upstream_url.to_string();
+        let endpoints = vec![acct_a, acct_b];
 
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: upstream_url.to_string(),
-            accounts,
-            endpoints: vec![],
+            endpoints,
             robin: AtomicUsize::new(0),
             routing_strategy,
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key,
             allowed_ips: vec![],
-            upstreams: vec![Upstream {
-                name: "mock".to_string(),
-                base_url: upstream_url.to_string(),
-                api_key: "test-key".to_string(),
-                priority: 0,
-                requests: AtomicU64::new(0),
-            }],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -9744,7 +8638,6 @@ token = "sk-ant-test"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -9800,7 +8693,7 @@ token = "sk-ant-test"
 
     #[test]
     fn empty_allowlist_allows_all() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         assert!(state.is_ip_allowed(&"192.168.1.1".parse().unwrap()));
         assert!(state.is_ip_allowed(&"8.8.8.8".parse().unwrap()));
     }
@@ -9812,16 +8705,13 @@ token = "sk-ant-test"
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![IpAllowEntry::Addr("10.0.0.1".parse().unwrap())],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -9840,7 +8730,6 @@ token = "sk-ant-test"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         assert!(state.is_ip_allowed(&"10.0.0.1".parse().unwrap()));
@@ -9854,23 +8743,23 @@ token = "sk-ant-test"
         // With weighted buckets, the account with more headroom should get
         // a proportionally larger share of traffic
         let state = test_state_with(vec![
-            make_account("high", "sk-ant-api-high"),
-            make_account("low", "sk-ant-api-low"),
+            mk_endpoint("high", "sk-ant-api-high"),
+            mk_endpoint("low", "sk-ant-api-low"),
         ]);
 
         // high=0.8 (headroom 0.2), low=0.2 (headroom 0.8) → 80% should go to "low"
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.8);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.2);
         }
 
         let mut counts = [0u32; 2];
         for _ in 0..1000 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             counts[idx] += 1;
         }
 
@@ -9886,22 +8775,22 @@ token = "sk-ant-test"
     #[tokio::test]
     async fn pick_skips_hard_limited() {
         let state = test_state_with(vec![
-            make_account("limited", "sk-ant-api-a"),
-            make_account("available", "sk-ant-api-b"),
+            mk_endpoint("limited", "sk-ant-api-a"),
+            mk_endpoint("available", "sk-ant-api-b"),
         ]);
 
         // Hard-limit the first account
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.1); // great utilization but hard-limited
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.9);
         }
 
-        let idx = state.pick_account(None, "", &[]).await.unwrap();
+        let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
         assert_eq!(
             idx, 1,
             "should skip hard-limited account despite lower utilization"
@@ -9912,15 +8801,15 @@ token = "sk-ant-test"
     async fn pick_round_robin_when_no_info() {
         // With no utilization data, all accounts get headroom=0.5 (equal buckets)
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-a"),
-            make_account("b", "sk-ant-api-b"),
-            make_account("c", "sk-ant-api-c"),
+            mk_endpoint("a", "sk-ant-api-a"),
+            mk_endpoint("b", "sk-ant-api-b"),
+            mk_endpoint("c", "sk-ant-api-c"),
         ]);
 
         // Call many times without affinity — Fibonacci scatter should distribute evenly
         let mut counts = [0u32; 3];
         for _ in 0..300 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             counts[idx] += 1;
         }
 
@@ -9939,28 +8828,28 @@ token = "sk-ant-test"
     #[tokio::test]
     async fn pick_returns_none_when_all_limited() {
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-a"),
-            make_account("b", "sk-ant-api-b"),
+            mk_endpoint("a", "sk-ant-api-a"),
+            mk_endpoint("b", "sk-ant-api-b"),
         ]);
 
-        for acct in &state.accounts {
+        for acct in &state.endpoints {
             let mut info = acct.rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
 
-        assert!(state.pick_account(None, "", &[]).await.is_none());
+        assert!(state.pick_endpoint(None, "", &[]).await.is_none());
     }
 
     #[tokio::test]
     async fn pick_recovers_after_hard_limit_expires() {
         // After a hard limit expires with stale data, the account should still be
         // selectable with 0.5 (unknown) utilization instead of being permanently stuck.
-        let state = test_state_with(vec![make_account("recovering", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("recovering", "sk-ant-api-a")]);
 
         // Simulate mark_hard_limited: set hard_limited_until in the past (expired),
         // poison remaining_tokens to 0, set high utilization from the 429 response.
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             let hard_limit_time = Instant::now() - Duration::from_secs(10);
             info.hard_limited_until = Some(hard_limit_time);
             info.remaining_tokens = Some(0);
@@ -9971,7 +8860,7 @@ token = "sk-ant-test"
             info.last_updated = Some(hard_limit_time - Duration::from_secs(1));
         }
 
-        let result = state.pick_account(None, "", &[]).await;
+        let result = state.pick_endpoint(None, "", &[]).await;
         assert!(
             result.is_some(),
             "account with expired hard limit should be selectable despite stale high utilization"
@@ -9982,11 +8871,11 @@ token = "sk-ant-test"
     async fn pick_ignores_stale_rejected_claim_after_hard_limit() {
         // A "rejected" 7d claim from a 429 response should not permanently block the
         // account once the hard limit has expired without fresh data.
-        let state = test_state_with(vec![make_account("recovering", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("recovering", "sk-ant-api-a")]);
         let now_epoch = AppState::now_epoch();
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             let hard_limit_time = Instant::now() - Duration::from_secs(10);
             info.hard_limited_until = Some(hard_limit_time);
             info.last_updated = Some(hard_limit_time - Duration::from_secs(1));
@@ -10004,7 +8893,7 @@ token = "sk-ant-test"
         }
 
         let result = state
-            .pick_account(Some("test"), "claude-sonnet-4-6", &[])
+            .pick_endpoint(Some("test"), "claude-sonnet-4-6", &[])
             .await;
         assert!(
             result.is_some(),
@@ -10017,13 +8906,13 @@ token = "sk-ant-test"
         // If data was refreshed AFTER the hard limit (e.g., by a probe that got fresh
         // "rejected" status), the account should still be skipped.
         let state = test_state_with(vec![
-            make_account("rejected", "sk-ant-api-a"),
-            make_account("available", "sk-ant-api-b"),
+            mk_endpoint("rejected", "sk-ant-api-a"),
+            mk_endpoint("available", "sk-ant-api-b"),
         ]);
         let now_epoch = AppState::now_epoch();
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             let hard_limit_time = Instant::now() - Duration::from_secs(300);
             info.hard_limited_until = Some(hard_limit_time);
             // last_updated AFTER the hard limit → data is fresh, not stale
@@ -10041,12 +8930,12 @@ token = "sk-ant-test"
             );
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.5);
         }
 
         let result = state
-            .pick_account(Some("test"), "claude-sonnet-4-6", &[])
+            .pick_endpoint(Some("test"), "claude-sonnet-4-6", &[])
             .await;
         assert_eq!(
             result,
@@ -10058,13 +8947,13 @@ token = "sk-ant-test"
     #[tokio::test]
     async fn pick_ignores_expired_rejected_claim_without_hard_limit() {
         let state = test_state_with(vec![
-            make_account("recovered", "sk-ant-api-a"),
-            make_account("available", "sk-ant-api-b"),
+            mk_endpoint("recovered", "sk-ant-api-a"),
+            mk_endpoint("available", "sk-ant-api-b"),
         ]);
         let now_epoch = AppState::now_epoch();
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.30);
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now_epoch + 10000);
@@ -10079,14 +8968,14 @@ token = "sk-ant-test"
             );
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.80);
             info.utilization_5h = Some(0.80);
             info.reset_5h = Some(now_epoch + 10000);
         }
 
         let result = state
-            .pick_account(Some("test"), "claude-sonnet-4-6", &[])
+            .pick_endpoint(Some("test"), "claude-sonnet-4-6", &[])
             .await;
         assert_eq!(
             result,
@@ -10100,18 +8989,18 @@ token = "sk-ant-test"
         // After a probe clears hard_limited_until and refreshes data, the normal
         // routing logic should apply (not the 0.5 fallback).
         let state = test_state_with(vec![
-            make_account("low_util", "sk-ant-api-a"),
-            make_account("high_util", "sk-ant-api-b"),
+            mk_endpoint("low_util", "sk-ant-api-a"),
+            mk_endpoint("high_util", "sk-ant-api-b"),
         ]);
 
         {
             // hard_limited_until is None (cleared by probe), fresh data available
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.2);
             info.last_updated = Some(Instant::now());
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.8);
             info.last_updated = Some(Instant::now());
         }
@@ -10119,7 +9008,7 @@ token = "sk-ant-test"
         // low_util should get ~80% of traffic (headroom=0.8 vs 0.2)
         let mut counts = [0u32; 2];
         for _ in 0..1000 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             counts[idx] += 1;
         }
         let low_pct = counts[0] as f64 / 1000.0;
@@ -10134,11 +9023,11 @@ token = "sk-ant-test"
     async fn mark_hard_limited_detects_burst_429() {
         // Burst 429: x-should-retry=true, no retry-after, no rate-limit headers.
         // Should use short cooldown, NOT poison remaining_tokens/requests.
-        let state = test_state_with(vec![make_account("burst-test", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("burst-test", "sk-ant-api-a")]);
 
         // Pre-set some remaining tokens to verify they aren't poisoned
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.remaining_tokens = Some(5000);
             info.remaining_requests = Some(10);
         }
@@ -10149,7 +9038,7 @@ token = "sk-ant-test"
 
         state.mark_hard_limited(0, &headers).await;
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert!(
             info.hard_limited_until.is_some(),
             "burst 429 should still set hard_limited_until"
@@ -10170,10 +9059,10 @@ token = "sk-ant-test"
     #[tokio::test]
     async fn mark_hard_limited_capacity_429_poisons_state() {
         // Capacity 429: has rate-limit headers → should poison remaining_tokens/requests to 0.
-        let state = test_state_with(vec![make_account("cap-test", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("cap-test", "sk-ant-api-a")]);
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.remaining_tokens = Some(5000);
             info.remaining_requests = Some(10);
         }
@@ -10188,7 +9077,7 @@ token = "sk-ant-test"
 
         state.mark_hard_limited(0, &headers).await;
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert_eq!(
             info.remaining_tokens,
             Some(0),
@@ -10208,7 +9097,7 @@ token = "sk-ant-test"
     #[tokio::test]
     async fn mark_hard_limited_burst_exponential_backoff() {
         // Consecutive burst 429s should produce increasing cooldowns.
-        let state = test_state_with(vec![make_account("backoff-test", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("backoff-test", "sk-ant-api-a")]);
 
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert("x-should-retry", HeaderValue::from_static("true"));
@@ -10217,7 +9106,7 @@ token = "sk-ant-test"
         let mut cooldowns = Vec::new();
         for _ in 0..5 {
             state.mark_hard_limited(0, &headers).await;
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             let until = info.hard_limited_until.unwrap();
             let remaining = until.duration_since(Instant::now());
             cooldowns.push(remaining.as_secs());
@@ -10250,21 +9139,21 @@ token = "sk-ant-test"
             cooldowns[4]
         );
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert_eq!(info.consecutive_burst_429s, 5);
     }
 
     #[tokio::test]
     async fn mark_hard_limited_retry_after_overrides_default() {
         // When retry-after is present, it should be used regardless of x-should-retry.
-        let state = test_state_with(vec![make_account("retry-test", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("retry-test", "sk-ant-api-a")]);
 
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert("retry-after", HeaderValue::from_static("30"));
 
         state.mark_hard_limited(0, &headers).await;
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         let until = info.hard_limited_until.unwrap();
         let remaining = until.duration_since(Instant::now()).as_secs();
         assert!(
@@ -10283,12 +9172,12 @@ token = "sk-ant-test"
         // Unknown accounts get headroom=0.5, known account with 0.1 util gets headroom=0.9
         // Traffic should favor the known account proportionally
         let state = test_state_with(vec![
-            make_account("known", "sk-ant-api-known"),
-            make_account("unknown", "sk-ant-api-unknown"),
+            mk_endpoint("known", "sk-ant-api-known"),
+            mk_endpoint("unknown", "sk-ant-api-unknown"),
         ]);
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.1); // headroom = 0.9
         }
         // accounts[1] has no rate info → headroom = 0.5
@@ -10296,7 +9185,7 @@ token = "sk-ant-test"
         // known should get ~64% (0.9 / 1.4), unknown ~36% (0.5 / 1.4)
         let mut counts = [0u32; 2];
         for _ in 0..1000 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             counts[idx] += 1;
         }
 
@@ -10315,29 +9204,29 @@ token = "sk-ant-test"
         // account's weight to the best — affinity is preserved when the ratio
         // exceeds the threshold, i.e. no single account is 2x better.
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-a"),
-            make_account("b", "sk-ant-api-b"),
-            make_account("c", "sk-ant-api-c"),
+            mk_endpoint("a", "sk-ant-api-a"),
+            mk_endpoint("b", "sk-ant-api-b"),
+            mk_endpoint("c", "sk-ant-api-c"),
         ]);
 
         // Similar utilization → similar weights → ratio stays above 0.5
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.40);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.45);
         }
         {
-            let mut info = state.accounts[2].rate_info.write().await;
+            let mut info = state.endpoints[2].rate_info.write().await;
             info.utilization = Some(0.50);
         }
 
         let key = "192.168.1.1:client-42:agent-7:session-abc";
-        let first = state.pick_account(Some(key), "", &[]).await.unwrap();
+        let first = state.pick_endpoint(Some(key), "", &[]).await.unwrap();
         for _ in 0..100 {
-            let idx = state.pick_account(Some(key), "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(Some(key), "", &[]).await.unwrap();
             assert_eq!(
                 idx, first,
                 "same affinity key must always pick same account"
@@ -10352,15 +9241,15 @@ token = "sk-ant-test"
         // where 5h utilization is similar but 7d utilization is vastly different —
         // the weight formula captures the 7d disparity via waste_risk.
         let state = test_state_with(vec![
-            make_account("low_7d", "sk-ant-api-a"),
-            make_account("high_7d", "sk-ant-api-b"),
+            mk_endpoint("low_7d", "sk-ant-api-a"),
+            mk_endpoint("high_7d", "sk-ant-api-b"),
         ]);
         let now_epoch = AppState::now_epoch();
 
         // Both have similar 5h utilization (so gate_5h is similar)
         // but vastly different 7d utilization via claims_7d.
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.12);
             info.reset_5h = Some(now_epoch + 10000);
             info.claims_7d.insert(
@@ -10374,7 +9263,7 @@ token = "sk-ant-test"
             );
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.10);
             info.reset_5h = Some(now_epoch + 10000);
             info.claims_7d.insert(
@@ -10393,7 +9282,7 @@ token = "sk-ant-test"
         for i in 0..200 {
             let key = format!("sticky-client-{}", i);
             let idx = state
-                .pick_account(Some(&key), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             assert_eq!(
@@ -10419,7 +9308,7 @@ token = "sk-ant-test"
         for i in 0..attempts {
             let key = format!("{}-{}", prefix, i);
             let idx = state
-                .pick_account(Some(&key), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             match expect_index {
@@ -10449,16 +9338,16 @@ token = "sk-ant-test"
         // Primary 5h=0.20, Jeff 5h=0.25, no claims_7d
         // Weights: headroom_only → 0.80 vs 0.75, ratio=0.94 > 0.5
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.20);
             info.reset_5h = Some(AppState::now_epoch() + 10000);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.25);
             info.reset_5h = Some(AppState::now_epoch() + 10000);
         }
@@ -10479,8 +9368,8 @@ token = "sk-ant-test"
         // Primary 5h=0.15, 7d=0.40 vs Jeff 5h=0.15, 7d=0.60
         // waste_risk ratio isn't extreme enough to trigger override
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         set_account_utilization(&state, 0, 0.15, 0.40, now + 10000, now + 300000).await;
@@ -10503,8 +9392,8 @@ token = "sk-ant-test"
         // Primary's waste_risk is enormous, jeff's is near zero
         // Weight ratio far below 0.25 → all traffic overridden to primary
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         set_account_utilization(&state, 0, 0.10, 0.10, now + 10000, now + 300000).await;
@@ -10526,8 +9415,8 @@ token = "sk-ant-test"
         // Primary 5h=0.10, 7d=0.10 vs Jeff 5h=0.10, 7d=0.90
         // Extreme weight ratio → all traffic to primary
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         set_account_utilization(&state, 0, 0.10, 0.10, now + 10000, now + 300000).await;
@@ -10550,8 +9439,8 @@ token = "sk-ant-test"
         // Primary has 5h pressure but 7d budget; Jeff has 5h headroom but 7d exhausted
         // Weights should be close enough to preserve affinity
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         set_account_utilization(&state, 0, 0.85, 0.20, now + 10000, now + 300000).await;
@@ -10574,9 +9463,9 @@ token = "sk-ant-test"
         // accounts receive sticky traffic via proportional bucket hashing.
         let state = test_state_with_strategy(
             vec![
-                make_account("primary", "sk-ant-api-a"),
-                make_account("steve", "sk-ant-api-b"),
-                make_account("jeff", "sk-ant-api-c"),
+                mk_endpoint("primary", "sk-ant-api-a"),
+                mk_endpoint("steve", "sk-ant-api-b"),
+                mk_endpoint("jeff", "sk-ant-api-c"),
             ],
             RoutingStrategy::StickyWeightedV2,
         );
@@ -10590,7 +9479,7 @@ token = "sk-ant-test"
         for i in 0..1000 {
             let key = format!("three-way-client-{}", i);
             let idx = state
-                .pick_account(Some(&key), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             saw[idx] = true;
@@ -10611,9 +9500,9 @@ token = "sk-ant-test"
         // bucket should be overridden to the best account.
         let state = test_state_with_strategy(
             vec![
-                make_account("primary", "sk-ant-api-a"),
-                make_account("jeff", "sk-ant-api-b"),
-                make_account("insight", "sk-ant-api-c"),
+                mk_endpoint("primary", "sk-ant-api-a"),
+                mk_endpoint("jeff", "sk-ant-api-b"),
+                mk_endpoint("insight", "sk-ant-api-c"),
             ],
             RoutingStrategy::StickyWeightedV2,
         );
@@ -10630,7 +9519,7 @@ token = "sk-ant-test"
         let mut cumulative = 0.0;
         for c in &candidates {
             cumulative += c.weight;
-            boundaries.push((c.endpoint.account().unwrap(), cumulative));
+            boundaries.push((c.endpoint, cumulative));
         }
 
         let mut insight_key = None;
@@ -10653,7 +9542,7 @@ token = "sk-ant-test"
 
         // With the override, pick_account should redirect away from insight
         let idx = state
-            .pick_account(Some(&key), "claude-opus-4-6", &[])
+            .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
             .await
             .unwrap();
         assert_ne!(
@@ -10667,31 +9556,31 @@ token = "sk-ant-test"
     async fn dynamic_capacity_v1_ignores_replica_local_request_history() {
         let state = test_state_with_strategy(
             vec![
-                make_account("primary", "sk-ant-api-a"),
-                make_account("jeff", "sk-ant-api-b"),
+                mk_endpoint("primary", "sk-ant-api-a"),
+                mk_endpoint("jeff", "sk-ant-api-b"),
             ],
             RoutingStrategy::DynamicCapacityV1,
         );
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.10);
             info.reset_5h = Some(AppState::now_epoch() + 10000);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.10);
             info.reset_5h = Some(AppState::now_epoch() + 10000);
         }
 
-        state.accounts[1].requests.store(900, Ordering::Relaxed);
-        state.accounts[0].requests.store(100, Ordering::Relaxed);
+        state.endpoints[1].requests.store(900, Ordering::Relaxed);
+        state.endpoints[0].requests.store(100, Ordering::Relaxed);
 
         let mut primary_count = 0u32;
         let total = 200u32;
         for i in 0..total {
             let key = format!("balance-test-{}", i);
             let idx = state
-                .pick_account(Some(&key), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             if idx == 0 {
@@ -10711,31 +9600,31 @@ token = "sk-ant-test"
     async fn sticky_weighted_v2_preserves_hash_distribution_under_skewed_history() {
         let state = test_state_with_strategy(
             vec![
-                make_account("primary", "sk-ant-api-a"),
-                make_account("jeff", "sk-ant-api-b"),
+                mk_endpoint("primary", "sk-ant-api-a"),
+                mk_endpoint("jeff", "sk-ant-api-b"),
             ],
             RoutingStrategy::StickyWeightedV2,
         );
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.10);
             info.reset_5h = Some(AppState::now_epoch() + 10000);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.10);
             info.reset_5h = Some(AppState::now_epoch() + 10000);
         }
 
-        state.accounts[1].requests.store(900, Ordering::Relaxed);
-        state.accounts[0].requests.store(100, Ordering::Relaxed);
+        state.endpoints[1].requests.store(900, Ordering::Relaxed);
+        state.endpoints[0].requests.store(100, Ordering::Relaxed);
 
         let mut primary_count = 0u32;
         let total = 200u32;
         for i in 0..total {
             let key = format!("balance-test-{}", i);
             let idx = state
-                .pick_account(Some(&key), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             if idx == 0 {
@@ -10760,19 +9649,19 @@ token = "sk-ant-test"
         // sessions that hashed to primary.
         let state = test_state_with_strategy(
             vec![
-                make_account("primary", "sk-ant-api-a"),
-                make_account("backup", "sk-ant-api-b"),
+                mk_endpoint("primary", "sk-ant-api-a"),
+                mk_endpoint("backup", "sk-ant-api-b"),
             ],
             RoutingStrategy::StickyWeightedV2,
         );
 
         // Start with primary having lots of headroom
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.2); // headroom = 0.8
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.5); // headroom = 0.5
         }
 
@@ -10780,7 +9669,7 @@ token = "sk-ant-test"
         let mut primary_keys: Vec<String> = Vec::new();
         for i in 0..500 {
             let key = format!("test-client-{}", i);
-            if state.pick_account(Some(&key), "", &[]).await.unwrap() == 0 {
+            if state.pick_endpoint(Some(&key), "", &[]).await.unwrap() == 0 {
                 primary_keys.push(key);
             }
         }
@@ -10791,14 +9680,14 @@ token = "sk-ant-test"
 
         // Now overload primary: util=0.99 (headroom=0.01), backup stays at 0.5 (headroom=0.5)
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.99);
         }
 
         // All sessions that hashed to primary should migrate (egregious disparity)
         let mut migrated = 0usize;
         for key in &primary_keys {
-            if state.pick_account(Some(key), "", &[]).await.unwrap() == 1 {
+            if state.pick_endpoint(Some(key), "", &[]).await.unwrap() == 1 {
                 migrated += 1;
             }
         }
@@ -10819,8 +9708,8 @@ token = "sk-ant-test"
         // perfectly stable session routing. This is the prompt-cache scenario —
         // bouncing between accounts wastes cache-creation tokens.
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         set_account_utilization(&state, 0, 0.07, 0.73, now + 10000, now + 300000).await;
@@ -10828,14 +9717,14 @@ token = "sk-ant-test"
 
         let session = "10.42.0.1:claude:first-steps:-:9e8efc8c-2891-4206-ae10-8bcd5fa7e1f0";
         let first = state
-            .pick_account(Some(session), "claude-opus-4-6", &[])
+            .pick_endpoint(Some(session), "claude-opus-4-6", &[])
             .await
             .unwrap();
 
         // Same session, 100 consecutive requests: must ALWAYS pick the same account
         for i in 0..100 {
             let pick = state
-                .pick_account(Some(session), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(session), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             assert_eq!(
@@ -10854,8 +9743,8 @@ token = "sk-ant-test"
         // Uses multiple sessions and asserts low aggregate migration rate,
         // avoiding boundary-sensitivity from any single hard-coded key.
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         set_account_utilization(&state, 0, 0.05, 0.70, now + 10000, now + 300000).await;
@@ -10870,7 +9759,7 @@ token = "sk-ant-test"
         for s in &sessions {
             initial_picks.push(
                 state
-                    .pick_account(Some(s), "claude-opus-4-6", &[])
+                    .pick_endpoint(Some(s), "claude-opus-4-6", &[])
                     .await
                     .unwrap(),
             );
@@ -10880,11 +9769,11 @@ token = "sk-ant-test"
         for i in 0..50 {
             let drift = 0.002 * (i as f64);
             {
-                let mut info = state.accounts[0].rate_info.write().await;
+                let mut info = state.endpoints[0].rate_info.write().await;
                 info.utilization_5h = Some(0.05 + drift);
             }
             {
-                let mut info = state.accounts[1].rate_info.write().await;
+                let mut info = state.endpoints[1].rate_info.write().await;
                 info.utilization_5h = Some(0.05 + drift * 0.8);
             }
         }
@@ -10893,7 +9782,7 @@ token = "sk-ant-test"
         let mut migrated = 0usize;
         for (j, s) in sessions.iter().enumerate() {
             let pick = state
-                .pick_account(Some(s), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(s), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             if pick != initial_picks[j] {
@@ -10918,8 +9807,8 @@ token = "sk-ant-test"
         // accounts via hash, providing cross-account balance without per-session
         // instability. This is the balancing mechanism.
         let state = test_state_with(vec![
-            make_account("primary", "sk-ant-api-a"),
-            make_account("jeff", "sk-ant-api-b"),
+            mk_endpoint("primary", "sk-ant-api-a"),
+            mk_endpoint("jeff", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         set_account_utilization(&state, 0, 0.10, 0.50, now + 10000, now + 300000).await;
@@ -10929,7 +9818,7 @@ token = "sk-ant-test"
         for i in 0..500 {
             let session = format!("session-{}", i);
             let idx = state
-                .pick_account(Some(&session), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&session), "claude-opus-4-6", &[])
                 .await
                 .unwrap();
             picks[idx] += 1;
@@ -10951,8 +9840,8 @@ token = "sk-ant-test"
         // Game theory: when one account is under extreme pressure,
         // cache locality cost is worth paying to avoid quota exhaustion.
         let state = test_state_with(vec![
-            make_account("healthy", "sk-ant-api-a"),
-            make_account("dying", "sk-ant-api-b"),
+            mk_endpoint("healthy", "sk-ant-api-a"),
+            mk_endpoint("dying", "sk-ant-api-b"),
         ]);
         let now = AppState::now_epoch();
         // healthy: 5h=0.10, 7d=0.20 (lots of capacity)
@@ -10965,7 +9854,7 @@ token = "sk-ant-test"
         for i in 0..200 {
             let session = format!("session-{}", i);
             if state
-                .pick_account(Some(&session), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&session), "claude-opus-4-6", &[])
                 .await
                 .unwrap()
                 == 0
@@ -10987,8 +9876,8 @@ token = "sk-ant-test"
         // benefit at this disparity level.
         let state = test_state_with_strategy(
             vec![
-                make_account("primary", "sk-ant-api-a"),
-                make_account("jeff", "sk-ant-api-b"),
+                mk_endpoint("primary", "sk-ant-api-a"),
+                mk_endpoint("jeff", "sk-ant-api-b"),
             ],
             RoutingStrategy::StickyWeightedV2,
         );
@@ -11002,7 +9891,7 @@ token = "sk-ant-test"
         for i in 0..500 {
             let session = format!("moderate-session-{}", i);
             match state
-                .pick_account(Some(&session), "claude-opus-4-6", &[])
+                .pick_endpoint(Some(&session), "claude-opus-4-6", &[])
                 .await
                 .unwrap()
             {
@@ -11023,30 +9912,30 @@ token = "sk-ant-test"
     async fn pick_proportional_distribution() {
         // Verify distribution matches headroom ratios over many calls
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-a"),
-            make_account("b", "sk-ant-api-b"),
-            make_account("c", "sk-ant-api-c"),
+            mk_endpoint("a", "sk-ant-api-a"),
+            mk_endpoint("b", "sk-ant-api-b"),
+            mk_endpoint("c", "sk-ant-api-c"),
         ]);
 
         // a=0.2 util (headroom 0.8), b=0.5 util (headroom 0.5), c=0.8 util (headroom 0.2)
         // Total headroom = 1.5. Expected: a=53.3%, b=33.3%, c=13.3%
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.2);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.5);
         }
         {
-            let mut info = state.accounts[2].rate_info.write().await;
+            let mut info = state.endpoints[2].rate_info.write().await;
             info.utilization = Some(0.8);
         }
 
         let mut counts = [0u32; 3];
         let total = 10000u32;
         for _ in 0..total {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             counts[idx] += 1;
         }
 
@@ -11128,7 +10017,7 @@ token = "sk-ant-test"
         assert_eq!(resp.status(), reqwest::StatusCode::OK);
 
         // Verify rate info was updated from mock response headers
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert_eq!(info.utilization, Some(0.25));
         assert_eq!(info.representative_claim.as_deref(), Some("five_hour"));
     }
@@ -11367,23 +10256,22 @@ token = "sk-ant-test"
             axum::serve(mock_listener, mock_app).await.unwrap();
         });
 
-        // Single OAuth account — forces all requests through the oauth_body_bytes path
-        let accounts = vec![make_account("oauth-acct", "sk-ant-oat01-test-token")];
+        // Single OAuth endpoint — forces all requests through the oauth_body_bytes path
+        let mut oauth_ep = mk_endpoint("oauth-acct", "sk-ant-oat01-test-token");
+        oauth_ep.base_url = format!("http://{}", mock_addr);
+        let accounts = vec![oauth_ep];
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: format!("http://{}", mock_addr),
-            accounts,
-            endpoints: vec![],
+            endpoints: accounts,
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-oauth-cache-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true, // KEY: auto-cache enabled
             client_usage: Mutex::new(HashMap::new()),
@@ -11402,7 +10290,6 @@ token = "sk-ant-test"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -11479,17 +10366,15 @@ token = "sk-ant-test"
 
         assert_eq!(resp.status(), reqwest::StatusCode::OK);
         let body: serde_json::Value = resp.json().await.unwrap();
-        let accounts = body["accounts"].as_array().unwrap();
-        assert_eq!(accounts.len(), 2);
-        assert_eq!(accounts[0]["name"], "acct-a");
-        assert_eq!(accounts[1]["name"], "acct-b");
+        let endpoints = body["endpoints"].as_array().unwrap();
+        assert_eq!(endpoints.len(), 2);
+        assert_eq!(endpoints[0]["name"], "acct-a");
+        assert_eq!(endpoints[1]["name"], "acct-b");
+        assert_eq!(endpoints[0]["protocol"], "anthropic");
         assert_eq!(body["strategy"], "dynamic-capacity-v1");
-        // Upstreams section should be present
-        let upstreams = body["upstreams"].as_array().unwrap();
-        assert_eq!(upstreams.len(), 1);
-        assert_eq!(upstreams[0]["name"], "mock");
-        // Endpoints array is always present (empty for a legacy accounts config).
-        assert_eq!(body["endpoints"].as_array().unwrap().len(), 0);
+        // Legacy `accounts` and `upstreams` arrays are gone from the schema.
+        assert!(body.get("accounts").is_none());
+        assert!(body.get("upstreams").is_none());
     }
 
     #[tokio::test]
@@ -11499,13 +10384,10 @@ token = "sk-ant-test"
             e.priority = 5;
             e
         };
-        // Endpoints-only config: legacy accounts pool is empty.
-        let mut state = test_state_with(vec![]);
-        {
-            let st = Arc::get_mut(&mut state).expect("uniquely owned before router build");
-            st.endpoints.push(ep("ep-anthropic", Protocol::Anthropic));
-            st.endpoints.push(ep("ep-openai", Protocol::OpenAI));
-        }
+        let state = test_state_with(vec![
+            ep("ep-anthropic", Protocol::Anthropic),
+            ep("ep-openai", Protocol::OpenAI),
+        ]);
         let addr = serve(build_router(state)).await;
 
         let client = Client::new();
@@ -11516,8 +10398,6 @@ token = "sk-ant-test"
             .unwrap();
         assert_eq!(resp.status(), reqwest::StatusCode::OK);
         let body: serde_json::Value = resp.json().await.unwrap();
-        // Legacy accounts array present and empty.
-        assert_eq!(body["accounts"].as_array().unwrap().len(), 0);
         let endpoints = body["endpoints"].as_array().unwrap();
         assert_eq!(endpoints.len(), 2);
         assert_eq!(endpoints[0]["name"], "ep-anthropic");
@@ -12590,28 +11470,27 @@ token = "sk-ant-test"
             .unwrap()
     }
 
-    /// Build test app with separate handlers for streaming vs non-streaming
+    /// Build test app with separate handlers for streaming vs non-streaming.
+    /// Both Anthropic endpoints point at `upstream_url` (the mock upstream).
     fn test_openai_app(upstream_url: &str, proxy_key: Option<String>) -> (Router, Arc<AppState>) {
-        let accounts = vec![
-            make_account("acct-a", "sk-ant-api-test-aaa"),
-            make_account("acct-b", "sk-ant-api-test-bbb"),
-        ];
+        let mut acct_a = mk_endpoint("acct-a", "sk-ant-api-test-aaa");
+        acct_a.base_url = upstream_url.to_string();
+        let mut acct_b = mk_endpoint("acct-b", "sk-ant-api-test-bbb");
+        acct_b.base_url = upstream_url.to_string();
+        let accounts = vec![acct_a, acct_b];
 
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: upstream_url.to_string(),
-            accounts,
-            endpoints: vec![],
+            endpoints: accounts,
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-openai-test.state.json"),
             proxy_key,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -12630,7 +11509,6 @@ token = "sk-ant-test"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -13158,27 +12036,25 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn record_usage_updates_account_and_client() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let usage = TokenUsage {
             input_tokens: 100,
             output_tokens: 50,
             cache_creation_input_tokens: 20,
             cache_read_input_tokens: 30,
         };
-        state
-            .record_usage(UsageTarget::Account(0), "test-client", &usage)
-            .await;
+        state.record_usage(0, "test-client", &usage).await;
 
-        assert_eq!(state.accounts[0].input_tokens.load(Ordering::Relaxed), 100);
-        assert_eq!(state.accounts[0].output_tokens.load(Ordering::Relaxed), 50);
+        assert_eq!(state.endpoints[0].input_tokens.load(Ordering::Relaxed), 100);
+        assert_eq!(state.endpoints[0].output_tokens.load(Ordering::Relaxed), 50);
         assert_eq!(
-            state.accounts[0]
+            state.endpoints[0]
                 .cache_creation_tokens
                 .load(Ordering::Relaxed),
             20
         );
         assert_eq!(
-            state.accounts[0].cache_read_tokens.load(Ordering::Relaxed),
+            state.endpoints[0].cache_read_tokens.load(Ordering::Relaxed),
             30
         );
 
@@ -13189,19 +12065,17 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn record_usage_ignores_anonymous() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let usage = TokenUsage {
             input_tokens: 100,
             output_tokens: 50,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
         };
-        state
-            .record_usage(UsageTarget::Account(0), "-", &usage)
-            .await;
+        state.record_usage(0, "-", &usage).await;
 
         // Account gets updated
-        assert_eq!(state.accounts[0].input_tokens.load(Ordering::Relaxed), 100);
+        assert_eq!(state.endpoints[0].input_tokens.load(Ordering::Relaxed), 100);
         // But no client entry for anonymous
         let map = state.client_usage.lock().unwrap();
         assert!(!map.contains_key("-"));
@@ -13211,7 +12085,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn account_serves_model_no_filter() {
-        let acct = make_account("a", "sk-ant-api-x");
+        let acct = mk_endpoint("a", "sk-ant-api-x");
         assert!(acct.serves_model("claude-opus-4-6"));
         assert!(acct.serves_model("claude-haiku-4-5"));
         assert!(acct.serves_model(""));
@@ -13219,7 +12093,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn account_serves_model_exact_match() {
-        let mut acct = make_account("a", "sk-ant-api-x");
+        let mut acct = mk_endpoint("a", "sk-ant-api-x");
         acct.models = vec!["claude-sonnet-4-6".to_string()];
         assert!(acct.serves_model("claude-sonnet-4-6"));
         assert!(!acct.serves_model("claude-opus-4-6"));
@@ -13227,7 +12101,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn account_serves_model_prefix_match() {
-        let mut acct = make_account("a", "sk-ant-api-x");
+        let mut acct = mk_endpoint("a", "sk-ant-api-x");
         acct.models = vec!["claude-opus-*".to_string(), "claude-sonnet-*".to_string()];
         assert!(acct.serves_model("claude-opus-4-6"));
         assert!(acct.serves_model("claude-sonnet-4-6"));
@@ -13236,23 +12110,23 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn pick_account_filters_by_model() {
-        let mut acct_a = make_account("opus-only", "sk-ant-api-a");
+        let mut acct_a = mk_endpoint("opus-only", "sk-ant-api-a");
         acct_a.models = vec!["claude-opus-*".to_string()];
 
-        let acct_b = make_account("any-model", "sk-ant-api-b");
+        let acct_b = mk_endpoint("any-model", "sk-ant-api-b");
 
         let state = test_state_with(vec![acct_a, acct_b]);
 
         // Requesting opus: both accounts eligible
         let idx = state
-            .pick_account(None, "claude-opus-4-6", &[])
+            .pick_endpoint(None, "claude-opus-4-6", &[])
             .await
             .unwrap();
         assert!(idx == 0 || idx == 1);
 
         // Requesting haiku: only acct_b eligible
         let idx = state
-            .pick_account(None, "claude-haiku-4-5", &[])
+            .pick_endpoint(None, "claude-haiku-4-5", &[])
             .await
             .unwrap();
         assert_eq!(idx, 1);
@@ -13260,8 +12134,8 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn soft_limit_excludes_overloaded_accounts() {
-        let acct_a = make_account("healthy", "sk-ant-api-a");
-        let acct_b = make_account("overloaded", "sk-ant-api-b");
+        let acct_a = mk_endpoint("healthy", "sk-ant-api-a");
+        let acct_b = mk_endpoint("overloaded", "sk-ant-api-b");
 
         let accounts = vec![acct_a, acct_b];
 
@@ -13285,16 +12159,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts,
-            endpoints: vec![],
+            endpoints: accounts,
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -13313,14 +12184,13 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
         // Try many affinity keys — all should route to healthy (idx 0)
         for i in 0..20 {
             let key = format!("client-{}", i);
-            let idx = state.pick_account(Some(&key), "any", &[]).await.unwrap();
+            let idx = state.pick_endpoint(Some(&key), "any", &[]).await.unwrap();
             assert_eq!(
                 idx, 0,
                 "client '{}' routed to overloaded account despite soft limit",
@@ -13331,11 +12201,11 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn routing_candidates_ignore_unmatched_7d_state() {
-        let state = test_state_with(vec![make_account("acct-a", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("acct-a", "sk-ant-api-a")]);
         let now = AppState::now_epoch();
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.20);
             info.utilization_5h = Some(0.20);
             info.reset_5h = Some(now + 10000);
@@ -13376,7 +12246,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn openai_endpoint_participates_at_configured_priority() {
-        let acct = make_account("anthropic", "sk-ant-api-a");
+        let acct = mk_endpoint("anthropic", "sk-ant-api-a");
         {
             let mut info = acct.rate_info.write().await;
             info.utilization = Some(0.0); // healthy
@@ -13388,14 +12258,13 @@ data: {\"type\":\"message_stop\"}\n\n";
         st.endpoints.push(ep);
 
         let candidates = state.routing_candidates("claude-opus-4-7", &[]).await;
-        let openai_candidate = candidates
-            .iter()
-            .find(|c| matches!(c.endpoint, EndpointIdx::Unified(_)));
+        let openai_candidate = candidates.iter().find(|c| c.source == "openai");
         assert!(
             openai_candidate.is_some(),
             "openai endpoint must be a candidate"
         );
         let c = openai_candidate.unwrap();
+        assert_eq!(c.endpoint, 1, "openai endpoint is at index 1");
         assert_eq!(c.priority, 100);
         assert_eq!(c.weight, 1.0);
         assert_eq!(c.gate, 0.0);
@@ -13419,7 +12288,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn budget_check_no_limit_configured() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         assert!(state.check_budget("any-client").await.is_ok());
     }
 
@@ -13432,16 +12301,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -13460,7 +12326,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -13755,7 +12620,7 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn status_clears_when_header_absent() {
         // Bug #1: stale status should clear when API sends utilization but no status header
-        let accounts = vec![make_account("acct-a", "sk-ant-api-test-aaa")];
+        let accounts = vec![mk_endpoint("acct-a", "sk-ant-api-test-aaa")];
         let state = test_state_with(accounts);
 
         // First response: set throttled status
@@ -13774,7 +12639,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         );
         state.update_rate_info(0, &headers1).await;
         {
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             assert_eq!(info.status_5h.as_deref(), Some("throttled"));
         }
 
@@ -13790,7 +12655,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         );
         state.update_rate_info(0, &headers2).await;
         {
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             assert_eq!(
                 info.status_5h, None,
                 "status should clear when header absent"
@@ -13802,7 +12667,7 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn status_persists_when_no_util_header() {
         // If neither util nor status header is present for a window, don't clear status
         // (the response might be for a different window entirely)
-        let accounts = vec![make_account("acct-a", "sk-ant-api-test-aaa")];
+        let accounts = vec![mk_endpoint("acct-a", "sk-ant-api-test-aaa")];
         let state = test_state_with(accounts);
 
         // Set throttled status
@@ -13821,7 +12686,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         let headers2 = reqwest::header::HeaderMap::new();
         state.update_rate_info(0, &headers2).await;
         {
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             assert_eq!(
                 info.status_5h.as_deref(),
                 Some("throttled"),
@@ -13835,10 +12700,10 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Bug #5: all-rejected accounts should return None (zero total headroom)
         let now_epoch = AppState::now_epoch();
         let state = test_state_with(vec![
-            make_account("acct-a", "sk-ant-api-test-aaa"),
-            make_account("acct-b", "sk-ant-api-test-bbb"),
+            mk_endpoint("acct-a", "sk-ant-api-test-aaa"),
+            mk_endpoint("acct-b", "sk-ant-api-test-bbb"),
         ]);
-        for acct in &state.accounts {
+        for acct in &state.endpoints {
             let mut info = acct.rate_info.write().await;
             info.utilization_5h = Some(0.50);
             info.utilization_7d = Some(0.30);
@@ -13847,14 +12712,14 @@ data: {\"type\":\"message_stop\"}\n\n";
             info.reset_5h = Some(now_epoch + 7200);
             info.reset_7d = Some(now_epoch + 86400);
         }
-        let result = state.pick_account(None, "", &[]).await;
+        let result = state.pick_endpoint(None, "", &[]).await;
         assert_eq!(result, None, "all-rejected should return None");
     }
 
     #[tokio::test]
     async fn reset_sanity_rejects_far_future() {
         // Bug #6: reset timestamp > block duration from now should be rejected
-        let accounts = vec![make_account("acct-a", "sk-ant-api-test-aaa")];
+        let accounts = vec![mk_endpoint("acct-a", "sk-ant-api-test-aaa")];
         let state = test_state_with(accounts);
 
         let mut headers = reqwest::header::HeaderMap::new();
@@ -13870,7 +12735,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         );
         state.update_rate_info(0, &headers).await;
         {
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             assert_eq!(
                 info.reset_5h, None,
                 "far-future 5h reset should be rejected"
@@ -13891,12 +12756,12 @@ data: {\"type\":\"message_stop\"}\n\n";
         // A's 5h gets heavily discounted, 7d=0.30 becomes binding → A has more headroom than B
         let now_epoch = AppState::now_epoch();
         let accounts = vec![
-            make_account("acct-a", "sk-ant-api-test-aaa"),
-            make_account("acct-b", "sk-ant-api-test-bbb"),
+            mk_endpoint("acct-a", "sk-ant-api-test-aaa"),
+            mk_endpoint("acct-b", "sk-ant-api-test-bbb"),
         ];
         let state = test_state_with(accounts);
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.95);
             info.utilization_7d = Some(0.30);
             info.utilization = Some(0.95);
@@ -13904,7 +12769,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             info.reset_7d = Some(now_epoch + 86400); // 1 day out
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.60);
             info.utilization_7d = Some(0.50);
             info.utilization = Some(0.60);
@@ -13915,7 +12780,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Run 100 picks without affinity to see distribution
         let mut a_count = 0;
         for _ in 0..100 {
-            if let Some(idx) = state.pick_account(None, "", &[]).await {
+            if let Some(idx) = state.pick_endpoint(None, "", &[]).await {
                 if idx == 0 {
                     a_count += 1;
                 }
@@ -13940,19 +12805,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("acct-a", "sk-ant-api-test-aaa"),
-                make_account("acct-b", "sk-ant-api-test-bbb"),
+            endpoints: vec![
+                mk_endpoint("acct-a", "sk-ant-api-test-aaa"),
+                mk_endpoint("acct-b", "sk-ant-api-test-bbb"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -13971,11 +12833,10 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.utilization_7d = Some(0.20);
             info.utilization = Some(0.30);
@@ -13984,7 +12845,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             info.reset_7d = Some(now_epoch + 86400);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.40);
             info.utilization_7d = Some(0.30);
             info.utilization = Some(0.40);
@@ -13995,7 +12856,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
         let mut b_count = 0;
         for _ in 0..100 {
-            if let Some(idx) = state.pick_account(None, "", &[]).await {
+            if let Some(idx) = state.pick_endpoint(None, "", &[]).await {
                 if idx == 1 {
                     b_count += 1;
                 }
@@ -14014,19 +12875,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("acct-a", "sk-ant-api-test-aaa"),
-                make_account("acct-b", "sk-ant-api-test-bbb"),
+            endpoints: vec![
+                mk_endpoint("acct-a", "sk-ant-api-test-aaa"),
+                mk_endpoint("acct-b", "sk-ant-api-test-bbb"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -14045,11 +12903,10 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.20);
             info.utilization = Some(0.20);
             info.status_5h = Some("allowed".to_string());
@@ -14065,7 +12922,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             );
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.40);
             info.utilization = Some(0.40);
             info.status_5h = Some("allowed".to_string());
@@ -14075,7 +12932,10 @@ data: {\"type\":\"message_stop\"}\n\n";
         let mut b_count = 0;
         for i in 0..100 {
             let key = format!("sticky-opus-{i}");
-            if let Some(idx) = state.pick_account(Some(&key), "claude-opus-4-6", &[]).await {
+            if let Some(idx) = state
+                .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
+                .await
+            {
                 if idx == 1 {
                     b_count += 1;
                 }
@@ -14094,12 +12954,12 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Should behave identically to raw utilization
         let now_epoch = AppState::now_epoch();
         let accounts = vec![
-            make_account("acct-a", "sk-ant-api-test-aaa"),
-            make_account("acct-b", "sk-ant-api-test-bbb"),
+            mk_endpoint("acct-a", "sk-ant-api-test-aaa"),
+            mk_endpoint("acct-b", "sk-ant-api-test-bbb"),
         ];
         let state = test_state_with(accounts);
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.80);
             info.utilization_7d = Some(0.40);
             info.utilization = Some(0.80);
@@ -14107,7 +12967,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             info.reset_7d = Some(now_epoch + 86400);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.40);
             info.utilization_7d = Some(0.30);
             info.utilization = Some(0.40);
@@ -14117,7 +12977,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
         let mut b_count = 0;
         for _ in 0..100 {
-            if let Some(idx) = state.pick_account(None, "", &[]).await {
+            if let Some(idx) = state.pick_endpoint(None, "", &[]).await {
                 if idx == 1 {
                     b_count += 1;
                 }
@@ -14666,18 +13526,18 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn signal_hard_limit_recovery_without_redis_is_noop() {
         // Without Redis, the helper must still refresh metrics + publish weights
         // locally. It must not panic and must not attempt Redis I/O.
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-test")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-test")]);
         // Pre-seed a non-zero weight so we can assert refresh_metrics_weights ran
-        state.accounts[0]
+        state.endpoints[0]
             .last_routing_weight
             .store(0u64, Ordering::Relaxed);
         state
-            .signal_hard_limit_recovery(&state.accounts[0].name)
+            .signal_hard_limit_recovery(&state.endpoints[0].name)
             .await;
         // refresh_metrics_weights always writes a value (even zero) — the point
         // is that the method completed without Redis and without panicking.
         let w = f64::from_bits(
-            state.accounts[0]
+            state.endpoints[0]
                 .last_routing_weight
                 .load(Ordering::Relaxed),
         );
@@ -14780,16 +13640,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names,
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -14808,7 +13665,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -14825,7 +13681,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn resolve_header_fallback() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let mut headers = hyper::HeaderMap::new();
         headers.insert("x-client-id", HeaderValue::from_static("gastown"));
         let ip: IpAddr = "192.168.1.99".parse().unwrap();
@@ -14834,7 +13690,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn resolve_unknown() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let headers = hyper::HeaderMap::new();
         let ip: IpAddr = "192.168.1.99".parse().unwrap();
         assert_eq!(state.resolve_client_id(&ip, &headers), "-");
@@ -14851,16 +13707,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names,
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -14879,7 +13732,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -15284,8 +14136,8 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Account A: Sonnet 7d at 0.90 (high), Opus 7d at 0.10 (low)
         // Account B: Sonnet 7d at 0.10 (low), Opus 7d at 0.90 (high)
         // Routing for Sonnet should prefer B, routing for Opus should prefer A
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_b = make_account("b", "sk-ant-api-b");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_b = mk_endpoint("b", "sk-ant-api-b");
         let state = test_state_with(vec![acct_a, acct_b]);
         let now = AppState::now_epoch();
 
@@ -15305,12 +14157,15 @@ data: {\"type\":\"message_stop\"}\n\n";
         for i in 0..100 {
             let key = format!("client_{}", i);
             if let Some(idx) = state
-                .pick_account(Some(&key), "claude-sonnet-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-sonnet-4-6", &[])
                 .await
             {
                 sonnet_picks[idx] += 1;
             }
-            if let Some(idx) = state.pick_account(Some(&key), "claude-opus-4-6", &[]).await {
+            if let Some(idx) = state
+                .pick_endpoint(Some(&key), "claude-opus-4-6", &[])
+                .await
+            {
                 opus_picks[idx] += 1;
             }
         }
@@ -15336,8 +14191,8 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn pick_account_prefers_expiring_quota() {
         // Account A: 7d=0.40, reset in 1 day → high waste_risk
         // Account B: 7d=0.40, reset in 6 days → low waste_risk
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_b = make_account("b", "sk-ant-api-b");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_b = mk_endpoint("b", "sk-ant-api-b");
         let state = test_state_with(vec![acct_a, acct_b]);
         let now = AppState::now_epoch();
 
@@ -15347,7 +14202,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
         // Override claims with different resets
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.claims_7d.insert(
                 "seven_day_sonnet".to_string(),
                 ClaimWindowData {
@@ -15359,7 +14214,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             );
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.claims_7d.insert(
                 "seven_day_sonnet".to_string(),
                 ClaimWindowData {
@@ -15375,7 +14230,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         for i in 0..200 {
             let key = format!("client_{}", i);
             if let Some(idx) = state
-                .pick_account(Some(&key), "claude-sonnet-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-sonnet-4-6", &[])
                 .await
             {
                 picks[idx] += 1;
@@ -15393,15 +14248,15 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn pick_account_dampens_by_5h() {
         // Account A: high waste_risk but high 5h → dampened
         // Account B: lower waste_risk but low 5h → more traffic
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_b = make_account("b", "sk-ant-api-b");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_b = mk_endpoint("b", "sk-ant-api-b");
         let state = test_state_with(vec![acct_a, acct_b]);
         let now = AppState::now_epoch();
 
         // A: 5h=0.85, 7d=0.20 (waste_risk ~5.0 with 1.5d remaining)
         set_account_utilization(&state, 0, 0.85, 0.20, now + 10000, now + 129600).await;
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.claims_7d.insert(
                 "seven_day_sonnet".to_string(),
                 ClaimWindowData {
@@ -15416,7 +14271,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         // B: 5h=0.30, 7d=0.50 (waste_risk ~1.2 with 3.5d remaining)
         set_account_utilization(&state, 1, 0.30, 0.50, now + 10000, now + 302400).await;
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.claims_7d.insert(
                 "seven_day_sonnet".to_string(),
                 ClaimWindowData {
@@ -15432,7 +14287,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         for i in 0..500 {
             let key = format!("client_{}", i);
             if let Some(idx) = state
-                .pick_account(Some(&key), "claude-sonnet-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-sonnet-4-6", &[])
                 .await
             {
                 picks[idx] += 1;
@@ -15454,21 +14309,21 @@ data: {\"type\":\"message_stop\"}\n\n";
         // No 7d claims → falls back to headroom-only weighting
         // Uses affinity (sticky) traffic to verify weight-proportional distribution
         // across distinct session keys, exercising the affinity path.
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_b = make_account("b", "sk-ant-api-b");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_b = mk_endpoint("b", "sk-ant-api-b");
         let state = test_state_with(vec![acct_a, acct_b]);
         let now = AppState::now_epoch();
 
         // Set 5h only, no claims_7d
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
             info.utilization = Some(0.30);
             info.claims_7d.clear();
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.70);
             info.reset_5h = Some(now + 10000);
             info.utilization = Some(0.70);
@@ -15481,7 +14336,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         for i in 0..200 {
             let key = format!("session-{}", i);
             if let Some(idx) = state
-                .pick_account(Some(&key), "claude-sonnet-4-6", &[])
+                .pick_endpoint(Some(&key), "claude-sonnet-4-6", &[])
                 .await
             {
                 picks[idx] += 1;
@@ -15492,7 +14347,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         let session = "10.42.0.1:client-test:agent-1:session-fallback";
         assert!(
             state
-                .pick_account(Some(session), "claude-sonnet-4-6", &[])
+                .pick_endpoint(Some(session), "claude-sonnet-4-6", &[])
                 .await
                 .is_some(),
             "affinity pick should return Some when accounts are available"
@@ -15512,8 +14367,8 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn emergency_brake_triggers_at_88() {
         // All accounts at 88% raw 7d → brake engages with new threshold
         let now = AppState::now_epoch();
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_b = make_account("b", "sk-ant-api-b");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_b = mk_endpoint("b", "sk-ant-api-b");
         let state = test_state_with(vec![acct_a, acct_b]);
 
         // Verify DEFAULT_EMERGENCY_THRESHOLD is 0.88
@@ -15526,7 +14381,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         set_account_utilization(&state, 1, 0.89, 0.89, now + 10000, now + 100000).await;
 
         // effective_utilization for both should be >= 0.88
-        let info0 = state.accounts[0].rate_info.read().await;
+        let info0 = state.endpoints[0].rate_info.read().await;
         let (util0, _, _, _) = effective_utilization(&info0, now, "");
         drop(info0);
         assert!(
@@ -15541,7 +14396,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         // A naive "iterate all endpoints" version sees the openai stub at (0.5, "unknown")
         // and forces all_above = false → brake never fires. The correct "skip OpenAI"
         // version excludes it and the brake fires.
-        let acct = make_account("anthropic", "sk-ant");
+        let acct = mk_endpoint("anthropic", "sk-ant");
         {
             let mut info = acct.rate_info.write().await;
             info.utilization = Some(0.95);
@@ -15560,7 +14415,7 @@ data: {\"type\":\"message_stop\"}\n\n";
     }
 
     #[tokio::test]
-    async fn probe_endpoint_unified_skips_openai() {
+    async fn probe_endpoint_skips_openai() {
         // The mock upstream injects `5h-utilization: 0.25` headers. If the probe
         // ran, `rate_info.utilization_5h` would become Some(0.25). The OpenAI
         // skip means the endpoint is never contacted and rate_info stays None.
@@ -15571,7 +14426,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         let mut state = test_state_with(vec![]);
         Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
 
-        state.probe_endpoint_unified(0, "claude-haiku-4-5").await;
+        state.probe_endpoint(0, "claude-haiku-4-5").await;
 
         // rate_info must be untouched: the OpenAI endpoint was skipped, no HTTP
         // call was made. A naive "probe all endpoints" version would have hit
@@ -15587,13 +14442,13 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_all_7d_rejected_returns_none() {
         // If all accounts have rejected 7d claims for the model, pick_account returns None
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_b = make_account("b", "sk-ant-api-b");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_b = mk_endpoint("b", "sk-ant-api-b");
         let state = test_state_with(vec![acct_a, acct_b]);
         let now = AppState::now_epoch();
 
         for idx in 0..2 {
-            let mut info = state.accounts[idx].rate_info.write().await;
+            let mut info = state.endpoints[idx].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
             info.claims_7d.insert(
@@ -15608,7 +14463,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         }
 
         let result = state
-            .pick_account(Some("test"), "claude-sonnet-4-6", &[])
+            .pick_endpoint(Some("test"), "claude-sonnet-4-6", &[])
             .await;
         assert!(
             result.is_none(),
@@ -15628,7 +14483,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         reset_5h: u64,
         reset_7d: u64,
     ) {
-        let mut info = state.accounts[idx].rate_info.write().await;
+        let mut info = state.endpoints[idx].rate_info.write().await;
         info.utilization_5h = Some(util_5h);
         info.utilization_7d = Some(util_7d);
         info.utilization = Some(util_5h.max(util_7d));
@@ -15660,7 +14515,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         } else {
             format!("seven_day_{}", family)
         };
-        let mut info = state.accounts[idx].rate_info.write().await;
+        let mut info = state.endpoints[idx].rate_info.write().await;
         info.claims_7d.insert(
             key,
             ClaimWindowData {
@@ -15694,19 +14549,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("a", "sk-ant-api-x"),
-                make_account("b", "sk-ant-api-y"),
+            endpoints: vec![
+                mk_endpoint("a", "sk-ant-api-x"),
+                mk_endpoint("b", "sk-ant-api-y"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -15725,7 +14577,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.50, 0.40, now + 10000, now + 100000).await;
@@ -15746,19 +14597,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("a", "sk-ant-api-x"),
-                make_account("b", "sk-ant-api-y"),
+            endpoints: vec![
+                mk_endpoint("a", "sk-ant-api-x"),
+                mk_endpoint("b", "sk-ant-api-y"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -15777,7 +14625,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.80, 0.70, now + 10000, now + 100000).await;
@@ -15799,19 +14646,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("a", "sk-ant-api-x"),
-                make_account("b", "sk-ant-api-y"),
+            endpoints: vec![
+                mk_endpoint("a", "sk-ant-api-x"),
+                mk_endpoint("b", "sk-ant-api-y"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -15830,7 +14674,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.90, 0.80, now + 10000, now + 100000).await;
@@ -15843,7 +14686,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn limit_no_config() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         assert!(state.check_utilization_limit("anyone", "").await.is_ok());
     }
 
@@ -15857,16 +14700,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -15885,7 +14725,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.95, 0.90, now + 10000, now + 100000).await;
@@ -15902,23 +14741,20 @@ data: {\"type\":\"message_stop\"}\n\n";
         // should return Ok (let pick_account handle the "no account" error later)
         let mut limits = HashMap::new();
         limits.insert("test-client".to_string(), 0.01); // very low limit
-        let mut acct = make_account("a", "sk-ant-api-x");
+        let mut acct = mk_endpoint("a", "sk-ant-api-x");
         acct.models = vec!["claude-sonnet".to_string()]; // only serves sonnet
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![acct],
-            endpoints: vec![],
+            endpoints: vec![acct],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -15937,7 +14773,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // Request for "claude-opus" — no account serves it → should pass
@@ -15960,19 +14795,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("a", "sk-ant-api-x"),
-                make_account("b", "sk-ant-api-y"),
+            endpoints: vec![
+                mk_endpoint("a", "sk-ant-api-x"),
+                mk_endpoint("b", "sk-ant-api-y"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -15991,7 +14823,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // Don't set any utilization — accounts remain "unknown" (0.5)
@@ -16017,20 +14848,17 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("a", "sk-ant-api-x"),
-                make_account("b", "sk-ant-api-y"),
-                make_account("c", "sk-ant-api-z"),
+            endpoints: vec![
+                mk_endpoint("a", "sk-ant-api-x"),
+                mk_endpoint("b", "sk-ant-api-y"),
+                mk_endpoint("c", "sk-ant-api-z"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16049,7 +14877,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // Two known accounts above limit, one unknown (no data set)
@@ -16069,8 +14896,8 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn emergency_all_above_threshold() {
         let now = AppState::now_epoch();
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-x"),
-            make_account("b", "sk-ant-api-y"),
+            mk_endpoint("a", "sk-ant-api-x"),
+            mk_endpoint("b", "sk-ant-api-y"),
         ]);
         set_account_utilization(&state, 0, 0.96, 0.90, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.97, 0.95, now + 10000, now + 100000).await;
@@ -16081,8 +14908,8 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn emergency_one_below() {
         let now = AppState::now_epoch();
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-x"),
-            make_account("b", "sk-ant-api-y"),
+            mk_endpoint("a", "sk-ant-api-x"),
+            mk_endpoint("b", "sk-ant-api-y"),
         ]);
         set_account_utilization(&state, 0, 0.96, 0.90, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.80, 0.70, now + 10000, now + 100000).await;
@@ -16099,16 +14926,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16127,7 +14951,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.98, 0.96, now + 10000, now + 100000).await;
@@ -16142,8 +14965,8 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn emergency_no_data() {
         // All accounts have default (0.5, "unknown") — brake should NOT activate (fail-open)
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-x"),
-            make_account("b", "sk-ant-api-y"),
+            mk_endpoint("a", "sk-ant-api-x"),
+            mk_endpoint("b", "sk-ant-api-y"),
         ]);
         assert!(
             !state.is_emergency_brake_active().await,
@@ -16154,9 +14977,9 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn emergency_stale_data_with_unified() {
         // Stale reset times but valid unified utilization at 0.97
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             // Resets in the past → stale per-window data
             info.utilization_5h = Some(0.97);
             info.reset_5h = Some(1);
@@ -16179,16 +15002,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16207,7 +15027,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.85, 0.70, now + 10000, now + 100000).await;
@@ -16233,9 +15052,9 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Brake stays inactive: the unknown account might have available quota.
         let now = AppState::now_epoch();
         let state = test_state_with(vec![
-            make_account("known-a", "sk-ant-api-a"),
-            make_account("known-b", "sk-ant-api-b"),
-            make_account("unknown-c", "sk-ant-api-c"), // no rate data set
+            mk_endpoint("known-a", "sk-ant-api-a"),
+            mk_endpoint("known-b", "sk-ant-api-b"),
+            mk_endpoint("unknown-c", "sk-ant-api-c"), // no rate data set
         ]);
         set_account_utilization(&state, 0, 0.96, 0.92, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.95, 0.91, now + 10000, now + 100000).await;
@@ -16251,9 +15070,9 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Some known above, some known below, plus an unknown. Brake inactive on multiple grounds.
         let now = AppState::now_epoch();
         let state = test_state_with(vec![
-            make_account("high", "sk-ant-api-a"),
-            make_account("low", "sk-ant-api-b"),
-            make_account("unknown", "sk-ant-api-c"),
+            mk_endpoint("high", "sk-ant-api-a"),
+            mk_endpoint("low", "sk-ant-api-b"),
+            mk_endpoint("unknown", "sk-ant-api-c"),
         ]);
         set_account_utilization(&state, 0, 0.96, 0.92, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.50, 0.40, now + 10000, now + 100000).await;
@@ -16274,16 +15093,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("mystery", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("mystery", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16302,7 +15118,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // No rate data set — account returns (0.5, "unknown")
@@ -16326,19 +15141,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("known", "sk-ant-api-a"),
-                make_account("unknown", "sk-ant-api-b"),
+            endpoints: vec![
+                mk_endpoint("known", "sk-ant-api-a"),
+                mk_endpoint("unknown", "sk-ant-api-b"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16357,7 +15169,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.60, 0.55, now + 10000, now + 100000).await;
@@ -16374,8 +15185,8 @@ data: {\"type\":\"message_stop\"}\n\n";
         // so util == threshold means NOT below → all_above stays true → brake fires.
         let now = AppState::now_epoch();
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-a"),
-            make_account("b", "sk-ant-api-b"),
+            mk_endpoint("a", "sk-ant-api-a"),
+            mk_endpoint("b", "sk-ant-api-b"),
         ]);
         set_account_utilization(&state, 0, 0.88, 0.88, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.88, 0.88, now + 10000, now + 100000).await;
@@ -16390,8 +15201,8 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Boundary: one account at threshold - epsilon. Just below → all_above = false.
         let now = AppState::now_epoch();
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-a"),
-            make_account("b", "sk-ant-api-b"),
+            mk_endpoint("a", "sk-ant-api-a"),
+            mk_endpoint("b", "sk-ant-api-b"),
         ]);
         set_account_utilization(&state, 0, 0.96, 0.92, now + 10000, now + 100000).await;
         set_account_utilization(&state, 1, 0.879, 0.85, now + 10000, now + 100000).await;
@@ -16405,7 +15216,7 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn emergency_single_known_above_threshold_fires() {
         // Single account fleet, known and above threshold → brake fires.
         let now = AppState::now_epoch();
-        let state = test_state_with(vec![make_account("solo", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("solo", "sk-ant-api-x")]);
         set_account_utilization(&state, 0, 0.95, 0.92, now + 10000, now + 100000).await;
         assert!(
             state.is_emergency_brake_active().await,
@@ -16417,7 +15228,7 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn emergency_single_unknown_account_fails_open() {
         // Single unknown account — both guards prevent activation:
         // 0.5 < 0.88 → all_above = false, AND any_known = false.
-        let state = test_state_with(vec![make_account("solo", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("solo", "sk-ant-api-x")]);
         assert!(
             !state.is_emergency_brake_active().await,
             "single unknown account: must fail-open"
@@ -16431,16 +15242,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16459,7 +15267,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // "-" is not the operator
@@ -16511,8 +15318,6 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![],
             endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
@@ -16520,7 +15325,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16539,7 +15343,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // Operator always gets "healthy" regardless of utilization
@@ -16558,8 +15361,6 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![],
             endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
@@ -16567,7 +15368,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -16586,7 +15386,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // gastown has limit 0.85, 80% of that = 0.68
@@ -16711,11 +15510,11 @@ data: {\"type\":\"message_stop\"}\n\n";
 
         assert_eq!(resp.status(), reqwest::StatusCode::OK);
         let body: serde_json::Value = resp.json().await.unwrap();
-        let accounts = body["accounts"].as_array().unwrap();
-        assert!(!accounts.is_empty());
+        let endpoints = body["endpoints"].as_array().unwrap();
+        assert!(!endpoints.is_empty());
 
-        // burn_rate object should exist on every account
-        let acct = &accounts[0];
+        // burn_rate object should exist on every endpoint
+        let acct = &endpoints[0];
         assert!(
             acct["burn_rate"].is_object(),
             "burn_rate should be an object"
@@ -16781,16 +15580,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: mock_url.clone(),
-            accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint_at("a", "sk-ant-api-test-aaa", &mock_url)],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test-limit-reject.state.json"),
             proxy_key: Some("key".to_string()),
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -16809,7 +15605,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // Set utilization above client's limit (0.80 > 0.50)
@@ -16846,16 +15641,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: mock_url.clone(),
-            accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint_at("a", "sk-ant-api-test-aaa", &mock_url)],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test-limit-pass.state.json"),
             proxy_key: Some("key".to_string()),
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -16874,7 +15666,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // Set utilization below client's limit (0.50 < 0.90)
@@ -16905,19 +15696,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: mock_url.clone(),
-            accounts: vec![
-                make_account("a", "sk-ant-api-test-aaa"),
-                make_account("b", "sk-ant-api-test-bbb"),
+            endpoints: vec![
+                mk_endpoint_at("a", "sk-ant-api-test-aaa", &mock_url),
+                mk_endpoint_at("b", "sk-ant-api-test-bbb", &mock_url),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test-emergency-block.state.json"),
             proxy_key: Some("key".to_string()),
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -16936,7 +15724,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // All accounts above emergency threshold. 5h=0.96 > emergency threshold (0.88).
@@ -16975,19 +15762,16 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: mock_url.clone(),
-            accounts: vec![
-                make_account("a", "sk-ant-api-test-aaa"),
-                make_account("b", "sk-ant-api-test-bbb"),
+            endpoints: vec![
+                mk_endpoint_at("a", "sk-ant-api-test-aaa", &mock_url),
+                mk_endpoint_at("b", "sk-ant-api-test-bbb", &mock_url),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test-emergency-operator.state.json"),
             proxy_key: Some("key".to_string()),
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names,
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -17006,7 +15790,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         // All accounts above emergency threshold — 5h only (avoid claim penalty on 7d)
@@ -17045,16 +15828,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: mock_url.clone(),
-            accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint_at("a", "sk-ant-api-test-aaa", &mock_url)],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test-openai-limit.state.json"),
             proxy_key: Some("key".to_string()),
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -17073,7 +15853,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.80, 0.70, now + 10000, now + 100000).await;
@@ -17107,16 +15886,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: mock_url.clone(),
-            accounts: vec![make_account("a", "sk-ant-api-test-aaa")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint_at("a", "sk-ant-api-test-aaa", &mock_url)],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test-openai-emergency.state.json"),
             proxy_key: Some("key".to_string()),
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -17135,7 +15911,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         set_account_utilization(&state, 0, 0.96, 0.0, now + 10000, now + 100000).await;
@@ -17193,7 +15968,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             .unwrap();
         assert_eq!(stats.status(), reqwest::StatusCode::OK);
         let body: serde_json::Value = stats.json().await.unwrap();
-        assert!(body["accounts"].is_array());
+        assert!(body["endpoints"].is_array());
         assert!(body["aggregate"].is_object());
         assert_eq!(body["strategy"], "dynamic-capacity-v1");
     }
@@ -17202,7 +15977,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn resolve_client_id_prefers_header() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let ip: IpAddr = "192.168.1.100".parse().unwrap();
         let mut headers = hyper::HeaderMap::new();
         headers.insert("x-client-id", HeaderValue::from_static("header-client"));
@@ -17220,16 +15995,13 @@ data: {\"type\":\"message_stop\"}\n\n";
         client_names.insert("192.168.1.100".to_string(), "mapped-client".to_string());
         let state = Arc::new(AppState {
             client: Client::new(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names,
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -17248,7 +16020,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -17261,7 +16032,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn resolve_client_id_defaults_to_dash() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let ip: IpAddr = "203.0.113.1".parse().unwrap();
         let headers = hyper::HeaderMap::new();
 
@@ -17271,7 +16042,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn resolve_client_id_ignores_empty_header() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let ip: IpAddr = "192.168.1.100".parse().unwrap();
         let mut headers = hyper::HeaderMap::new();
         headers.insert("x-client-id", HeaderValue::from_static(""));
@@ -17282,7 +16053,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn resolve_client_id_ignores_dash_header() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let ip: IpAddr = "192.168.1.100".parse().unwrap();
         let mut headers = hyper::HeaderMap::new();
         headers.insert("x-client-id", HeaderValue::from_static("-"));
@@ -17295,8 +16066,6 @@ data: {\"type\":\"message_stop\"}\n\n";
     fn compute_pressure_status_operator_always_healthy() {
         let state = Arc::new(AppState {
             client: Client::new(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![],
             endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
@@ -17304,7 +16073,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -17323,7 +16091,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -17350,8 +16117,6 @@ data: {\"type\":\"message_stop\"}\n\n";
         limits.insert("client".to_string(), 0.80);
         let state = Arc::new(AppState {
             client: Client::new(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![],
             endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
@@ -17359,7 +16124,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -17378,7 +16142,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -17521,7 +16284,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn account_serves_model_empty_filter_allows_all() {
-        let acct = make_account("test", "sk-ant-api-x");
+        let acct = mk_endpoint("test", "sk-ant-api-x");
         assert!(acct.serves_model("claude-sonnet-4-6"));
         assert!(acct.serves_model("claude-opus-4-6"));
         assert!(acct.serves_model(""));
@@ -17529,7 +16292,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn account_serves_model_prefix_wildcard() {
-        let mut acct = make_account("test", "sk-ant-api-x");
+        let mut acct = mk_endpoint("test", "sk-ant-api-x");
         acct.models = vec!["claude-opus-*".to_string()];
 
         assert!(acct.serves_model("claude-opus-4-6"));
@@ -17539,7 +16302,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn account_serves_model_multiple_patterns() {
-        let mut acct = make_account("test", "sk-ant-api-x");
+        let mut acct = mk_endpoint("test", "sk-ant-api-x");
         acct.models = vec!["claude-opus-*".to_string(), "claude-sonnet-4-6".to_string()];
 
         assert!(acct.serves_model("claude-opus-4-6"));
@@ -17607,25 +16370,25 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_rejected_account_gets_no_traffic() {
         let state = test_state_with(vec![
-            make_account("rejected", "sk-ant-api-a"),
-            make_account("healthy", "sk-ant-api-b"),
+            mk_endpoint("rejected", "sk-ant-api-a"),
+            mk_endpoint("healthy", "sk-ant-api-b"),
         ]);
 
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.90);
             info.reset_5h = Some(now + 10000);
             info.status_5h = Some("rejected".to_string()); // Rejected = util floor 1.0
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.50);
         }
 
         // All requests should go to healthy account
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert_eq!(idx, 1, "rejected account should receive no traffic");
         }
     }
@@ -17650,12 +16413,12 @@ data: {\"type\":\"message_stop\"}\n\n";
         // When all accounts are throttled (status=throttled, floor=0.98 > soft_limit=0.90),
         // should use all accounts (graceful degradation)
         let state = test_state_with(vec![
-            make_account("a", "sk-ant-api-a"),
-            make_account("b", "sk-ant-api-b"),
+            mk_endpoint("a", "sk-ant-api-a"),
+            mk_endpoint("b", "sk-ant-api-b"),
         ]);
 
         let now = AppState::now_epoch();
-        for acct in &state.accounts {
+        for acct in &state.endpoints {
             let mut info = acct.rate_info.write().await;
             info.utilization_5h = Some(0.80);
             info.reset_5h = Some(now + 10000);
@@ -17665,7 +16428,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Both accounts should receive traffic
         let mut counts = [0u32; 2];
         for _ in 0..1000 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             counts[idx] += 1;
         }
 
@@ -17684,21 +16447,21 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_respects_priority_tiers() {
         // Tier 0 accounts with headroom should get ALL traffic — tier 1 gets nothing.
-        let mut primary = make_account("primary", "sk-ant-api-a");
+        let mut primary = mk_endpoint("primary", "sk-ant-api-a");
         primary.priority = 0;
-        let mut fallback = make_account("fallback", "sk-ant-api-b");
+        let mut fallback = mk_endpoint("fallback", "sk-ant-api-b");
         fallback.priority = 1;
         let state = test_state_with(vec![primary, fallback]);
 
         let now = AppState::now_epoch();
-        for acct in &state.accounts {
+        for acct in &state.endpoints {
             let mut info = acct.rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
         }
 
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert_eq!(idx, 0, "all traffic should go to tier 0 when healthy");
         }
     }
@@ -17706,27 +16469,27 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_falls_through_to_lower_priority() {
         // Tier 0 hard-limited → tier 1 should receive traffic.
-        let mut primary = make_account("primary", "sk-ant-api-a");
+        let mut primary = mk_endpoint("primary", "sk-ant-api-a");
         primary.priority = 0;
-        let mut fallback = make_account("fallback", "sk-ant-api-b");
+        let mut fallback = mk_endpoint("fallback", "sk-ant-api-b");
         fallback.priority = 1;
         let state = test_state_with(vec![primary, fallback]);
 
         // Hard-limit tier 0
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
 
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
         }
 
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert_eq!(
                 idx, 1,
                 "tier 1 should get traffic when tier 0 is hard-limited"
@@ -17737,14 +16500,14 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_priority_default_zero() {
         // Accounts without explicit priority should behave as tier 0.
-        let a = make_account("a", "sk-ant-api-a");
-        let b = make_account("b", "sk-ant-api-b");
+        let a = mk_endpoint("a", "sk-ant-api-a");
+        let b = mk_endpoint("b", "sk-ant-api-b");
         assert_eq!(a.priority, 0);
         assert_eq!(b.priority, 0);
 
         let state = test_state_with(vec![a, b]);
         let now = AppState::now_epoch();
-        for acct in &state.accounts {
+        for acct in &state.endpoints {
             let mut info = acct.rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
@@ -17753,7 +16516,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Both should receive traffic (same tier)
         let mut counts = [0u32; 2];
         for _ in 0..1000 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             counts[idx] += 1;
         }
         assert!(counts[0] > 0, "account a should get traffic");
@@ -17765,30 +16528,30 @@ data: {\"type\":\"message_stop\"}\n\n";
         // Tier 0 accounts above soft_limit but still alive (weight > 0) → tier 0 is
         // degraded-used, NOT skipped. soft_limit is intra-tier load-shedding; it must
         // never cause a jump to a lower-priority (paid) tier while free capacity remains.
-        let mut primary_a = make_account("primary_a", "sk-ant-api-a");
+        let mut primary_a = mk_endpoint("primary_a", "sk-ant-api-a");
         primary_a.priority = 0;
-        let mut primary_b = make_account("primary_b", "sk-ant-api-b");
+        let mut primary_b = mk_endpoint("primary_b", "sk-ant-api-b");
         primary_b.priority = 0;
-        let mut fallback = make_account("fallback", "sk-ant-api-c");
+        let mut fallback = mk_endpoint("fallback", "sk-ant-api-c");
         fallback.priority = 1;
         let state = test_state_with_soft_limit(vec![primary_a, primary_b, fallback], 0.90);
 
         let now = AppState::now_epoch();
         // Tier 0: above soft limit (0.95) but still has headroom — weight > 0.
         for i in 0..2 {
-            let mut info = state.accounts[i].rate_info.write().await;
+            let mut info = state.endpoints[i].rate_info.write().await;
             info.utilization_5h = Some(0.95);
             info.reset_5h = Some(now + 10000);
         }
         // Tier 1: healthy.
         {
-            let mut info = state.accounts[2].rate_info.write().await;
+            let mut info = state.endpoints[2].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
         }
 
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert!(
                 idx == 0 || idx == 1,
                 "tier 0 must be drained (degraded) before tier 1 is touched"
@@ -17800,30 +16563,30 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn pick_account_priority_zero_weight_tier_falls_through() {
         // Tier 0 accounts at zero weight (util 1.0 → gate 1.0) → genuinely exhausted →
         // routing falls through to tier 1.
-        let mut primary_a = make_account("primary_a", "sk-ant-api-a");
+        let mut primary_a = mk_endpoint("primary_a", "sk-ant-api-a");
         primary_a.priority = 0;
-        let mut primary_b = make_account("primary_b", "sk-ant-api-b");
+        let mut primary_b = mk_endpoint("primary_b", "sk-ant-api-b");
         primary_b.priority = 0;
-        let mut fallback = make_account("fallback", "sk-ant-api-c");
+        let mut fallback = mk_endpoint("fallback", "sk-ant-api-c");
         fallback.priority = 1;
         let state = test_state_with_soft_limit(vec![primary_a, primary_b, fallback], 0.90);
 
         let now = AppState::now_epoch();
         // Tier 0: fully exhausted — util 1.0 → gate 1.0 → weight 0.
         for i in 0..2 {
-            let mut info = state.accounts[i].rate_info.write().await;
+            let mut info = state.endpoints[i].rate_info.write().await;
             info.utilization_5h = Some(1.0);
             info.reset_5h = Some(now + 10000);
         }
         // Tier 1: healthy.
         {
-            let mut info = state.accounts[2].rate_info.write().await;
+            let mut info = state.endpoints[2].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
         }
 
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert_eq!(idx, 2, "tier 1 used once tier 0 is genuinely zero-weight");
         }
     }
@@ -17831,29 +16594,29 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_multiple_tiers_cascade() {
         // Three tiers: 0, 1, 2. Tier 0 and 1 exhausted → tier 2 gets traffic.
-        let mut t0 = make_account("t0", "sk-ant-api-a");
+        let mut t0 = mk_endpoint("t0", "sk-ant-api-a");
         t0.priority = 0;
-        let mut t1 = make_account("t1", "sk-ant-api-b");
+        let mut t1 = mk_endpoint("t1", "sk-ant-api-b");
         t1.priority = 1;
-        let mut t2 = make_account("t2", "sk-ant-api-c");
+        let mut t2 = mk_endpoint("t2", "sk-ant-api-c");
         t2.priority = 2;
         let state = test_state_with(vec![t0, t1, t2]);
 
         // Hard-limit tiers 0 and 1
         for i in 0..2 {
-            let mut info = state.accounts[i].rate_info.write().await;
+            let mut info = state.endpoints[i].rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
 
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[2].rate_info.write().await;
+            let mut info = state.endpoints[2].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
         }
 
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert_eq!(
                 idx, 2,
                 "tier 2 should get traffic when tiers 0 and 1 are exhausted"
@@ -17864,25 +16627,25 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_all_tiers_exhausted_returns_none() {
         // All tiers hard-limited → None.
-        let mut t0 = make_account("t0", "sk-ant-api-a");
+        let mut t0 = mk_endpoint("t0", "sk-ant-api-a");
         t0.priority = 0;
-        let mut t1 = make_account("t1", "sk-ant-api-b");
+        let mut t1 = mk_endpoint("t1", "sk-ant-api-b");
         t1.priority = 1;
         let state = test_state_with(vec![t0, t1]);
 
-        for acct in &state.accounts {
+        for acct in &state.endpoints {
             let mut info = acct.rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
 
-        assert!(state.pick_account(None, "", &[]).await.is_none());
+        assert!(state.pick_endpoint(None, "", &[]).await.is_none());
     }
 
     // ── Overage tests ────────────────────────────────────────────────
 
     #[tokio::test]
     async fn update_rate_info_parses_overage_headers() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-a")]);
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             "anthropic-ratelimit-unified-overage-in-use",
@@ -17903,7 +16666,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         );
         state.update_rate_info(0, &headers).await;
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert!(info.overage_in_use);
         assert_eq!(info.overage_status.as_deref(), Some("allowed"));
         assert_eq!(info.overage_utilization, Some(0.25));
@@ -17914,9 +16677,9 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn update_rate_info_overage_absent_resets_to_false() {
         // Corner 1: an account previously in overage whose next response omits the
         // overage-in-use header must drop back to overage_in_use=false.
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-a")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-a")]);
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.overage_in_use = true;
             info.overage_status = Some("allowed".to_string());
             info.overage_utilization = Some(0.5);
@@ -17925,7 +16688,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         let headers = reqwest::header::HeaderMap::new();
         state.update_rate_info(0, &headers).await;
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert!(!info.overage_in_use, "overage_in_use must reset to false");
         assert_eq!(info.overage_status, None);
         assert_eq!(info.overage_utilization, None);
@@ -17982,18 +16745,18 @@ data: {\"type\":\"message_stop\"}\n\n";
     async fn pick_account_overage_demoted_below_free() {
         // Free account (eff. priority 0) must drain before an overage account
         // (eff. priority 0 + overage_penalty 10) receives any traffic.
-        let free = make_account("free", "sk-ant-api-a");
-        let overage = make_account("overage", "sk-ant-api-b");
+        let free = mk_endpoint("free", "sk-ant-api-a");
+        let overage = mk_endpoint("overage", "sk-ant-api-b");
         let state = test_state_with(vec![free, overage]);
 
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(1.0);
             info.reset_5h = Some(now + 3000);
             info.status_5h = Some("rejected".to_string());
@@ -18004,7 +16767,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         }
 
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert_eq!(idx, 0, "free account preferred over overage account");
         }
     }
@@ -18012,18 +16775,18 @@ data: {\"type\":\"message_stop\"}\n\n";
     #[tokio::test]
     async fn pick_account_overage_used_when_free_exhausted() {
         // Free account at zero weight → the overage account (demoted) is used.
-        let free = make_account("free", "sk-ant-api-a");
-        let overage = make_account("overage", "sk-ant-api-b");
+        let free = mk_endpoint("free", "sk-ant-api-a");
+        let overage = mk_endpoint("overage", "sk-ant-api-b");
         let state = test_state_with(vec![free, overage]);
 
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(1.0); // zero weight
             info.reset_5h = Some(now + 10000);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(1.0);
             info.reset_5h = Some(now + 3000);
             info.status_5h = Some("rejected".to_string());
@@ -18034,19 +16797,22 @@ data: {\"type\":\"message_stop\"}\n\n";
         }
 
         for _ in 0..100 {
-            let idx = state.pick_account(None, "", &[]).await.unwrap();
+            let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
             assert_eq!(idx, 1, "overage account used once free tier is exhausted");
         }
     }
 
     #[tokio::test]
-    async fn pick_endpoint_upstream_is_last_resort() {
-        // The fallback upstream (priority 100) is a unified routing candidate: a
-        // healthy account beats it; it is selected only once accounts are exhausted.
-        let state = test_state_with_fallback(vec![make_account("a", "sk-ant-api-a")], 100);
+    async fn pick_endpoint_openai_is_last_resort() {
+        // A priority-100 OpenAI endpoint is a routing candidate: a healthy
+        // Anthropic endpoint beats it; it is selected only once the lower
+        // tier is exhausted.
+        let mut openai = make_endpoint("fallback", Protocol::OpenAI);
+        openai.priority = 100;
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-a"), openai]);
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now + 10000);
         }
@@ -18054,20 +16820,21 @@ data: {\"type\":\"message_stop\"}\n\n";
         for _ in 0..50 {
             assert_eq!(
                 state.pick_endpoint(None, "", &[]).await,
-                Some(EndpointIdx::Account(0)),
-                "healthy account beats the priority-100 upstream"
+                Some(0),
+                "healthy endpoint beats the priority-100 openai endpoint"
             );
         }
 
-        // Hard-limit the account → the upstream is the only remaining candidate.
+        // Hard-limit the Anthropic endpoint → the openai endpoint is the only
+        // remaining candidate.
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
         assert_eq!(
             state.pick_endpoint(None, "", &[]).await,
-            Some(EndpointIdx::Upstream(0)),
-            "upstream selected once the account tier is exhausted"
+            Some(1),
+            "openai endpoint selected once the lower tier is exhausted"
         );
     }
 
@@ -18075,8 +16842,6 @@ data: {\"type\":\"message_stop\"}\n\n";
     fn is_operator_checks_configured_operator() {
         let state = Arc::new(AppState {
             client: Client::new(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![],
             endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
@@ -18084,7 +16849,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -18103,7 +16867,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -18121,8 +16884,6 @@ data: {\"type\":\"message_stop\"}\n\n";
     fn is_operator_supports_multiple_operators() {
         let state = Arc::new(AppState {
             client: Client::new(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![],
             endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
@@ -18130,7 +16891,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             state_path: PathBuf::from("/tmp/test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -18153,7 +16913,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
         assert!(state.is_operator("ray"));
@@ -18167,13 +16926,13 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn cluster_info_returns_none_without_redis() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         assert!(state.cluster_info().await.is_none());
     }
 
     #[tokio::test]
     async fn sync_from_redis_noop_without_redis() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         // Should not panic or error when redis is None
         state.sync_from_redis().await;
         // Cluster cache should remain None
@@ -18207,16 +16966,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -18235,7 +16991,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -18328,18 +17083,18 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn hard_limit_unchanged_by_sync_without_redis() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
 
         // Set a local hard limit
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(30));
         }
 
         // sync_from_redis should not touch it when redis is None
         state.sync_from_redis().await;
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert!(info.hard_limited_until.is_some());
     }
 
@@ -18352,16 +17107,13 @@ data: {\"type\":\"message_stop\"}\n\n";
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -18380,7 +17132,6 @@ data: {\"type\":\"message_stop\"}\n\n";
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -18392,7 +17143,7 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[tokio::test]
     async fn record_budget_usage_skips_unknown_client() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         // No budgets configured — recording should be a no-op
         state.record_budget_usage("unknown-client", 500).await;
         let map = state.budget_usage.lock().unwrap();
@@ -18405,17 +17156,15 @@ data: {\"type\":\"message_stop\"}\n\n";
     fn config_deser_minimal() {
         let toml = r#"
 listen = "127.0.0.1:8082"
-upstream = "https://api.anthropic.com"
 
-[[accounts]]
+[[endpoints]]
 name = "primary"
 token = "sk-ant-api-test"
 "#;
         let cfg: Config = toml::from_str(toml).expect("minimal config should deserialize");
         assert_eq!(cfg.listen, "127.0.0.1:8082");
-        assert_eq!(cfg.upstream, "https://api.anthropic.com");
-        assert_eq!(cfg.accounts.len(), 1);
-        assert_eq!(cfg.accounts[0].name, "primary");
+        assert_eq!(cfg.endpoints.len(), 1);
+        assert_eq!(cfg.endpoints[0].name, "primary");
         // Optional fields absent
         assert!(cfg.proxy_key.is_none());
         assert!(cfg.redis_url.is_none());
@@ -18425,14 +17174,12 @@ token = "sk-ant-api-test"
         assert!(cfg.client_budgets.is_empty());
         assert!(cfg.client_utilization_limits.is_empty());
         assert!(cfg.client_names.is_empty());
-        assert!(cfg.upstreams.is_empty());
     }
 
     #[test]
     fn config_deser_all_optional_fields() {
         let toml = r#"
 listen = "0.0.0.0:8082"
-upstream = "https://api.anthropic.com"
 strategy = "dynamic-capacity"
 rate_limit_cooldown_secs = 120
 probe_interval_secs = 600
@@ -18457,19 +17204,21 @@ bob = 500000
 alice = 0.95
 bob = 0.80
 
-[[accounts]]
+[[endpoints]]
 name = "acct-a"
 token = "sk-ant-oat01-token1"
 
-[[accounts]]
+[[endpoints]]
 name = "acct-b"
 token = "sk-ant-api-token2"
 models = ["claude-opus-*", "claude-sonnet-4-6"]
 
-[[upstreams]]
+[[endpoints]]
 name = "openai"
+protocol = "openai"
 base_url = "https://api.openai.com"
-api_key = "sk-openai-key"
+token = "sk-openai-key"
+priority = 100
 "#;
         let cfg: Config = toml::from_str(toml).expect("full config should deserialize");
         assert_eq!(cfg.proxy_key.as_deref(), Some("secret"));
@@ -18486,13 +17235,12 @@ api_key = "sk-openai-key"
         assert_eq!(cfg.client_names.get("10.0.0.1").unwrap(), "alice");
         assert_eq!(*cfg.client_budgets.get("alice").unwrap(), 1000000u64);
         assert_eq!(*cfg.client_utilization_limits.get("alice").unwrap(), 0.95);
-        // Accounts
-        assert_eq!(cfg.accounts.len(), 2);
-        assert_eq!(cfg.accounts[1].models.len(), 2);
-        assert_eq!(cfg.accounts[1].models[0], "claude-opus-*");
-        // Upstreams
-        assert_eq!(cfg.upstreams.len(), 1);
-        assert_eq!(cfg.upstreams[0].name, "openai");
+        // Endpoints
+        assert_eq!(cfg.endpoints.len(), 3);
+        assert_eq!(cfg.endpoints[1].models.len(), 2);
+        assert_eq!(cfg.endpoints[1].models[0], "claude-opus-*");
+        assert_eq!(cfg.endpoints[2].protocol, Protocol::OpenAI);
+        assert_eq!(cfg.endpoints[2].priority, 100);
     }
 
     #[test]
@@ -18522,44 +17270,40 @@ api_key = "sk-openai-key"
 
     #[test]
     fn config_deser_missing_required_field_fails() {
-        // Missing `upstream`
+        // Missing `listen` (the sole required top-level key).
         let toml = r#"
-listen = "127.0.0.1:8082"
-
-[[accounts]]
+[[endpoints]]
 name = "test"
 token = "sk-ant-api-test"
 "#;
         let result = toml::from_str::<Config>(toml);
         assert!(
             result.is_err(),
-            "missing upstream should fail deserialization"
+            "missing listen should fail deserialization"
         );
     }
 
     #[test]
-    fn config_deser_missing_accounts_fails() {
+    fn config_deser_endpoints_default_empty() {
+        // `endpoints` defaults to an empty vec at the deserialization layer;
+        // the non-empty requirement is enforced in `main()`, not by serde.
         let toml = r#"
 listen = "127.0.0.1:8082"
-upstream = "https://api.anthropic.com"
 "#;
-        let result = toml::from_str::<Config>(toml);
-        assert!(
-            result.is_err(),
-            "missing accounts should fail deserialization"
-        );
+        let cfg: Config = toml::from_str(toml).expect("config without endpoints deserializes");
+        assert!(cfg.endpoints.is_empty());
     }
 
     // ── Rate info merge: "most recent wins" ─────────────────────
 
     #[tokio::test]
     async fn rate_info_merge_remote_newer_wins() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let now_epoch = AppState::now_epoch();
 
         // Set local rate info with an older timestamp
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.last_updated_epoch = Some(now_epoch - 60); // 60s ago
         }
@@ -18588,7 +17332,7 @@ upstream = "https://api.anthropic.com"
 
         // Apply same merge logic as sync_from_redis
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             let local_age = info
                 .last_updated_epoch
                 .map(|epoch| now_epoch.saturating_sub(epoch))
@@ -18605,19 +17349,19 @@ upstream = "https://api.anthropic.com"
             info.last_updated_epoch = Some(remote.updated_at);
         }
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert_eq!(info.utilization_5h, Some(0.75));
         assert_eq!(info.last_updated_epoch, Some(now_epoch - 10));
     }
 
     #[tokio::test]
     async fn rate_info_merge_local_newer_preserved() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let now_epoch = AppState::now_epoch();
 
         // Set local rate info with a recent timestamp (5s ago)
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.30);
             info.last_updated_epoch = Some(now_epoch - 5);
         }
@@ -18646,7 +17390,7 @@ upstream = "https://api.anthropic.com"
 
         // Apply same merge logic as sync_from_redis
         {
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             let local_age = info
                 .last_updated_epoch
                 .map(|epoch| now_epoch.saturating_sub(epoch))
@@ -18661,7 +17405,7 @@ upstream = "https://api.anthropic.com"
             // Local wins — do NOT apply remote
         }
 
-        let info = state.accounts[0].rate_info.read().await;
+        let info = state.endpoints[0].rate_info.read().await;
         assert_eq!(
             info.utilization_5h,
             Some(0.30),
@@ -18671,12 +17415,12 @@ upstream = "https://api.anthropic.com"
 
     #[tokio::test]
     async fn rate_info_merge_no_local_epoch_remote_wins() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let now_epoch = AppState::now_epoch();
 
         // Local has no last_updated_epoch (fresh state)
         {
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             assert!(info.last_updated_epoch.is_none());
         }
 
@@ -18703,7 +17447,7 @@ upstream = "https://api.anthropic.com"
 
         // When local has no epoch, local_age = u64::MAX, so remote always wins
         {
-            let info = state.accounts[0].rate_info.read().await;
+            let info = state.endpoints[0].rate_info.read().await;
             let local_age = info
                 .last_updated_epoch
                 .map(|epoch| now_epoch.saturating_sub(epoch))
@@ -18728,19 +17472,16 @@ upstream = "https://api.anthropic.com"
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("primary", "sk-ant-api-aaa"),
-                make_account("secondary", "sk-ant-api-bbb"),
+            endpoints: vec![
+                mk_endpoint("primary", "sk-ant-api-aaa"),
+                mk_endpoint("secondary", "sk-ant-api-bbb"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: state_path.clone(),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -18759,16 +17500,15 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
         // Set up some state to persist
         let now_epoch = AppState::now_epoch();
-        state.accounts[0].requests.store(42, Ordering::Relaxed);
-        state.accounts[1].requests.store(17, Ordering::Relaxed);
+        state.endpoints[0].requests.store(42, Ordering::Relaxed);
+        state.endpoints[1].requests.store(17, Ordering::Relaxed);
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.65);
             info.utilization_5h = Some(0.50);
             info.utilization_7d = Some(0.70);
@@ -18793,7 +17533,7 @@ upstream = "https://api.anthropic.com"
             );
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.20);
             info.reset_5h = Some(now_epoch + 18000);
             // hard-limit 60s from now
@@ -18817,19 +17557,16 @@ upstream = "https://api.anthropic.com"
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![
-                make_account("primary", "sk-ant-api-aaa"),
-                make_account("secondary", "sk-ant-api-bbb"),
+            endpoints: vec![
+                mk_endpoint("primary", "sk-ant-api-aaa"),
+                mk_endpoint("secondary", "sk-ant-api-bbb"),
             ],
-            endpoints: vec![],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path,
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -18848,7 +17585,6 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -18857,14 +17593,14 @@ upstream = "https://api.anthropic.com"
 
         // Verify fields survived the round-trip
         assert_eq!(
-            state2.accounts[0].requests.load(Ordering::Relaxed),
+            state2.endpoints[0].requests.load(Ordering::Relaxed),
             42,
             "request count should persist"
         );
-        assert_eq!(state2.accounts[1].requests.load(Ordering::Relaxed), 17);
+        assert_eq!(state2.endpoints[1].requests.load(Ordering::Relaxed), 17);
 
         {
-            let info = state2.accounts[0].rate_info.read().await;
+            let info = state2.endpoints[0].rate_info.read().await;
             // Unified is recomputed as max(utilization_5h, utilization_7d)
             assert_eq!(info.utilization, Some(0.70));
             assert_eq!(info.utilization_5h, Some(0.50));
@@ -18888,7 +17624,7 @@ upstream = "https://api.anthropic.com"
         }
 
         {
-            let info = state2.accounts[1].rate_info.read().await;
+            let info = state2.endpoints[1].rate_info.read().await;
             assert_eq!(info.utilization_5h, Some(0.20));
             // Hard limit should have been restored (future epoch)
             assert!(
@@ -18909,11 +17645,11 @@ upstream = "https://api.anthropic.com"
             r#"{"accounts":[{"name":"primary","requests_total":42}],"saved_at":0}"#,
         )
         .unwrap();
-        let mut state = test_state_with(vec![make_account("primary", "sk-ant")]);
+        let mut state = test_state_with(vec![mk_endpoint("primary", "sk-ant")]);
         Arc::get_mut(&mut state).unwrap().state_path = tmp.path().to_path_buf();
         state.load_state().await; // must not panic
         assert_eq!(
-            state.accounts[0].requests.load(Ordering::Relaxed),
+            state.endpoints[0].requests.load(Ordering::Relaxed),
             0,
             "legacy accounts-keyed state file must not load into the new schema"
         );
@@ -18967,16 +17703,13 @@ upstream = "https://api.anthropic.com"
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -18995,7 +17728,6 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -19025,16 +17757,13 @@ upstream = "https://api.anthropic.com"
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("a", "sk-ant-api-x")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -19053,7 +17782,6 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -19117,7 +17845,7 @@ upstream = "https://api.anthropic.com"
 
     #[test]
     fn routing_metrics_present() {
-        let acct = make_account("acct-a", "sk-ant-api-a");
+        let acct = mk_endpoint("acct-a", "sk-ant-api-a");
         acct.last_routing_weight
             .store(0.4f64.to_bits(), Ordering::Relaxed);
         acct.last_routing_share
@@ -19150,7 +17878,7 @@ upstream = "https://api.anthropic.com"
     }
     #[test]
     fn routing_metrics_zero_weight_for_rejected_claim() {
-        let acct = make_account("acct-a", "sk-ant-api-a");
+        let acct = mk_endpoint("acct-a", "sk-ant-api-a");
         acct.last_routing_weight
             .store(0.0f64.to_bits(), Ordering::Relaxed);
         acct.last_routing_share
@@ -19184,20 +17912,20 @@ upstream = "https://api.anthropic.com"
     #[tokio::test]
     async fn passthrough_accounts_participate_in_routing_candidates_and_metrics() {
         let mut state = test_state_with(vec![
-            make_account("passthrough", "passthrough"),
-            make_account("api", "sk-ant-api-b"),
+            mk_endpoint("passthrough", "passthrough"),
+            mk_endpoint("api", "sk-ant-api-b"),
         ]);
         Arc::get_mut(&mut state).unwrap().soft_limit = 1.0;
 
         let now_epoch = AppState::now_epoch();
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.20);
             info.utilization_5h = Some(0.20);
             info.reset_5h = Some(now_epoch + 10000);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.40);
             info.utilization_5h = Some(0.40);
             info.reset_5h = Some(now_epoch + 10000);
@@ -19214,7 +17942,7 @@ upstream = "https://api.anthropic.com"
         let mut buf = String::new();
         append_routing_weight_metrics(
             &mut buf,
-            &state.accounts,
+            &state.endpoints,
             &[
                 EndpointMetricsSnap {
                     name: "passthrough".to_string(),
@@ -19255,7 +17983,7 @@ upstream = "https://api.anthropic.com"
 
         // Set some state so metrics are interesting
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.42);
             info.utilization_7d = Some(0.35);
             info.remaining_requests = Some(1000);
@@ -19265,22 +17993,22 @@ upstream = "https://api.anthropic.com"
         }
         // Set burn rate values (R2.2)
         {
-            let mut br = state.accounts[0].burn_rate.lock().unwrap();
+            let mut br = state.endpoints[0].burn_rate.lock().unwrap();
             br.rate_5m.value = 2.5;
             br.rate_1h.value = 1.8;
             br.rate_6h.value = 0.9;
         }
-        state.accounts[0].requests.store(123, Ordering::Relaxed);
-        state.accounts[0]
+        state.endpoints[0].requests.store(123, Ordering::Relaxed);
+        state.endpoints[0]
             .input_tokens
             .store(90000, Ordering::Relaxed);
-        state.accounts[0]
+        state.endpoints[0]
             .output_tokens
             .store(30000, Ordering::Relaxed);
-        state.accounts[0]
+        state.endpoints[0]
             .cache_creation_tokens
             .store(5000, Ordering::Relaxed);
-        state.accounts[0]
+        state.endpoints[0]
             .cache_read_tokens
             .store(15000, Ordering::Relaxed);
 
@@ -19408,12 +18136,6 @@ upstream = "https://api.anthropic.com"
             body.contains("# TYPE anthropic_account_utilization gauge"),
             "missing TYPE header:\n{body}"
         );
-
-        // Upstream metrics
-        assert!(
-            body.contains("anthropic_upstream_requests_total{upstream=\"mock\""),
-            "missing upstream:\n{body}"
-        );
     }
 
     #[tokio::test]
@@ -19490,22 +18212,19 @@ upstream = "https://api.anthropic.com"
     #[tokio::test]
     async fn metrics_operator_hiding() {
         let (mock_url, _handle) = spawn_mock_upstream().await;
-        let accounts = vec![make_account("acct-a", "sk-ant-api-test-aaa")];
+        let accounts = vec![mk_endpoint_at("acct-a", "sk-ant-api-test-aaa", &mock_url)];
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: mock_url.clone(),
-            accounts,
-            endpoints: vec![],
+            endpoints: accounts,
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -19524,7 +18243,6 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -19624,14 +18342,14 @@ upstream = "https://api.anthropic.com"
 
         // Set some state so all metric families are populated
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.5);
             info.remaining_requests = Some(100);
             info.remaining_tokens = Some(50000);
             info.limit_requests = Some(1000);
             info.limit_tokens = Some(100000);
         }
-        state.accounts[0].requests.store(10, Ordering::Relaxed);
+        state.endpoints[0].requests.store(10, Ordering::Relaxed);
 
         let addr = serve(app).await;
         let client = Client::new();
@@ -19693,13 +18411,13 @@ upstream = "https://api.anthropic.com"
 
         // acct-a: eff_util >= 0.5 and br_1h >= 0.01 → projected_throttle IS emitted
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.7);
             info.remaining_requests = Some(500);
             info.limit_requests = Some(2000);
         }
         {
-            let mut br = state.accounts[0].burn_rate.lock().unwrap();
+            let mut br = state.endpoints[0].burn_rate.lock().unwrap();
             br.rate_1h.value = 2.0;
         }
 
@@ -19728,7 +18446,7 @@ upstream = "https://api.anthropic.com"
 
     #[tokio::test]
     async fn metrics_client_budgets_and_rpm() {
-        let accounts = vec![make_account("acct-a", "sk-ant-api-test-aaa")];
+        let accounts = vec![mk_endpoint("acct-a", "sk-ant-api-test-aaa")];
         let today = AppState::now_epoch() / 86400;
 
         let mut client_budgets = HashMap::new();
@@ -19747,16 +18465,13 @@ upstream = "https://api.anthropic.com"
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts,
-            endpoints: vec![],
+            endpoints: accounts,
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: true,
             client_usage: Mutex::new(HashMap::new()),
@@ -19775,7 +18490,6 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -19817,11 +18531,11 @@ upstream = "https://api.anthropic.com"
 
         // Set headroom on both accounts
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.remaining_requests = Some(1000);
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.remaining_requests = Some(500);
         }
 
@@ -19873,7 +18587,7 @@ upstream = "https://api.anthropic.com"
         let reset_epoch = now_epoch + 302400; // 3.5 * 86400
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.claims_7d.insert(
                 "claude-sonnet".to_string(),
                 ClaimWindowData {
@@ -19931,7 +18645,7 @@ upstream = "https://api.anthropic.com"
         let reset_7d = now_epoch + 302400; // 3.5 days
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.reset_5h = Some(reset_5h);
             info.reset_7d = Some(reset_7d);
             info.claims_7d.insert(
@@ -20025,7 +18739,7 @@ upstream = "https://api.anthropic.com"
         let data_age_secs = 120u64;
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.60);
             info.reset_5h = Some(now_epoch + 7200);
             info.status_5h = Some("allowed_warning".to_string());
@@ -20124,16 +18838,16 @@ upstream = "https://api.anthropic.com"
     /// for rejected accounts and accounts above soft_limit.
     #[tokio::test]
     async fn refresh_metrics_weights_persists_atomics() {
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_b = make_account("b", "sk-ant-api-b");
-        let acct_c = make_account("c", "sk-ant-api-c");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_b = mk_endpoint("b", "sk-ant-api-b");
+        let acct_c = mk_endpoint("c", "sk-ant-api-c");
         let state = test_state_with(vec![acct_a, acct_b, acct_c]);
 
         let now = AppState::now_epoch();
 
         // a: 5h=0.20 (healthy), b: 5h=0.30 (healthy)
         for (i, util) in [(0, 0.20), (1, 0.30)].iter() {
-            let mut info = state.accounts[*i].rate_info.write().await;
+            let mut info = state.endpoints[*i].rate_info.write().await;
             info.utilization_5h = Some(*util);
             info.reset_5h = Some(now + 10000);
             info.utilization = Some(*util);
@@ -20141,7 +18855,7 @@ upstream = "https://api.anthropic.com"
         }
         // c: status=rejected → status_to_floor → gate=1.0 → weight=0
         {
-            let mut info = state.accounts[2].rate_info.write().await;
+            let mut info = state.endpoints[2].rate_info.write().await;
             info.utilization_5h = Some(0.10);
             info.reset_5h = Some(now + 10000);
             info.utilization = Some(0.10);
@@ -20153,13 +18867,18 @@ upstream = "https://api.anthropic.com"
 
         let read_weight = |i: usize| {
             f64::from_bits(
-                state.accounts[i]
+                state.endpoints[i]
                     .last_routing_weight
                     .load(Ordering::Relaxed),
             )
         };
-        let read_share =
-            |i: usize| f64::from_bits(state.accounts[i].last_routing_share.load(Ordering::Relaxed));
+        let read_share = |i: usize| {
+            f64::from_bits(
+                state.endpoints[i]
+                    .last_routing_share
+                    .load(Ordering::Relaxed),
+            )
+        };
 
         // a and b are healthy: positive weight + positive share
         assert!(read_weight(0) > 0.0, "a should have non-zero weight");
@@ -20244,13 +18963,13 @@ upstream = "https://api.anthropic.com"
         {
             let state = test_state_with_soft_limit(
                 vec![
-                    make_account("a", "sk-ant-api-a"),
-                    make_account("b", "sk-ant-api-b"),
+                    mk_endpoint("a", "sk-ant-api-a"),
+                    mk_endpoint("b", "sk-ant-api-b"),
                 ],
                 0.90,
             );
             for (i, util) in [(0, 0.20), (1, 0.95)].iter() {
-                let mut info = state.accounts[*i].rate_info.write().await;
+                let mut info = state.endpoints[*i].rate_info.write().await;
                 info.utilization_5h = Some(*util);
                 info.reset_5h = Some(now + 10000);
                 info.utilization = Some(*util);
@@ -20260,17 +18979,25 @@ upstream = "https://api.anthropic.com"
             state.refresh_metrics_weights().await;
 
             let w_a = f64::from_bits(
-                state.accounts[0]
+                state.endpoints[0]
                     .last_routing_weight
                     .load(Ordering::Relaxed),
             );
             let w_b = f64::from_bits(
-                state.accounts[1]
+                state.endpoints[1]
                     .last_routing_weight
                     .load(Ordering::Relaxed),
             );
-            let s_a = f64::from_bits(state.accounts[0].last_routing_share.load(Ordering::Relaxed));
-            let s_b = f64::from_bits(state.accounts[1].last_routing_share.load(Ordering::Relaxed));
+            let s_a = f64::from_bits(
+                state.endpoints[0]
+                    .last_routing_share
+                    .load(Ordering::Relaxed),
+            );
+            let s_b = f64::from_bits(
+                state.endpoints[1]
+                    .last_routing_share
+                    .load(Ordering::Relaxed),
+            );
 
             assert!(w_a > 0.0, "healthy a should have non-zero weight");
             assert_eq!(
@@ -20291,13 +19018,13 @@ upstream = "https://api.anthropic.com"
         {
             let state = test_state_with_soft_limit(
                 vec![
-                    make_account("a", "sk-ant-api-a"),
-                    make_account("b", "sk-ant-api-b"),
+                    mk_endpoint("a", "sk-ant-api-a"),
+                    mk_endpoint("b", "sk-ant-api-b"),
                 ],
                 0.90,
             );
             for (i, util) in [(0, 0.95), (1, 0.92)].iter() {
-                let mut info = state.accounts[*i].rate_info.write().await;
+                let mut info = state.endpoints[*i].rate_info.write().await;
                 info.utilization_5h = Some(*util);
                 info.reset_5h = Some(now + 10000);
                 info.utilization = Some(*util);
@@ -20307,17 +19034,25 @@ upstream = "https://api.anthropic.com"
             state.refresh_metrics_weights().await;
 
             let w_a = f64::from_bits(
-                state.accounts[0]
+                state.endpoints[0]
                     .last_routing_weight
                     .load(Ordering::Relaxed),
             );
             let w_b = f64::from_bits(
-                state.accounts[1]
+                state.endpoints[1]
                     .last_routing_weight
                     .load(Ordering::Relaxed),
             );
-            let s_a = f64::from_bits(state.accounts[0].last_routing_share.load(Ordering::Relaxed));
-            let s_b = f64::from_bits(state.accounts[1].last_routing_share.load(Ordering::Relaxed));
+            let s_a = f64::from_bits(
+                state.endpoints[0]
+                    .last_routing_share
+                    .load(Ordering::Relaxed),
+            );
+            let s_b = f64::from_bits(
+                state.endpoints[1]
+                    .last_routing_share
+                    .load(Ordering::Relaxed),
+            );
 
             assert!(
                 w_a > 0.0,
@@ -20347,7 +19082,7 @@ upstream = "https://api.anthropic.com"
         let now_epoch = AppState::now_epoch();
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.20);
             info.utilization_5h = Some(0.20);
             info.reset_5h = Some(now_epoch + NEAR_RESET_5H_SECS as u64 + 600);
@@ -20366,7 +19101,7 @@ upstream = "https://api.anthropic.com"
             info.status_7d = Some("allowed".to_string());
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(1.0);
             info.utilization_5h = Some(1.0);
             info.reset_5h = Some(now_epoch + NEAR_RESET_5H_SECS as u64 + 600);
@@ -20412,14 +19147,14 @@ upstream = "https://api.anthropic.com"
         // Default test_app builds 2 non-passthrough accounts: acct-a, acct-b.
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.25);
             info.reset_5h = Some(now + 10000);
             info.utilization = Some(0.25);
             info.claims_7d.clear();
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization_5h = Some(0.50);
             info.reset_5h = Some(now + 10000);
             info.utilization = Some(0.50);
@@ -20488,21 +19223,21 @@ upstream = "https://api.anthropic.com"
     #[tokio::test]
     async fn routing_metrics_zero_share_for_soft_limited_account_matches_pick_account() {
         let mut state = test_state_with(vec![
-            make_account("healthy", "sk-ant-api-a"),
-            make_account("soft-limited", "sk-ant-api-b"),
+            mk_endpoint("healthy", "sk-ant-api-a"),
+            mk_endpoint("soft-limited", "sk-ant-api-b"),
         ]);
         Arc::get_mut(&mut state).unwrap().soft_limit = 0.90;
         let now_epoch = AppState::now_epoch();
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization = Some(0.30);
             info.utilization_5h = Some(0.30);
             info.reset_5h = Some(now_epoch + 10000);
             info.status_5h = Some("allowed".to_string());
         }
         {
-            let mut info = state.accounts[1].rate_info.write().await;
+            let mut info = state.endpoints[1].rate_info.write().await;
             info.utilization = Some(0.95);
             info.utilization_5h = Some(0.95);
             info.reset_5h = Some(now_epoch + 10000);
@@ -20513,7 +19248,7 @@ upstream = "https://api.anthropic.com"
         let mut buf = String::new();
         append_routing_weight_metrics(
             &mut buf,
-            &state.accounts,
+            &state.endpoints,
             &[
                 EndpointMetricsSnap {
                     name: "healthy".to_string(),
@@ -20552,7 +19287,7 @@ upstream = "https://api.anthropic.com"
 
         for i in 0..20 {
             let key = format!("client-{i}");
-            let idx = state.pick_account(Some(&key), "any", &[]).await.unwrap();
+            let idx = state.pick_endpoint(Some(&key), "any", &[]).await.unwrap();
             assert_eq!(
                 idx, 0,
                 "client '{}' routed to soft-limited account despite exported zero share",
@@ -20565,13 +19300,13 @@ upstream = "https://api.anthropic.com"
     /// routing_share output (refresh_metrics_weights skips them).
     #[tokio::test]
     async fn metrics_routing_weight_omits_passthrough() {
-        let acct_a = make_account("a", "sk-ant-api-a");
-        let acct_pt = make_account("pt", "passthrough");
+        let acct_a = mk_endpoint("a", "sk-ant-api-a");
+        let acct_pt = mk_endpoint("pt", "passthrough");
         let state = test_state_with(vec![acct_a, acct_pt]);
 
         let now = AppState::now_epoch();
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.utilization_5h = Some(0.25);
             info.reset_5h = Some(now + 10000);
             info.utilization = Some(0.25);
@@ -20804,22 +19539,23 @@ upstream = "https://api.anthropic.com"
         });
 
         // Build app with an OAuth account, auto_cache off for clean signal
-        let accounts = vec![make_account("oauth-acct", "sk-ant-oat01-test-token")];
+        let accounts = vec![mk_endpoint_at(
+            "oauth-acct",
+            "sk-ant-oat01-test-token",
+            &format!("http://{}", mock_addr),
+        )];
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: format!("http://{}", mock_addr),
-            accounts,
-            endpoints: vec![],
+            endpoints: accounts,
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-oauth-regression.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -20838,7 +19574,6 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -20943,22 +19678,23 @@ upstream = "https://api.anthropic.com"
         });
 
         // Build app with an OAuth account
-        let accounts = vec![make_account("oauth-acct", "sk-ant-oat01-test-token")];
+        let accounts = vec![mk_endpoint_at(
+            "oauth-acct",
+            "sk-ant-oat01-test-token",
+            &format!("http://{}", mock_addr),
+        )];
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: format!("http://{}", mock_addr),
-            accounts,
-            endpoints: vec![],
+            endpoints: accounts,
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-oauth-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![],
             client_names: HashMap::new(),
             auto_cache: false, // disable to keep body simple
             client_usage: Mutex::new(HashMap::new()),
@@ -20977,7 +19713,6 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: None,
             overage_penalty: 10,
         });
 
@@ -21166,7 +19901,7 @@ upstream = "https://api.anthropic.com"
 
     #[test]
     fn request_context_trims_whitespace_headers() {
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-x")]);
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
         let mut headers = axum::http::HeaderMap::new();
         headers.insert("x-agent-id", HeaderValue::from_static("  "));
         headers.insert("x-session-id", HeaderValue::from_static(" \t "));
@@ -21251,28 +19986,23 @@ upstream = "https://api.anthropic.com"
         });
         let mock_url = format!("http://{}", mock_addr);
 
-        // Build state with all accounts hard-limited and a fallback upstream
+        // Build state with the Anthropic endpoint hard-limited and a
+        // priority-100 OpenAI endpoint as the fallback.
+        let mut openai = make_endpoint("fallback", Protocol::OpenAI);
+        openai.base_url = mock_url.clone();
+        openai.priority = 100;
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(), // unused — accounts are hard-limited
-            accounts: vec![make_account("acct-a", "sk-ant-api-a")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("acct-a", "sk-ant-api-a"), openai],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-fallback-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![Upstream {
-                name: "litellm".to_string(),
-                base_url: mock_url,
-                api_key: "sk-test-key".to_string(),
-                priority: 0,
-                requests: AtomicU64::new(0),
-            }],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -21291,13 +20021,12 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: Some(0), // index into upstreams
             overage_penalty: 10,
         });
 
         // Hard-limit the only account
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
 
@@ -21338,8 +20067,8 @@ upstream = "https://api.anthropic.com"
         assert_eq!(body["content"][0]["text"], "Fallback response");
         assert_eq!(body["stop_reason"], "end_turn");
 
-        // Verify upstream got the request
-        assert_eq!(state.upstreams[0].requests.load(Ordering::Relaxed), 1);
+        // Verify the OpenAI endpoint got the request
+        assert_eq!(state.endpoints[1].requests.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -21353,27 +20082,21 @@ upstream = "https://api.anthropic.com"
         });
         let mock_url = format!("http://{}", mock_addr);
 
+        let mut openai = make_endpoint("fallback", Protocol::OpenAI);
+        openai.base_url = mock_url.clone();
+        openai.priority = 100;
         let state = Arc::new(AppState {
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
                 .unwrap(),
-            upstream: "http://127.0.0.1:1".to_string(),
-            accounts: vec![make_account("acct-a", "sk-ant-api-a")],
-            endpoints: vec![],
+            endpoints: vec![mk_endpoint("acct-a", "sk-ant-api-a"), openai],
             robin: AtomicUsize::new(0),
             routing_strategy: RoutingStrategy::default(),
             cooldown: Duration::from_secs(60),
             state_path: PathBuf::from("/tmp/anthropic-lb-fallback-stream-test.state.json"),
             proxy_key: None,
             allowed_ips: vec![],
-            upstreams: vec![Upstream {
-                name: "litellm".to_string(),
-                base_url: mock_url,
-                api_key: "sk-test-key".to_string(),
-                priority: 0,
-                requests: AtomicU64::new(0),
-            }],
             client_names: HashMap::new(),
             auto_cache: false,
             client_usage: Mutex::new(HashMap::new()),
@@ -21392,12 +20115,11 @@ upstream = "https://api.anthropic.com"
             next_req_id: AtomicU64::new(0),
             instance_id: 0,
             probe_interval_secs: 300,
-            fallback_upstream: Some(0),
             overage_penalty: 10,
         });
 
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
 
@@ -21454,27 +20176,26 @@ upstream = "https://api.anthropic.com"
 
     #[tokio::test]
     async fn proxy_handler_no_fallback_returns_429() {
-        // Without fallback_upstream, exhausted accounts should return 429
-        let state = test_state_with(vec![make_account("a", "sk-ant-api-a")]);
+        // With no fallback endpoint, an exhausted pool yields None (→ 429).
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-a")]);
 
-        // Hard-limit the account
+        // Hard-limit the only endpoint
         {
-            let mut info = state.accounts[0].rate_info.write().await;
+            let mut info = state.endpoints[0].rate_info.write().await;
             info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
         }
 
-        assert!(state.fallback_upstream.is_none());
-        let result = state.pick_account(None, "", &[]).await;
+        let result = state.pick_endpoint(None, "", &[]).await;
         assert!(
             result.is_none(),
-            "should return None when account is hard-limited"
+            "should return None when endpoint is hard-limited"
         );
     }
 
     // ── Unified endpoint: fallback retry semantics ─────────────────
 
     #[tokio::test]
-    async fn try_fallback_upstream_unified_returns_none_on_429() {
+    async fn try_fallback_upstream_returns_none_on_429() {
         // Mock upstream returns 429
         let app = Router::new().fallback(any(|| async {
             (StatusCode::TOO_MANY_REQUESTS, "rate limited").into_response()
@@ -21491,7 +20212,7 @@ upstream = "https://api.anthropic.com"
         Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
 
         let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
-        let result = try_fallback_upstream_unified(
+        let result = try_fallback_upstream(
             &state,
             body,
             "req-1",
@@ -21508,7 +20229,7 @@ upstream = "https://api.anthropic.com"
     }
 
     #[tokio::test]
-    async fn try_fallback_upstream_unified_returns_none_on_500() {
+    async fn try_fallback_upstream_returns_none_on_500() {
         let app = Router::new().fallback(any(|| async {
             (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response()
         }));
@@ -21524,7 +20245,7 @@ upstream = "https://api.anthropic.com"
         Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
 
         let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
-        let result = try_fallback_upstream_unified(
+        let result = try_fallback_upstream(
             &state,
             body,
             "req-1",

--- a/src/main.rs
+++ b/src/main.rs
@@ -13549,6 +13549,35 @@ data: {\"type\":\"message_stop\"}\n\n";
         );
     }
 
+    // ── Unit: unified endpoint participation in routing ────────────
+
+    #[tokio::test]
+    async fn openai_endpoint_participates_at_configured_priority() {
+        let acct = make_account("anthropic", "sk-ant-api-a");
+        {
+            let mut info = acct.rate_info.write().await;
+            info.utilization = Some(0.0); // healthy
+        }
+        let mut state = test_state_with(vec![acct]);
+        let st = Arc::get_mut(&mut state).unwrap();
+        let mut ep = make_endpoint("openai", Protocol::OpenAI);
+        ep.priority = 100;
+        st.endpoints.push(ep);
+
+        let candidates = state.routing_candidates("claude-opus-4-7", &[]).await;
+        let openai_candidate = candidates
+            .iter()
+            .find(|c| matches!(c.endpoint, EndpointIdx::Unified(_)));
+        assert!(
+            openai_candidate.is_some(),
+            "openai endpoint must be a candidate"
+        );
+        let c = openai_candidate.unwrap();
+        assert_eq!(c.priority, 100);
+        assert_eq!(c.weight, 1.0);
+        assert_eq!(c.gate, 0.0);
+    }
+
     // ── Unit: per-client budget ────────────────────────────────────
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3572,8 +3572,6 @@ enum UsageTarget {
     /// Index into AppState.accounts (legacy pool).
     Account(usize),
     /// Index into AppState.endpoints (unified pool).
-    #[allow(dead_code)]
-    // wired up in Task 9 (forward_anthropic for Unified Anthropic endpoint)
     Unified(usize),
 }
 
@@ -3628,9 +3626,9 @@ impl AppState {
     }
 
     /// Update burn rate for an account and per-client request tracking.
-    fn update_burn_rate(&self, acct: &Account, client_id: &str) {
+    fn update_burn_rate(&self, burn_rate: &Mutex<BurnRate>, client_id: &str) {
         let now = Instant::now();
-        if let Ok(mut br) = acct.burn_rate.lock() {
+        if let Ok(mut br) = burn_rate.lock() {
             br.update(now);
         }
         if let Ok(mut rates) = self.client_request_rates.lock() {
@@ -4174,6 +4172,352 @@ fn debug_dump_cache_control(body: &serde_json::Value, req_id: &str) {
 
 // ── Handler ─────────────────────────────────────────────────────────
 
+/// Outcome of a single forward attempt to an Anthropic-protocol endpoint.
+/// The retry loop in `proxy_handler` interprets the outcome:
+///   - `Done(resp)`: final response — return it to the caller.
+///   - `Retry { saw_529, push_skip }`: try the next candidate. If
+///     `push_skip` is true the caller appends the failed endpoint index to
+///     its `skip` list; if `saw_529` is true the loop will BEBO-retry once
+///     this round exhausts.
+enum ForwardOutcome {
+    Done(Response),
+    Retry { saw_529: bool, push_skip: bool },
+}
+
+/// Forward one Anthropic-protocol request to a single endpoint. Pool-agnostic:
+/// reusable for both `AppState.accounts` (legacy) and `AppState.endpoints`
+/// (unified) by passing the endpoint's identity, auth, and shared state in
+/// explicitly. Behavior is byte-for-byte equivalent to the prior inline block
+/// in `proxy_handler` — only the `EndpointIdx::X(i)` value used for `skip` is
+/// chosen by the caller, since this helper does not know which pool it's
+/// serving.
+#[allow(clippy::too_many_arguments)]
+async fn forward_anthropic(
+    state: &Arc<AppState>,
+    parts: &axum::http::request::Parts,
+    body_bytes: &bytes::Bytes,
+    oauth_body_bytes: &bytes::Bytes,
+    base_url: &str,
+    token: &str,
+    passthrough: bool,
+    endpoint_name: &str,
+    usage_target: UsageTarget,
+    requests_counter: &AtomicU64,
+    rate_info: &RwLock<RateLimitInfo>,
+    burn_rate: &Mutex<BurnRate>,
+    req_id: &str,
+    client_id: &str,
+    client_ver: &str,
+    client_ip: &std::net::IpAddr,
+    agent_id: &str,
+    session_id: &str,
+    model: &str,
+    request_start: std::time::Instant,
+) -> ForwardOutcome {
+    let url = format!(
+        "{}{}",
+        base_url,
+        parts
+            .uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("/")
+    );
+
+    let mut upstream_req = state.client.request(parts.method.clone(), &url);
+
+    // Forward headers
+    let mut headers = parts.headers.clone();
+    headers.remove("host");
+    headers.remove("content-length"); // body size may change after cache injection
+    headers.remove("accept-encoding"); // need plaintext SSE to extract token usage
+
+    // Default anthropic-version if client didn't set it
+    if !headers.contains_key("anthropic-version") {
+        headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+    }
+
+    // Auth: passthrough keeps caller's headers, otherwise inject account token
+    inject_account_auth(&mut headers, token, passthrough);
+
+    // Debug: log outbound auth method and key headers
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        let auth_method = if passthrough {
+            "passthrough"
+        } else if token.starts_with("sk-ant-oat") {
+            "oauth"
+        } else {
+            "api-key"
+        };
+        debug!(
+            req_id,
+            account = endpoint_name,
+            auth_method,
+            body_bytes = if token.starts_with("sk-ant-oat") {
+                oauth_body_bytes.len()
+            } else {
+                body_bytes.len()
+            },
+            has_anthropic_beta = headers
+                .get("anthropic-beta")
+                .map(|v| v.to_str().unwrap_or("-")),
+            has_anthropic_version = headers
+                .get("anthropic-version")
+                .map(|v| v.to_str().unwrap_or("-")),
+            "<<< outbound to upstream"
+        );
+    }
+
+    upstream_req = upstream_req.headers(headers);
+    // Use OAuth variant (with CC system prompt) for OAuth tokens
+    let req_body = if token.starts_with("sk-ant-oat") {
+        oauth_body_bytes
+    } else {
+        body_bytes
+    };
+    upstream_req = upstream_req.body(req_body.clone());
+
+    let mut resp = match upstream_req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            error!(account = endpoint_name, "upstream request failed: {e}");
+            // Preserve original behavior: transport errors retry without
+            // adding the endpoint to the skip list.
+            return ForwardOutcome::Retry {
+                saw_529: false,
+                push_skip: false,
+            };
+        }
+    };
+
+    let status = resp.status();
+    requests_counter.fetch_add(1, Ordering::Relaxed);
+
+    // Debug: dump all response headers
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        debug!(
+            req_id,
+            status = status.as_u16(),
+            account = endpoint_name,
+            "<<< upstream response"
+        );
+        for (k, v) in resp.headers().iter() {
+            debug!(req_id, header = %k, value = debug_header_value(k, v), "<<< resp header");
+        }
+    }
+
+    // Always update rate limit info and persist
+    state
+        .update_rate_info_for(rate_info, endpoint_name, resp.headers())
+        .await;
+
+    // Update burn rate (after rate-limit headers are parsed)
+    state.update_burn_rate(burn_rate, client_id);
+
+    // 429 → mark hard-limited and try next account
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        state
+            .mark_hard_limited_for(rate_info, endpoint_name, resp.headers())
+            .await;
+        log_429_details(endpoint_name, resp).await;
+        state.save_state().await;
+        info!(account = endpoint_name, "got 429, rotating to next account");
+        return ForwardOutcome::Retry {
+            saw_529: false,
+            push_skip: true,
+        };
+    }
+
+    // 529 → overloaded, try next account; flag for BEBO retry if all exhausted
+    if status.as_u16() == 529 {
+        state.save_state().await;
+        warn!(account = endpoint_name, "got 529, rotating to next account");
+        return ForwardOutcome::Retry {
+            saw_529: true,
+            push_skip: true,
+        };
+    }
+
+    // Other 5xx → transient, try next account (no BEBO retry)
+    if status.is_server_error() {
+        state.save_state().await;
+        warn!(
+            account = endpoint_name,
+            status = status.as_u16(),
+            "got server error, rotating to next account"
+        );
+        return ForwardOutcome::Retry {
+            saw_529: false,
+            push_skip: true,
+        };
+    }
+
+    // Clear hard limit and burst counter only on a genuine 2xx success.
+    // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
+    // that the rate-limit window has drained — don't clobber state on
+    // client errors.
+    let recovered = if status.is_success() {
+        let mut info = rate_info.write().await;
+        let was = info.hard_limited_until.is_some();
+        info.hard_limited_until = None;
+        info.consecutive_burst_429s = 0;
+        was
+    } else {
+        false
+    };
+
+    // Persist state after updating rate-limit state so completed 4xx
+    // responses and other terminal outcomes aren't dropped on restart.
+    state.save_state().await;
+
+    if recovered {
+        state.signal_hard_limit_recovery(endpoint_name).await;
+    }
+
+    // Log with capacity info + inject budget status header
+    let budget_status = {
+        let info = rate_info.read().await;
+        let (eff_util, constraint, _adj_5h, _adj_7d) =
+            effective_utilization(&info, AppState::now_epoch(), model);
+        info!(
+            req_id,
+            client = %client_ip,
+            client_id = %client_id,
+            ver = %client_ver,
+            agent = %agent_id,
+            session = %session_id,
+            model = %model,
+            account = endpoint_name,
+            status = status.as_u16(),
+            utilization = format_args!("{eff_util:.2}"),
+            util_5h = info.utilization_5h.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
+            util_7d = info.utilization_7d.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
+            constraint,
+            overage = info.overage_in_use,
+            total = requests_counter.load(Ordering::Relaxed),
+            "proxied"
+        );
+        compute_pressure_status(eff_util, client_id, state)
+    };
+
+    let latency_ms = request_start.elapsed().as_millis() as u64;
+
+    // Stream response through, extracting token usage
+    let resp_status = StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let resp_headers = resp.headers().clone();
+
+    let mut builder = Response::builder().status(resp_status);
+    for (k, v) in resp_headers.iter() {
+        if k == "transfer-encoding" {
+            continue;
+        }
+        builder = builder.header(k, v);
+    }
+
+    // Inject budget status header
+    builder = builder.header("x-budget-status", budget_status);
+
+    // Detect streaming from content-type
+    let is_streaming = resp_headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|ct| ct.contains("text/event-stream"))
+        .unwrap_or(false);
+
+    if is_streaming {
+        // Streaming: tee the byte stream to accumulate SSE text for usage extraction
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
+        let state_clone = state.clone();
+        let client_id_clone = client_id.to_owned();
+        let acct_name = endpoint_name.to_owned();
+        let model_clone = model.to_owned();
+        let client_ip_str = client_ip.to_string();
+        let agent_clone = agent_id.to_owned();
+        let session_clone = session_id.to_owned();
+        let req_id_clone = req_id.to_owned();
+        let status_code = status.as_u16();
+
+        tokio::spawn(async move {
+            let mut sse_buf = Vec::new();
+            let mut client_disconnected = false;
+            let mut upstream_error = false;
+            loop {
+                match resp.chunk().await {
+                    Ok(Some(chunk)) => {
+                        sse_buf.extend_from_slice(&chunk);
+                        if tx.send(Ok(chunk)).await.is_err() {
+                            client_disconnected = true;
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        upstream_error = true;
+                        warn!(req_id = req_id_clone, error = %e, "upstream SSE read failed");
+                        break;
+                    }
+                }
+            }
+            // Parse accumulated SSE data for usage
+            finalize_stream(
+                &state_clone,
+                usage_target,
+                &req_id_clone,
+                &client_id_clone,
+                &model_clone,
+                &acct_name,
+                &client_ip_str,
+                &agent_clone,
+                &session_clone,
+                status_code,
+                &sse_buf,
+                request_start,
+                client_disconnected,
+                upstream_error,
+                false,
+            )
+            .await;
+        });
+
+        let body_stream = ReceiverStream::new(rx);
+        let response = builder
+            .body(Body::from_stream(body_stream))
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+            });
+        ForwardOutcome::Done(response)
+    } else {
+        // Non-streaming: buffer, extract usage, forward
+        let resp_body_bytes = resp.bytes().await.unwrap_or_default();
+        let mut usage = TokenUsage::default();
+        if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&resp_body_bytes) {
+            usage = TokenUsage::from_response_body(&parsed);
+        }
+        finalize_non_stream(
+            state,
+            usage_target,
+            req_id,
+            client_id,
+            model,
+            endpoint_name,
+            &client_ip.to_string(),
+            agent_id,
+            session_id,
+            status.as_u16(),
+            &usage,
+            latency_ms,
+            false,
+        )
+        .await;
+        let response = builder
+            .body(Body::from(resp_body_bytes))
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+            });
+        ForwardOutcome::Done(response)
+    }
+}
+
 async fn proxy_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::ConnectInfo(client_addr): axum::extract::ConnectInfo<SocketAddr>,
@@ -4319,325 +4663,132 @@ async fn proxy_handler(
         let mut saw_529 = false;
         // n accounts + 1 fallback upstream is the candidate ceiling.
         for _attempt in 0..(n + 1) {
-            let idx = match state.pick_endpoint(affinity, &model, &skip).await {
-                Some(EndpointIdx::Account(i)) => i,
-                Some(EndpointIdx::Upstream(u)) => {
-                    // All account tiers exhausted — route through the fallback upstream.
-                    match try_fallback_upstream(
-                        &state,
-                        &body_bytes,
-                        &req_id,
-                        &client_id,
-                        &model,
-                        u,
-                        true,
-                    )
-                    .await
-                    {
-                        Some(resp) => return resp,
-                        None => {
-                            skip.push(EndpointIdx::Upstream(u));
-                            continue;
+            // Pick the next candidate. Each branch resolves the call to
+            // `forward_anthropic` (Anthropic-protocol endpoints — accounts or
+            // unified Anthropic) or `try_fallback_upstream*` (OpenAI-protocol).
+            let (outcome, picked_idx): (ForwardOutcome, EndpointIdx) =
+                match state.pick_endpoint(affinity, &model, &skip).await {
+                    Some(EndpointIdx::Account(i)) => {
+                        let acct = &state.accounts[i];
+                        let out = forward_anthropic(
+                            &state,
+                            &parts,
+                            &body_bytes,
+                            &oauth_body_bytes,
+                            &state.upstream,
+                            &acct.token,
+                            acct.passthrough,
+                            &acct.name,
+                            UsageTarget::Account(i),
+                            &acct.requests,
+                            &acct.rate_info,
+                            &acct.burn_rate,
+                            &req_id,
+                            &client_id,
+                            &client_ver,
+                            &client_ip,
+                            &agent_id,
+                            &session_id,
+                            &model,
+                            request_start,
+                        )
+                        .await;
+                        (out, EndpointIdx::Account(i))
+                    }
+                    Some(EndpointIdx::Upstream(u)) => {
+                        // All account tiers exhausted — route through the fallback upstream.
+                        match try_fallback_upstream(
+                            &state,
+                            &body_bytes,
+                            &req_id,
+                            &client_id,
+                            &model,
+                            u,
+                            true,
+                        )
+                        .await
+                        {
+                            Some(resp) => return resp,
+                            None => {
+                                skip.push(EndpointIdx::Upstream(u));
+                                continue;
+                            }
                         }
                     }
-                }
-                Some(EndpointIdx::Unified(_)) => unreachable!(
-                    "Phase 2b: handler dispatch for EndpointIdx::Unified is not yet wired; the startup guard in main() rejects [[endpoints]] configs until this branch lands."
-                ),
-                None => {
-                    warn!("all endpoints exhausted");
-                    return (
-                        StatusCode::TOO_MANY_REQUESTS,
-                        "all upstream endpoints exhausted",
-                    )
-                        .into_response();
-                }
-            };
-
-            let acct = &state.accounts[idx];
-            let url = format!(
-                "{}{}",
-                state.upstream,
-                parts
-                    .uri
-                    .path_and_query()
-                    .map(|pq| pq.as_str())
-                    .unwrap_or("/")
-            );
-
-            let mut upstream_req = state.client.request(parts.method.clone(), &url);
-
-            // Forward headers
-            let mut headers = parts.headers.clone();
-            headers.remove("host");
-            headers.remove("content-length"); // body size may change after cache injection
-            headers.remove("accept-encoding"); // need plaintext SSE to extract token usage
-
-            // Default anthropic-version if client didn't set it
-            if !headers.contains_key("anthropic-version") {
-                headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
-            }
-
-            // Auth: passthrough keeps caller's headers, otherwise inject account token
-            inject_account_auth(&mut headers, &acct.token, acct.passthrough);
-
-            // Debug: log outbound auth method and key headers
-            if tracing::enabled!(tracing::Level::DEBUG) {
-                let auth_method = if acct.passthrough {
-                    "passthrough"
-                } else if acct.token.starts_with("sk-ant-oat") {
-                    "oauth"
-                } else {
-                    "api-key"
-                };
-                debug!(
-                    req_id,
-                    account = acct.name,
-                    auth_method,
-                    body_bytes = if acct.token.starts_with("sk-ant-oat") {
-                        oauth_body_bytes.len()
-                    } else {
-                        body_bytes.len()
-                    },
-                    has_anthropic_beta = headers
-                        .get("anthropic-beta")
-                        .map(|v| v.to_str().unwrap_or("-")),
-                    has_anthropic_version = headers
-                        .get("anthropic-version")
-                        .map(|v| v.to_str().unwrap_or("-")),
-                    "<<< outbound to upstream"
-                );
-            }
-
-            upstream_req = upstream_req.headers(headers);
-            // Use OAuth variant (with CC system prompt) for OAuth tokens
-            let req_body = if acct.token.starts_with("sk-ant-oat") {
-                &oauth_body_bytes
-            } else {
-                &body_bytes
-            };
-            upstream_req = upstream_req.body(req_body.clone());
-
-            let mut resp = match upstream_req.send().await {
-                Ok(r) => r,
-                Err(e) => {
-                    error!(account = acct.name, "upstream request failed: {e}");
-                    continue;
-                }
-            };
-
-            let status = resp.status();
-            acct.requests.fetch_add(1, Ordering::Relaxed);
-
-            // Debug: dump all response headers
-            if tracing::enabled!(tracing::Level::DEBUG) {
-                debug!(
-                    req_id,
-                    status = status.as_u16(),
-                    account = acct.name,
-                    "<<< upstream response"
-                );
-                for (k, v) in resp.headers().iter() {
-                    debug!(req_id, header = %k, value = debug_header_value(k, v), "<<< resp header");
-                }
-            }
-
-            // Always update rate limit info and persist
-            state.update_rate_info(idx, resp.headers()).await;
-
-            // Update burn rate (after rate-limit headers are parsed)
-            state.update_burn_rate(acct, &client_id);
-
-            // 429 → mark hard-limited and try next account
-            if status == StatusCode::TOO_MANY_REQUESTS {
-                state.mark_hard_limited(idx, resp.headers()).await;
-                log_429_details(&acct.name, resp).await;
-                state.save_state().await;
-                info!(account = acct.name, "got 429, rotating to next account");
-                skip.push(EndpointIdx::Account(idx));
-                continue;
-            }
-
-            // 529 → overloaded, try next account; flag for BEBO retry if all exhausted
-            if status.as_u16() == 529 {
-                state.save_state().await;
-                warn!(account = acct.name, "got 529, rotating to next account");
-                saw_529 = true;
-                skip.push(EndpointIdx::Account(idx));
-                continue;
-            }
-
-            // Other 5xx → transient, try next account (no BEBO retry)
-            if status.is_server_error() {
-                state.save_state().await;
-                warn!(
-                    account = acct.name,
-                    status = status.as_u16(),
-                    "got server error, rotating to next account"
-                );
-                skip.push(EndpointIdx::Account(idx));
-                continue;
-            }
-
-            // Clear hard limit and burst counter only on a genuine 2xx success.
-            // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
-            // that the rate-limit window has drained — don't clobber state on
-            // client errors.
-            let recovered = if status.is_success() {
-                let mut info = acct.rate_info.write().await;
-                let was = info.hard_limited_until.is_some();
-                info.hard_limited_until = None;
-                info.consecutive_burst_429s = 0;
-                was
-            } else {
-                false
-            };
-
-            // Persist state after updating rate-limit state so completed 4xx
-            // responses and other terminal outcomes aren't dropped on restart.
-            state.save_state().await;
-
-            if recovered {
-                state.signal_hard_limit_recovery(&acct.name).await;
-            }
-
-            // Log with capacity info + inject budget status header
-            let budget_status = {
-                let info = acct.rate_info.read().await;
-                let (eff_util, constraint, _adj_5h, _adj_7d) =
-                    effective_utilization(&info, AppState::now_epoch(), &model);
-                info!(
-                    req_id,
-                    client = %client_ip,
-                    client_id = %client_id,
-                    ver = %client_ver,
-                    agent = %agent_id,
-                    session = %session_id,
-                    model = %model,
-                    account = acct.name,
-                    status = status.as_u16(),
-                    utilization = format_args!("{eff_util:.2}"),
-                    util_5h = info.utilization_5h.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
-                    util_7d = info.utilization_7d.map(|v| format!("{v:.2}")).as_deref().unwrap_or("-"),
-                    constraint,
-                    overage = info.overage_in_use,
-                    total = acct.requests.load(Ordering::Relaxed),
-                    "proxied"
-                );
-                compute_pressure_status(eff_util, &client_id, &state)
-            };
-
-            let latency_ms = request_start.elapsed().as_millis() as u64;
-
-            // Stream response through, extracting token usage
-            let resp_status =
-                StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
-            let resp_headers = resp.headers().clone();
-
-            let mut builder = Response::builder().status(resp_status);
-            for (k, v) in resp_headers.iter() {
-                if k == "transfer-encoding" {
-                    continue;
-                }
-                builder = builder.header(k, v);
-            }
-
-            // Inject budget status header
-            builder = builder.header("x-budget-status", budget_status);
-
-            // Detect streaming from content-type
-            let is_streaming = resp_headers
-                .get("content-type")
-                .and_then(|v| v.to_str().ok())
-                .map(|ct| ct.contains("text/event-stream"))
-                .unwrap_or(false);
-
-            if is_streaming {
-                // Streaming: tee the byte stream to accumulate SSE text for usage extraction
-                let (tx, rx) =
-                    tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
-                let state_clone = state.clone();
-                let client_id_clone = client_id.clone();
-                let acct_name = acct.name.clone();
-                let model_clone = model.clone();
-                let client_ip_str = client_ip.to_string();
-                let agent_clone = agent_id.clone();
-                let session_clone = session_id.clone();
-
-                tokio::spawn(async move {
-                    let mut sse_buf = Vec::new();
-                    let mut client_disconnected = false;
-                    let mut upstream_error = false;
-                    loop {
-                        match resp.chunk().await {
-                            Ok(Some(chunk)) => {
-                                sse_buf.extend_from_slice(&chunk);
-                                if tx.send(Ok(chunk)).await.is_err() {
-                                    client_disconnected = true;
-                                    break;
+                    Some(EndpointIdx::Unified(i)) => {
+                        let ep = &state.endpoints[i];
+                        match ep.protocol {
+                            Protocol::Anthropic => {
+                                let out = forward_anthropic(
+                                    &state,
+                                    &parts,
+                                    &body_bytes,
+                                    &oauth_body_bytes,
+                                    &ep.base_url,
+                                    &ep.token,
+                                    ep.passthrough,
+                                    &ep.name,
+                                    UsageTarget::Unified(i),
+                                    &ep.requests,
+                                    &ep.rate_info,
+                                    &ep.burn_rate,
+                                    &req_id,
+                                    &client_id,
+                                    &client_ver,
+                                    &client_ip,
+                                    &agent_id,
+                                    &session_id,
+                                    &model,
+                                    request_start,
+                                )
+                                .await;
+                                (out, EndpointIdx::Unified(i))
+                            }
+                            Protocol::OpenAI => {
+                                match try_fallback_upstream_unified(
+                                    &state,
+                                    &body_bytes,
+                                    &req_id,
+                                    &client_id,
+                                    &model,
+                                    i,
+                                    true,
+                                )
+                                .await
+                                {
+                                    Some(resp) => return resp,
+                                    None => {
+                                        skip.push(EndpointIdx::Unified(i));
+                                        continue;
+                                    }
                                 }
                             }
-                            Ok(None) => break,
-                            Err(e) => {
-                                upstream_error = true;
-                                warn!(req_id, error = %e, "upstream SSE read failed");
-                                break;
-                            }
                         }
                     }
-                    // Parse accumulated SSE data for usage
-                    finalize_stream(
-                        &state_clone,
-                        UsageTarget::Account(idx),
-                        &req_id,
-                        &client_id_clone,
-                        &model_clone,
-                        &acct_name,
-                        &client_ip_str,
-                        &agent_clone,
-                        &session_clone,
-                        status.as_u16(),
-                        &sse_buf,
-                        request_start,
-                        client_disconnected,
-                        upstream_error,
-                        false,
-                    )
-                    .await;
-                });
+                    None => {
+                        warn!("all endpoints exhausted");
+                        return (
+                            StatusCode::TOO_MANY_REQUESTS,
+                            "all upstream endpoints exhausted",
+                        )
+                            .into_response();
+                    }
+                };
 
-                let body_stream = ReceiverStream::new(rx);
-                return builder
-                    .body(Body::from_stream(body_stream))
-                    .unwrap_or_else(|_| {
-                        (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
-                    });
-            } else {
-                // Non-streaming: buffer, extract usage, forward
-                let body_bytes = resp.bytes().await.unwrap_or_default();
-                let mut usage = TokenUsage::default();
-                if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
-                    usage = TokenUsage::from_response_body(&parsed);
+            match outcome {
+                ForwardOutcome::Done(resp) => return resp,
+                ForwardOutcome::Retry {
+                    saw_529: this_529,
+                    push_skip,
+                } => {
+                    if this_529 {
+                        saw_529 = true;
+                    }
+                    if push_skip {
+                        skip.push(picked_idx);
+                    }
+                    continue;
                 }
-                finalize_non_stream(
-                    &state,
-                    UsageTarget::Account(idx),
-                    &req_id,
-                    &client_id,
-                    &model,
-                    &acct.name,
-                    &client_ip.to_string(),
-                    &agent_id,
-                    &session_id,
-                    status.as_u16(),
-                    &usage,
-                    latency_ms,
-                    false,
-                )
-                .await;
-                return builder.body(Body::from(body_bytes)).unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
-                });
             }
         }
         // If no 529s in this round, don't retry (e.g. all were 429s or errors)
@@ -4904,17 +5055,15 @@ async fn try_fallback_upstream(
 
 /// Forward a request to a `Protocol::OpenAI` endpoint in the unified pool.
 ///
-/// Used by `proxy_handler`'s `EndpointIdx::Unified` arm (Task 9). Marked
-/// `#[allow(dead_code)]` until that arm lands in the same series.
-/// Mirrors `try_fallback_upstream` but reads from `state.endpoints` and —
-/// critically — returns `None` on upstream 429/5xx so the retry loop advances
-/// to the next candidate. Other 4xx (e.g. 400, 401) are still returned to the
-/// caller as a final response — retry won't help on client-side errors.
+/// Used by `proxy_handler`'s `EndpointIdx::Unified` arm. Mirrors
+/// `try_fallback_upstream` but reads from `state.endpoints` and — critically —
+/// returns `None` on upstream 429/5xx so the retry loop advances to the next
+/// candidate. Other 4xx (e.g. 400, 401) are still returned to the caller as a
+/// final response — retry won't help on client-side errors.
 ///
 /// Like the original `try_fallback_upstream`, this only increments the
 /// endpoint's request counter; it does not call `record_usage` (OpenAI-compat
 /// responses don't carry the same usage signal we extract for Anthropic).
-#[allow(dead_code)] // wired in Task 9 (proxy_handler EndpointIdx::Unified dispatch)
 async fn try_fallback_upstream_unified(
     state: &AppState,
     body_bytes: &[u8],
@@ -7942,7 +8091,7 @@ async fn openai_chat_handler(
             state.update_rate_info(idx, resp.headers()).await;
 
             // Update burn rate (after rate-limit headers are parsed)
-            state.update_burn_rate(acct, &client_id);
+            state.update_burn_rate(&acct.burn_rate, &client_id);
 
             if status == StatusCode::TOO_MANY_REQUESTS {
                 state.mark_hard_limited(idx, resp.headers()).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -500,7 +500,7 @@ struct Upstream {
 ///   1. `routing_candidates()` — short-circuits to a fixed RoutingCandidate.
 ///   2. `is_emergency_brake_active()` — iterates only Anthropic endpoints.
 ///   3. probe loop — skips OpenAI endpoints.
-#[allow(dead_code)] // fields read by routing in Task 8 (next commit)
+#[allow(dead_code)] // probe loop, emergency-brake reads in later phases
 struct Endpoint {
     name: String,
     protocol: Protocol,
@@ -524,7 +524,6 @@ struct Endpoint {
     last_effective_gate: AtomicU64,
 }
 
-#[allow(dead_code)] // method used by routing_candidates in Task 8 (next commit)
 impl Endpoint {
     /// Check if this endpoint can serve the given model. Empty allowlist = all.
     /// Identical to the historical `Account::serves_model` predicate.
@@ -549,7 +548,6 @@ struct AppState {
     /// Unified endpoints. After Phase 4, this replaces `accounts` and `upstreams`.
     /// During migration, both sets are populated so consumers can be migrated
     /// one at a time.
-    #[allow(dead_code)] // read by routing_candidates in Task 8 (next commit)
     endpoints: Vec<Endpoint>,
     robin: AtomicUsize,
     routing_strategy: RoutingStrategy,
@@ -1789,6 +1787,95 @@ impl AppState {
                     weight: 1.0,
                     source: "upstream",
                 });
+            }
+        }
+
+        // Unified endpoints. During the migration, both the old `accounts`+`upstreams`
+        // pools and the new `endpoints` pool are enumerated. The deployed config will
+        // populate only one side at a time — both populated is a configuration error
+        // caught elsewhere.
+        for (i, ep) in self.endpoints.iter().enumerate() {
+            if skip.contains(&EndpointIdx::Unified(i)) {
+                continue;
+            }
+            if !ep.serves_model(model) {
+                continue;
+            }
+            match ep.protocol {
+                Protocol::OpenAI => {
+                    // OpenAI endpoints carry no rate-limit data — push a fixed candidate
+                    // at the configured priority. This is one of the three named
+                    // `match protocol` sites (see Endpoint struct docs).
+                    trace!(
+                        endpoint = ep.name,
+                        priority = ep.priority,
+                        "pick: candidate (openai, fixed)"
+                    );
+                    candidates.push(RoutingCandidate {
+                        endpoint: EndpointIdx::Unified(i),
+                        priority: ep.priority,
+                        gate_5h: 0.0,
+                        gate_7d: 0.0,
+                        gate: 0.0,
+                        wr: 0.0,
+                        weight: 1.0,
+                        source: "openai",
+                    });
+                }
+                Protocol::Anthropic => {
+                    let info = ep.rate_info.read().await;
+                    if let Some(until) = info.hard_limited_until {
+                        if now < until {
+                            trace!(
+                                endpoint = ep.name,
+                                hard_limited_secs = until.duration_since(now).as_secs(),
+                                "pick: skipping hard-limited endpoint"
+                            );
+                            continue;
+                        }
+                    }
+                    let stale_after_hard_limit = info
+                        .hard_limited_until
+                        .is_some_and(|until| info.last_updated.is_none_or(|lu| lu <= until));
+                    let rw = match compute_routing_weight(
+                        &info,
+                        model,
+                        now_epoch,
+                        stale_after_hard_limit,
+                    ) {
+                        Some(rw) => rw,
+                        None => {
+                            trace!(
+                                endpoint = ep.name,
+                                model = model,
+                                "pick: skipping, 7d claim rejected"
+                            );
+                            continue;
+                        }
+                    };
+                    let effective_priority = if rw.overage_active {
+                        ep.priority.saturating_add(self.overage_penalty)
+                    } else {
+                        ep.priority
+                    };
+                    trace!(
+                        endpoint = ep.name,
+                        gate = format!("{:.4}", rw.gate),
+                        weight = format!("{:.4}", rw.weight),
+                        priority = effective_priority,
+                        "pick: candidate (anthropic)"
+                    );
+                    candidates.push(RoutingCandidate {
+                        endpoint: EndpointIdx::Unified(i),
+                        priority: effective_priority,
+                        gate_5h: rw.gate_5h,
+                        gate_7d: rw.gate_7d,
+                        gate: rw.gate,
+                        wr: rw.wr,
+                        weight: rw.weight,
+                        source: rw.source,
+                    });
+                }
             }
         }
         candidates

--- a/src/main.rs
+++ b/src/main.rs
@@ -696,8 +696,8 @@ impl AppState {
         let mut endpoints = Vec::new();
         let now = Instant::now();
 
-        // Build a PersistedEndpoint from the shared (name, requests, rate_info)
-        // fields common to both Account and Endpoint.
+        // Build a PersistedEndpoint from an endpoint's (name, requests,
+        // rate_info) fields.
         async fn persist_one(
             name: &str,
             requests: &AtomicU64,
@@ -869,8 +869,7 @@ impl AppState {
             }
         }
 
-        // The unified Endpoint carries its own base URL (the Account pool used
-        // the global self.upstream).
+        // Each endpoint carries its own base URL.
         let url = format!("{}/v1/messages", ep.base_url);
         let body = serde_json::json!({
             "model": model,
@@ -1791,8 +1790,7 @@ impl AppState {
 
 /// Per-entry representative `(gate, weight)` for metrics gauges, model-agnostic.
 /// Returns `None` for hard-limited members (they contribute zero in any state).
-/// Shared by both the legacy account pool and the unified endpoint pool — only
-/// reads `RateLimitInfo`, so it is pool-agnostic.
+/// Computed purely from a `RateLimitInfo`.
 fn metrics_gate_weight(info: &RateLimitInfo, now_epoch: u64, now: Instant) -> Option<(f64, f64)> {
     // Hard-limited members contribute zero (mirrors routing_candidates filter).
     if let Some(until) = info.hard_limited_until {
@@ -1965,9 +1963,8 @@ impl AppState {
     ///
     /// Also refreshes metric gauges and publishes updated routing weights so all
     /// replicas reflect the recovery within the next sync tick.
-    /// Broadcast a hard-limit recovery for an endpoint by name. Pool-agnostic:
-    /// the Redis sentinel key is derived from the name alone, so this serves
-    /// both the legacy Account pool and the unified Endpoint pool.
+    /// Broadcast a hard-limit recovery for an endpoint by name. The Redis
+    /// sentinel key is derived from the name alone.
     async fn signal_hard_limit_recovery(&self, endpoint_name: &str) {
         if let Some(redis) = &self.redis {
             let mut conn = redis.clone();
@@ -4647,10 +4644,9 @@ async fn try_fallback_upstream(
 
 // ── Stats endpoint ──────────────────────────────────────────────────
 
-/// Build one `/stats` JSON entry from the shared (name, priority, rate_info,
-/// burn_rate, counters) field set common to both `Account` and the unified
-/// `Endpoint`. When `protocol` is `Some`, a `"protocol"` field is added — the
-/// only shape difference between an account entry and an endpoint entry.
+/// Build one `/stats` JSON entry from an endpoint's (name, priority,
+/// rate_info, burn_rate, counters) fields. When `protocol` is `Some`, a
+/// `"protocol"` field is added to the entry.
 #[allow(clippy::too_many_arguments)]
 async fn build_stats_entry(
     name: &str,
@@ -5131,10 +5127,9 @@ fn append_routing_weight_metrics(
     }
 }
 
-/// Build an `EndpointMetricsSnap` from the shared (name, rate_info, burn_rate,
-/// counters, gauge atomics) field set common to both `Account` and the unified
-/// `Endpoint`. Pool-agnostic: callers pass field references, so one
-/// implementation serves both the legacy account pool and the endpoint pool.
+/// Build an `EndpointMetricsSnap` from an endpoint's (name, rate_info,
+/// burn_rate, counters, gauge atomics) fields. Callers pass field references
+/// rather than an `&Endpoint`.
 #[allow(clippy::too_many_arguments)]
 async fn build_metrics_snap(
     name: &str,
@@ -5751,7 +5746,7 @@ async fn metrics_handler(
         "Effective routing gate: max(time_adjusted_5h, time_adjusted_7d) with status floors",
     );
 
-    // Snap-carried gauges (captured at snap time) — covers both pools.
+    // Snap-carried gauges (captured at snap time).
     for s in &snaps {
         if s.passthrough {
             continue;
@@ -16955,8 +16950,8 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert!(state.cluster_info_cache.lock().unwrap().is_none());
     }
 
-    /// sync_from_redis / publish_routing_weights build the unified SyncTarget
-    /// list over BOTH pools. With an endpoints-only config (and a mix of
+    /// sync_from_redis / publish_routing_weights build the SyncTarget list over
+    /// the endpoint pool. With an endpoints-only config (and a mix of
     /// Anthropic + OpenAI protocols) neither path may panic.
     #[tokio::test]
     async fn sync_and_publish_handle_endpoint_pool_without_redis() {

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -458,6 +458,25 @@ fn test_example_config_file_is_valid() {
         "endpoints field should exist"
     );
 
+    // Verify removed legacy fields are absent — guards against accidental
+    // reintroduction of the old schema in the example config.
+    assert!(
+        config.get("upstream").is_none(),
+        "global `upstream` field was removed and must not reappear"
+    );
+    assert!(
+        config.get("accounts").is_none(),
+        "[[accounts]] section was removed and must not reappear"
+    );
+    assert!(
+        config.get("upstreams").is_none(),
+        "[[upstreams]] section was removed and must not reappear"
+    );
+    assert!(
+        config.get("fallback_upstream").is_none(),
+        "fallback_upstream was removed and must not reappear"
+    );
+
     // Verify endpoints is an array with at least one entry
     let endpoints = config["endpoints"]
         .as_array()

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -450,33 +450,24 @@ fn test_example_config_file_is_valid() {
 
     let config = result.unwrap();
 
-    // Verify essential fields exist
+    // Verify essential fields exist (unified [[endpoints]] schema — `upstream`
+    // and `[[accounts]]` were removed in the unified-endpoints refactor).
     assert!(config.get("listen").is_some(), "listen field should exist");
     assert!(
-        config.get("upstream").is_some(),
-        "upstream field should exist"
-    );
-    assert!(
-        config.get("accounts").is_some(),
-        "accounts field should exist"
+        config.get("endpoints").is_some(),
+        "endpoints field should exist"
     );
 
-    // Verify accounts is an array with at least one account
-    let accounts = config["accounts"]
+    // Verify endpoints is an array with at least one entry
+    let endpoints = config["endpoints"]
         .as_array()
-        .expect("accounts should be an array");
-    assert!(!accounts.is_empty(), "accounts should not be empty");
+        .expect("endpoints should be an array");
+    assert!(!endpoints.is_empty(), "endpoints should not be empty");
 
-    // Verify first account has required fields
-    let first_account = &accounts[0];
-    assert!(
-        first_account.get("name").is_some(),
-        "account should have name"
-    );
-    assert!(
-        first_account.get("token").is_some(),
-        "account should have token"
-    );
+    // Verify first endpoint has required fields
+    let first = &endpoints[0];
+    assert!(first.get("name").is_some(), "endpoint should have name");
+    assert!(first.get("token").is_some(), "endpoint should have token");
 }
 
 #[test]


### PR DESCRIPTION
# Unified Endpoints — collapse accounts + upstreams + fallback_upstream into `[[endpoints]]`

Replaces the proxy's two routing-candidate types (`[[accounts]]` Anthropic-native + `[[upstreams]]` OpenAI-compatible) and the `fallback_upstream` config key with a single unified `[[endpoints]]` concept distinguished by a `protocol` field.

## Why

Three problems with the old design:
1. `fallback_upstream` was a misnomer — priority tiers (PR #58) made "fallback" semantics just `priority = 100`, but the name lied about what the field did. The lab `insight-gateway` upstream defaulted to `priority = 0` and competed with primary accounts — exactly the bug this refactor exists to prevent recurring.
2. "Upstream" was overloaded — the whole binary is an upstream proxy. The two TOML sections did essentially the same job: routing candidates partitioned into one priority space.
3. Hidden coupling — special-cased `Option<usize>` index for the fallback meant routing had two code paths for one concept.

## What changes

**Config (hard break):**
```toml
[[endpoints]]
name = "primary"
token = "sk-ant-..."                  # protocol = "anthropic" is the default

[[endpoints]]
name = "insight-gateway"
protocol = "openai"
base_url = "https://gateway.example"
token = "sk-..."
priority = 100                        # high priority = last-resort
```

Old `[[accounts]]`/`[[upstreams]]`/`fallback_upstream` keys are explicitly rejected at startup with operator-friendly migration errors (`reject_legacy_config_keys`).

**Runtime:**
- One unified `Endpoint` struct (replaces `Account` + `Upstream`).
- `EndpointIdx` collapsed to `usize`; `UsageTarget` enum deleted.
- Three named `match protocol` sites: `routing_candidates` (fixed-vs-computed weight), `is_emergency_brake_active` (skip OpenAI — stub `RateLimitInfo` would prevent firing), probe loop (skip OpenAI — no rate-limit headers).
- `try_fallback_upstream_unified` returns `None` on upstream 429/5xx so the retry loop advances (the old `try_fallback_upstream` returned errors directly).
- `openai_chat_handler` keeps routing to Anthropic accounts via OpenAI↔Anthropic translation — existing feature with 18 tests, preserved.

**Removed:**
- `/upstream/{name}/*` passthrough route (unused).
- `/_stats` JSON `accounts` and `upstreams` arrays (replaced by `endpoints`) — schema break.

## Spec / plan

- Design: [`docs/superpowers/specs/2026-05-21-unified-endpoints-design.md`](docs/superpowers/specs/2026-05-21-unified-endpoints-design.md)
- Implementation plan: [`docs/superpowers/plans/2026-05-21-unified-endpoints.md`](docs/superpowers/plans/2026-05-21-unified-endpoints.md)

## Verification

- 384 tests pass (84+ pre-existing + new behavior-coverage suite: priority routing, model allowlists, 429/5xx retry, OpenAI↔Anthropic round-trip translation, emergency-brake correctness, legacy-config rejection, persistence round-trip).
- `cargo fmt --check` + `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` clean.
- Multi-agent review across both phases (spec compliance + code quality) — every behavior-preservation claim verified by line-by-line diff against the base.
- Net: +8810 / −2713, mostly in `src/main.rs`.

## Migration / rollout

Coordinated lockstep with config repos:
- `27b-io/fleet-infra` PR: migrates `mem` cluster `externalsecret.yaml` to `[[endpoints]]` (committed locally).
- `27b-io/lab` PR: migrates `lab` cluster `externalsecret.yaml` (committed locally).

Rollout sequence: merge here → CI builds `:main` image → Flux image policy picks up new digest → push config-repo PRs → `kubectl rollout restart` to pick up new binary + new secret together. Verify pod logs show `loaded endpoint name="..." protocol=Anthropic` for each configured endpoint.

Suggested merge: **squash** — the per-task commits trace the TDD/review history; the spec and plan in-tree provide the discoverable narrative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced separate account/upstream concepts with a unified endpoints model (protocol, base_url, token, priority) and documented routing, priority, affinity and overage behaviours.
  * Added a design spec and phased migration/rollout plan for endpoints; updated examples and throttling docs to show endpoints-based and OpenAI-compatible setups.
* **Tests**
  * Updated config tests to validate the new endpoints schema and ensure legacy keys are rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/27b-io/anthropic-lb/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->