### PR TITLE
fix: graceful drain + SSE error frames on upstream interruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ shadow.jsonl
 .spec-workflow/
 .claude/
 AGENTS.md
-.claude/coderabbit-loop-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ shadow.jsonl
 .spec-workflow/
 .claude/
 AGENTS.md
+.claude/coderabbit-loop-*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,10 @@ Production runs on the **mem** k8s cluster (`kubectl --context mem`), namespace 
 
 ```bash
 kubectl --context mem -n anthropic-lb rollout restart deployment/anthropic-lb
+kubectl --context lab -n mcp           rollout restart deployment/anthropic-lb
 ```
 
-Local dev instance also runs as systemd user unit: `systemctl --user restart anthropic-lb`
+Also deployed on `lab` (namespace `mcp`) as a 2-pod Deployment serving real Claude Code traffic via Tailscale. There is no local systemd unit.
 
 ## Architecture
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4074,6 +4074,15 @@ async fn forward_anthropic(
                     Err(e) => {
                         upstream_error = true;
                         warn!(req_id = req_id_clone, error = %e, "upstream SSE read failed");
+                        if tx
+                            .send(Ok(anthropic_error_frame(&format!(
+                                "upstream stream interrupted: {e}"
+                            ))))
+                            .await
+                            .is_err()
+                        {
+                            client_disconnected = true;
+                        }
                         break;
                     }
                 }
@@ -4511,6 +4520,12 @@ async fn try_fallback_upstream(
             let mut buffer: Vec<u8> = Vec::new();
             let mut ctx = ReverseStreamContext::default();
             let mut client_gone = false;
+            // Passthrough-only: tracks whether upstream's `[DONE]` terminator
+            // has been forwarded verbatim, so an error frame on the next read
+            // doesn't ship a second `[DONE]` and break strict OpenAI parsers.
+            // Not needed in the translate branch — translation converts
+            // `[DONE]` to `message_stop`, which has no analogous terminator.
+            let mut sent_done = false;
 
             loop {
                 match resp.chunk().await {
@@ -4537,8 +4552,16 @@ async fn try_fallback_upstream(
                                     break;
                                 }
                             }
-                        } else if tx.send(Ok(chunk)).await.is_err() {
-                            client_gone = true;
+                        } else {
+                            if chunk
+                                .windows(b"data: [DONE]".len())
+                                .any(|w| w == b"data: [DONE]")
+                            {
+                                sent_done = true;
+                            }
+                            if tx.send(Ok(chunk)).await.is_err() {
+                                client_gone = true;
+                            }
                         }
                         if client_gone {
                             break;
@@ -4547,6 +4570,25 @@ async fn try_fallback_upstream(
                     Ok(None) => break,
                     Err(e) => {
                         warn!(req_id, error = %e, "fallback: unified endpoint SSE read failed");
+                        // Downstream protocol depends on whether we're translating:
+                        // translate_response=true → /v1/messages client expects
+                        // Anthropic SSE; translate_response=false → /v1/chat/completions
+                        // passthrough, downstream is the OpenAI SSE format. Skip
+                        // the openai error frame when `[DONE]` was already
+                        // forwarded — emitting it would ship a second `[DONE]`.
+                        let msg = format!("upstream stream interrupted: {e}");
+                        let frame = if translate_response {
+                            Some(anthropic_error_frame(&msg))
+                        } else if !sent_done {
+                            Some(openai_error_frame(&msg))
+                        } else {
+                            None
+                        };
+                        if let Some(frame) = frame {
+                            if tx.send(Ok(frame)).await.is_err() {
+                                client_gone = true;
+                            }
+                        }
                         break;
                     }
                 }
@@ -6952,6 +6994,35 @@ fn make_anthropic_event(event_type: &str, data: &serde_json::Value) -> String {
     format!("event: {}\ndata: {}\n\n", event_type, data)
 }
 
+/// Final-frame Anthropic SSE error event for downstream when an upstream
+/// stream dies mid-flight. Without this the client sees a bare TCP FIN
+/// ("socket closed unexpectedly"). Emits a single `event: error` frame; the
+/// Anthropic SSE protocol has no terminator analogous to OpenAI's `[DONE]`,
+/// so the channel may close naturally after this frame.
+fn anthropic_error_frame(message: &str) -> bytes::Bytes {
+    // `error.type` must be one of Anthropic's documented values
+    // (overloaded_error, api_error, invalid_request_error, ...). Using a
+    // custom type like "upstream_error" risks the SDK rejecting the frame
+    // and the client falling back to "socket closed unexpectedly" — the
+    // exact failure mode this helper exists to prevent. `api_error` is the
+    // documented catch-all; the descriptive detail lives in `message`.
+    let body = serde_json::json!({
+        "type": "error",
+        "error": { "type": "api_error", "message": message }
+    });
+    bytes::Bytes::from(make_anthropic_event("error", &body))
+}
+
+/// Final-frame OpenAI SSE error for downstream. Emits the error JSON
+/// followed by `data: [DONE]` (OpenAI's stream terminator) — callers MUST
+/// NOT emit an additional `[DONE]` after this frame.
+fn openai_error_frame(message: &str) -> bytes::Bytes {
+    let err = serde_json::json!({
+        "error": { "message": message, "type": "upstream_error" }
+    });
+    bytes::Bytes::from(format!("data: {err}\n\ndata: [DONE]\n\n"))
+}
+
 /// Translate an OpenAI SSE chunk to Anthropic SSE events.
 /// Returns Vec because one OpenAI chunk may produce multiple Anthropic events.
 /// `raw` is the raw SSE data line (after stripping "data: " prefix).
@@ -7416,6 +7487,20 @@ async fn forward_openai_compat_anthropic(
                     Err(e) => {
                         upstream_error = true;
                         warn!(req_id = req_id_clone, error = %e, "upstream SSE read failed");
+                        // The post-loop "ensure DONE sent" block gates on
+                        // !upstream_error (set above), so emitting the error
+                        // frame here — which already ships [DONE] — cannot
+                        // race with a second [DONE] from the post-loop guard.
+                        if !sent_done
+                            && tx
+                                .send(Ok(openai_error_frame(&format!(
+                                    "upstream stream interrupted: {e}"
+                                ))))
+                                .await
+                                .is_err()
+                        {
+                            client_gone = true;
+                        }
                         break;
                     }
                 }
@@ -8071,8 +8156,23 @@ async fn main() {
     };
 
     let state = Arc::new(AppState {
+        // Liveness knobs are load-bearing against Anthropic's Cloudflare edge:
+        // h2 PING (while_idle) evicts half-closed pooled streams before they're
+        // reused; read_timeout catches mid-stream stalls without waiting out
+        // the full request budget; pool_idle_timeout keeps connections warm
+        // through Claude Code read/think pauses to avoid paying a fresh TLS
+        // handshake on every burst. read_timeout is set at 180s so Opus's
+        // extended-thinking pauses (which can exceed 90s of inter-chunk
+        // silence on deep reasoning) don't trip a false-positive interruption.
         client: Client::builder()
-            .timeout(Duration::from_secs(600))
+            .timeout(Duration::from_secs(900))
+            .read_timeout(Duration::from_secs(180))
+            .connect_timeout(Duration::from_secs(10))
+            .tcp_keepalive(Duration::from_secs(30))
+            .http2_keep_alive_interval(Duration::from_secs(20))
+            .http2_keep_alive_timeout(Duration::from_secs(10))
+            .http2_keep_alive_while_idle(true)
+            .pool_idle_timeout(Duration::from_secs(300))
             .build()
             .expect("failed to build HTTP client"),
         endpoints,
@@ -8223,8 +8323,22 @@ async fn main() {
         });
     }
 
-    // Graceful shutdown: save state on SIGTERM/SIGINT
+    // Bounded drain so a wedged stream can't hold the process past the
+    // orchestrator's kill deadline and earn a SIGKILL with unsaved state.
+    // In k8s this is `terminationGracePeriodSeconds`; keep SHUTDOWN_DRAIN_SECS
+    // strictly less so the proxy exits cleanly before SIGKILL. Long Claude
+    // Code streams (Opus on long outputs) can run 60–120s, so the budget
+    // must accommodate that or in-flight responses get cut.
+    const SHUTDOWN_DRAIN_SECS: u64 = 160;
     let shutdown_state = state.clone();
+
+    // The drain deadline must start ticking from signal-arrival, not from
+    // process start — `tokio::time::timeout(d, server)` would arm `d` when
+    // first polled and force-exit any uptime > d. The signal handler fires
+    // notify_waiters(), and the deadline future awaits that before its sleep.
+    let drain_signal = Arc::new(tokio::sync::Notify::new());
+    let drain_signal_in = drain_signal.clone();
+
     let shutdown = async move {
         let ctrl_c = tokio::signal::ctrl_c();
         let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -8233,18 +8347,37 @@ async fn main() {
             _ = ctrl_c => info!("received SIGINT"),
             _ = sigterm.recv() => info!("received SIGTERM"),
         }
-        info!("saving state before shutdown...");
-        shutdown_state.save_state().await;
-        info!("state saved, shutting down");
+        info!(
+            drain_budget_secs = SHUTDOWN_DRAIN_SECS,
+            "draining in-flight requests"
+        );
+        drain_signal_in.notify_waiters();
     };
 
-    axum::serve(
+    let server = axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
-    .with_graceful_shutdown(shutdown)
-    .await
-    .unwrap_or_else(|e| panic!("server error: {e}"));
+    .with_graceful_shutdown(shutdown);
+
+    let drain_deadline = async {
+        drain_signal.notified().await;
+        tokio::time::sleep(Duration::from_secs(SHUTDOWN_DRAIN_SECS)).await;
+    };
+
+    tokio::select! {
+        res = server => match res {
+            Ok(()) => info!("drain complete"),
+            Err(e) => error!(error = %e, "server error during drain"),
+        },
+        _ = drain_deadline => warn!(
+            drain_budget_secs = SHUTDOWN_DRAIN_SECS,
+            "drain timeout exceeded — forcing exit; in-flight streams will be cut"
+        ),
+    }
+    info!("saving state");
+    shutdown_state.save_state().await;
+    info!("state saved, shutdown complete");
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -20402,5 +20535,125 @@ listen = "127.0.0.1:8082"
             "translated request must have OpenAI `messages` field"
         );
         assert_eq!(received["model"], "claude-opus-4-7");
+    }
+
+    // ── Connection resilience: synthetic SSE error on upstream disconnect ──
+
+    #[test]
+    fn anthropic_error_frame_is_well_formed_sse() {
+        let bytes = anthropic_error_frame("connection reset by peer");
+        let s = std::str::from_utf8(&bytes).expect("frame must be utf8");
+        assert!(s.starts_with("event: error\n"), "must use SSE event syntax");
+        assert!(s.ends_with("\n\n"), "must terminate with blank line");
+        let data_line = s
+            .lines()
+            .find_map(|l| l.strip_prefix("data: "))
+            .expect("must have a data: line");
+        let parsed: serde_json::Value =
+            serde_json::from_str(data_line).expect("data payload must be valid JSON");
+        assert_eq!(parsed["type"], "error");
+        // Must be one of Anthropic's documented SSE error types so the
+        // SDK doesn't reject the frame and fall back to "socket closed".
+        assert_eq!(parsed["error"]["type"], "api_error");
+        assert_eq!(parsed["error"]["message"], "connection reset by peer");
+    }
+
+    #[test]
+    fn openai_error_frame_includes_done_marker() {
+        let bytes = openai_error_frame("upstream gone");
+        let s = std::str::from_utf8(&bytes).expect("frame must be utf8");
+        assert!(
+            s.contains("\ndata: [DONE]\n\n"),
+            "must terminate with OpenAI [DONE] marker so the client parser closes cleanly: {s:?}"
+        );
+        let first_data = s
+            .lines()
+            .find_map(|l| l.strip_prefix("data: "))
+            .expect("must have a leading data: line");
+        let parsed: serde_json::Value =
+            serde_json::from_str(first_data).expect("first data payload must be valid JSON");
+        assert_eq!(parsed["error"]["type"], "upstream_error");
+        assert_eq!(parsed["error"]["message"], "upstream gone");
+    }
+
+    /// When an upstream Anthropic SSE stream dies mid-flight, the downstream
+    /// client must receive a synthetic `event: error` frame rather than a bare
+    /// TCP FIN. Without this guarantee the Claude Code CLI surfaces the
+    /// uninterpretable "socket connection was closed unexpectedly" error.
+    #[tokio::test]
+    async fn streaming_upstream_disconnect_emits_sse_error_to_client() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Mock upstream: replies with text/event-stream + one partial SSE
+        // chunk, then drops the socket without writing the terminating
+        // `message_stop` event or a 0-length chunked terminator.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+            let reset = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 3600)
+                .to_string();
+            let head = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 content-type: text/event-stream\r\n\
+                 transfer-encoding: chunked\r\n\
+                 anthropic-ratelimit-unified-representative-claim: five_hour\r\n\
+                 anthropic-ratelimit-unified-5h-utilization: 0.10\r\n\
+                 anthropic-ratelimit-unified-5h-reset: {reset}\r\n\
+                 \r\n"
+            );
+            let _ = stream.write_all(head.as_bytes()).await;
+            // One valid chunk, then drop. Chunk = hex-size, CRLF, bytes, CRLF.
+            let body = "event: message_start\ndata: {\"type\":\"message_start\"}\n\n";
+            let chunk = format!("{:x}\r\n{}\r\n", body.len(), body);
+            let _ = stream.write_all(chunk.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        });
+
+        let upstream_url = format!("http://{}", mock_addr);
+        let (app, _state) = test_app(&upstream_url, None);
+
+        let app_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let app_addr = app_listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                app_listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("http://{}/v1/messages", app_addr))
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .header("x-api-key", "any")
+            .body(
+                r#"{"model":"claude-sonnet-4-6","stream":true,"messages":[{"role":"user","content":"hi"}]}"#,
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let body = resp.bytes().await.unwrap();
+        let body_s = std::str::from_utf8(&body).expect("body utf8");
+
+        assert!(
+            body_s.contains("event: error\n"),
+            "downstream must receive synthetic SSE error frame on upstream disconnect, got: {body_s:?}"
+        );
+        assert!(
+            body_s.contains("\"type\":\"api_error\""),
+            "error frame must use Anthropic's documented api_error type, got: {body_s:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4526,11 +4526,13 @@ async fn try_fallback_upstream(
             // Not needed in the translate branch — translation converts
             // `[DONE]` to `message_stop`, which has no analogous terminator.
             let mut sent_done = false;
-            // Rolling tail of (pattern_len - 1) bytes so a `data: [DONE]`
-            // marker split across two `resp.chunk()` boundaries is still
-            // detected. A naive per-chunk window scan misses splits.
-            const DONE_PATTERN: &[u8] = b"data: [DONE]";
-            let mut done_scan_tail: Vec<u8> = Vec::with_capacity(DONE_PATTERN.len() - 1);
+            // Carries any partial trailing SSE line between chunks so the
+            // `[DONE]` terminator is detected across resp.chunk() boundaries.
+            // A naive byte-window scan would false-positive on the literal
+            // string "data: [DONE]" appearing inside a JSON content delta,
+            // so we split on SSE newline boundaries and only treat a complete
+            // `data: [DONE]` line as the terminator.
+            let mut done_scan_tail: Vec<u8> = Vec::new();
 
             loop {
                 match resp.chunk().await {
@@ -4560,17 +4562,25 @@ async fn try_fallback_upstream(
                         } else {
                             if !sent_done {
                                 done_scan_tail.extend_from_slice(&chunk);
-                                if done_scan_tail
-                                    .windows(DONE_PATTERN.len())
-                                    .any(|w| w == DONE_PATTERN)
+                                while let Some(nl) = done_scan_tail.iter().position(|&b| b == b'\n')
                                 {
-                                    sent_done = true;
-                                    done_scan_tail.clear();
-                                } else {
-                                    let keep = DONE_PATTERN.len() - 1;
-                                    if done_scan_tail.len() > keep {
-                                        let drop_n = done_scan_tail.len() - keep;
-                                        done_scan_tail.drain(..drop_n);
+                                    let line_end = if nl > 0 && done_scan_tail[nl - 1] == b'\r' {
+                                        nl - 1
+                                    } else {
+                                        nl
+                                    };
+                                    let is_done_marker = if let Some(payload) =
+                                        done_scan_tail[..line_end].strip_prefix(b"data:")
+                                    {
+                                        payload.trim_ascii() == b"[DONE]"
+                                    } else {
+                                        false
+                                    };
+                                    done_scan_tail.drain(..=nl);
+                                    if is_done_marker {
+                                        sent_done = true;
+                                        done_scan_tail.clear();
+                                        break;
                                     }
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::PathBuf,
     sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -4526,6 +4526,11 @@ async fn try_fallback_upstream(
             // Not needed in the translate branch — translation converts
             // `[DONE]` to `message_stop`, which has no analogous terminator.
             let mut sent_done = false;
+            // Rolling tail of (pattern_len - 1) bytes so a `data: [DONE]`
+            // marker split across two `resp.chunk()` boundaries is still
+            // detected. A naive per-chunk window scan misses splits.
+            const DONE_PATTERN: &[u8] = b"data: [DONE]";
+            let mut done_scan_tail: Vec<u8> = Vec::with_capacity(DONE_PATTERN.len() - 1);
 
             loop {
                 match resp.chunk().await {
@@ -4553,11 +4558,21 @@ async fn try_fallback_upstream(
                                 }
                             }
                         } else {
-                            if chunk
-                                .windows(b"data: [DONE]".len())
-                                .any(|w| w == b"data: [DONE]")
-                            {
-                                sent_done = true;
+                            if !sent_done {
+                                done_scan_tail.extend_from_slice(&chunk);
+                                if done_scan_tail
+                                    .windows(DONE_PATTERN.len())
+                                    .any(|w| w == DONE_PATTERN)
+                                {
+                                    sent_done = true;
+                                    done_scan_tail.clear();
+                                } else {
+                                    let keep = DONE_PATTERN.len() - 1;
+                                    if done_scan_tail.len() > keep {
+                                        let drop_n = done_scan_tail.len() - keep;
+                                        done_scan_tail.drain(..drop_n);
+                                    }
+                                }
                             }
                             if tx.send(Ok(chunk)).await.is_err() {
                                 client_gone = true;
@@ -8336,8 +8351,17 @@ async fn main() {
     // process start — `tokio::time::timeout(d, server)` would arm `d` when
     // first polled and force-exit any uptime > d. The signal handler fires
     // notify_waiters(), and the deadline future awaits that before its sleep.
+    //
+    // `drain_triggered` closes a race in `Notify::notify_waiters()`: it only
+    // wakes waiters registered at call time. Without the flag, a signal that
+    // arrives before drain_deadline registers its waiter is lost and the
+    // deadline never fires. With the flag, drain_deadline registers the
+    // waiter eagerly via Notified::enable(), then checks the flag — so
+    // either path (signal-before-poll, signal-after-poll) is observed.
     let drain_signal = Arc::new(tokio::sync::Notify::new());
     let drain_signal_in = drain_signal.clone();
+    let drain_triggered = Arc::new(AtomicBool::new(false));
+    let drain_triggered_in = drain_triggered.clone();
 
     let shutdown = async move {
         let ctrl_c = tokio::signal::ctrl_c();
@@ -8351,6 +8375,7 @@ async fn main() {
             drain_budget_secs = SHUTDOWN_DRAIN_SECS,
             "draining in-flight requests"
         );
+        drain_triggered_in.store(true, Ordering::SeqCst);
         drain_signal_in.notify_waiters();
     };
 
@@ -8361,7 +8386,12 @@ async fn main() {
     .with_graceful_shutdown(shutdown);
 
     let drain_deadline = async {
-        drain_signal.notified().await;
+        let notified = drain_signal.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if !drain_triggered.load(Ordering::SeqCst) {
+            notified.await;
+        }
         tokio::time::sleep(Duration::from_secs(SHUTDOWN_DRAIN_SECS)).await;
     };
 


### PR DESCRIPTION
## Summary

Eliminates two classes of \"socket connection closed unexpectedly\" errors surfacing to Claude Code clients:

1. **Mid-stream upstream interruptions** now emit a structured SSE error frame (Anthropic `event: error` or OpenAI `data: {error}; data: [DONE]`) instead of a bare TCP FIN. The client parser closes cleanly with an actionable message rather than a generic socket error.

2. **Pod rotation cuts long streams.** `SHUTDOWN_DRAIN_SECS` bumped 30 → 160s; k8s manifest changes (lab + fleet-infra) add `terminationGracePeriodSeconds: 180`, `preStop: sleep 10`, and `maxUnavailable: 0` so streams survive rolling deploys.

## Client tuning

- `read_timeout`: NEW at 180s (separate from 900s total). Detects dead streams without false-firing on Opus extended-thinking pauses (a panel reviewer flagged 90s as too aggressive — independent reproduction of the issue I would have shipped)
- `pool_idle_timeout`: 60 → 300s. Keeps h2 connections warm through read/think pauses to avoid TLS handshake tax on every burst
- `timeout`: 600 → 900s. Headroom for extended-thinking + long-output requests

## Protocol compliance

- `anthropic_error_frame` uses `api_error` as the `error.type` — Anthropic's documented catch-all. Non-documented types risk SDK rejection (the very fallback the frame exists to prevent).
- `try_fallback_upstream` passthrough tracks `sent_done` by byte-scanning forwarded chunks, so a transport error after upstream's final `[DONE]` doesn't produce a double-`[DONE]` and break strict OpenAI parsers.

## Cuts

- Deleted the HTTP/2 startup probe — diagnostic theater (one-shot HEAD, nothing alerted on, weak correlation to POST/stream negotiation).

## Companion manifest changes

- `27b-io/lab` → `k8s/mcp/anthropic-lb.yaml`: termGrace + preStop + maxUnavailable/maxSurge
- `27b-io/fleet-infra` → `apps/mem/anthropic-lb/deployment.yaml`: termGrace + preStop

## Test plan

- [x] `cargo test --bin anthropic-lb` (387/387 pass; includes new `streaming_upstream_disconnect_emits_sse_error_to_client` integration test that proves the synthetic frame crosses the wire via mock TCP listener)
- [x] `cargo fmt --check`
- [x] `RUSTFLAGS=\"-Dwarnings\" cargo clippy --bin anthropic-lb --no-deps`
- [ ] Watch a long Claude Code session through the proxy after rollout; no \"socket closed unexpectedly\" during pod rotation
- [ ] Verify with `kubectl rollout restart deployment/anthropic-lb` mid-stream that in-flight SSE responses complete cleanly

## Deferred (panel should-fix, separate PRs)

- Bump termGrace 180 → 200 for save_state headroom against slow Redis
- Replace `Notify::notify_waiters()` with `oneshot`/`CancellationToken` (signal-ordering brittleness)
- Cross-file comment encoding the constant-coupling inequality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming termination so clients receive a structured final error event when upstream streams fail; prevents duplicate terminators and improves reliability.
  * Tuned HTTP timeouts and connection settings; reworked graceful shutdown into a bounded drain-with-timeout flow.

* **Documentation**
  * Updated deployment instructions to include an extra restart step for load‑balancer deployment.

* **Tests**
  * Added tests validating final-frame error formatting and mid‑stream disconnect handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/27b-io/anthropic-lb/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->