### PR TITLE
chore: jemalloc heap-profiling allocator for OOM leak hunt (#73) [DRAFT]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "toml",
@@ -1370,6 +1371,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,12 @@ ipnet = "2.11.0"
 tokio-stream = "0.1"
 redis = { version = "1.0.3", features = ["tokio-comp", "connection-manager", "tls-rustls", "tokio-rustls-comp"] }
 
+# Heap-profiling allocator. jemalloc's prof support is compiled in but stays
+# INERT until enabled at runtime via MALLOC_CONF, so this is safe to ship. Capture:
+#   MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,lg_prof_interval:30,prof_prefix:/data/jeprof
+# auto-dumps /data/jeprof.*.heap to the mounted volume; analyze with `jeprof`.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["profiling"] }
+
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,11 @@
+// Heap-profiling allocator (profiling/jemalloc-heap branch). jemalloc's prof is
+// inert until enabled via MALLOC_CONF at runtime (see Cargo.toml), so this is
+// safe to ship; it lets us capture an allocation profile to pinpoint the OOM
+// leak (issue #73) without a code-path bisect.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use axum::{
     body::Body,
     extract::State,


### PR DESCRIPTION
**Draft — diagnostic tooling for the OOM leak (#73). Do not merge to main; deploy this image to one pod when ready to capture a profile.**

## What
- Adds `tikv-jemallocator` as the global allocator (Linux/non-msvc).
- jemalloc is compiled with `prof` support but it's **inert** until enabled via `MALLOC_CONF` at runtime — zero behaviour change otherwise. 389 tests + fmt + clippy green.

## How to capture a heap profile
1. Build/deploy this branch's image to a pod (or scale a dedicated profiling replica).
2. Set the env in the manifest:
   ```
   MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,lg_prof_interval:30,prof_prefix:/data/jeprof
   ```
   `lg_prof_interval:30` auto-dumps a profile every ~1GiB allocated to the mounted `/data` volume (`/data/jeprof.<n>.heap`).
3. Let it run through a memory climb (ideally on the `mem` zero-traffic cluster to isolate a *baseline* leak from storm accumulation).
4. Pull the profiles and resolve symbols:
   ```
   kubectl cp <ns>/<pod>:/data/jeprof.<n>.heap ./
   jeprof --collapsed ./target/release/anthropic-lb jeprof.<n>.heap > heap.folded
   # flamegraph.pl heap.folded > heap.svg  — top stacks = the leak
   ```

## Notes
- Profiling has ~small CPU/mem overhead; fine for a canary, not recommended fleet-wide long-term.
- Branch is off `main` (the currently-deployed leaky code), not #69 — we want to profile what's actually OOMing.
- Once the leak is found, this branch is a throwaway; revert the allocator or keep it gated behind a build feature.
