### PR TITLE
chore: demote per-request usage and per-probe logs to DEBUG

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -943,7 +943,11 @@ impl AppState {
                 } else {
                     None
                 };
-                info!(
+                // DEBUG, not INFO: per-probe completion is high-volume periodic
+                // noise (every probe_interval × model-family × endpoint). The
+                // routing-weight metrics this computes are still exported via
+                // Prometheus; this line is only the human-readable echo.
+                debug!(
                     endpoint = ep.name,
                     status = status.as_u16(),
                     probe_model = model,
@@ -3068,7 +3072,11 @@ impl RequestContext {
 }
 
 fn log_usage(req_id: &str, client_id: &str, model: &str, account: &str, usage: &TokenUsage) {
-    info!(
+    // DEBUG, not INFO: per-request usage is high-volume operator noise. Token
+    // accounting is preserved regardless of log level via the shadow-log JSONL
+    // audit trail and the Prometheus counters — this line is only the
+    // human-readable echo.
+    debug!(
         req_id,
         client_id,
         model,


### PR DESCRIPTION
## What
Demote two high-volume periodic log lines from `INFO` to `DEBUG`:

- **`log_usage`** — the per-request `"usage"` event (token counts), emitted on every proxied request from `finalize_stream` / `finalize_non_stream`.
- **`"probe complete"`** — emitted on every background utilization probe (`probe_interval` × model-family × endpoint).

## Why
Both are per-request / per-probe operator noise that dominates INFO logs at production traffic. Neither carries accounting that exists only in the log:
- Token usage is durably recorded in the **shadow-log JSONL** audit trail and **Prometheus** counters.
- Probe-derived **routing weights** are exported via Prometheus.

So this line is purely the human-readable echo — DEBUG is the right level. Startup lines (`"starting utilization probes"`, `"probes disabled"`) and the `WARN` `"probe failed"` error signal are untouched.

## Gates
`cargo fmt --check`, `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets`, `cargo test --bin anthropic-lb` (388 pass) — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reduced log verbosity by adjusting internal logging levels to decrease noise in human-readable logs.
  * All metrics and audit trails remain fully captured and exported as before.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/27b-io/anthropic-lb/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->