### PR TITLE
chore: log content fingerprint for all requests (verify fp stability per session)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4567,15 +4567,27 @@ async fn proxy_handler(
                 .to_string();
             let mut mutated = false;
 
-            // Privacy-safe fingerprint instrumentation. For HEADERLESS traffic
-            // (no session/agent id — the sessionless SDK fleet we can't pin), log
-            // only the content-prefix digests so we can measure whether a content
-            // fingerprint would separate the fleet (distinct fp count vs request
-            // volume). No body content is logged — digests only. Computed before
-            // auto-cache injection so it reflects the client's original prefix.
-            if agent_id == "-" && session_id == "-" {
+            // Privacy-safe fingerprint instrumentation (digests only, no body
+            // content). Logged for EVERY request, tagged with session + agent, to
+            // answer two questions before wiring fp into routing:
+            //   (1) headerless: does fp separate the fleet? (distinct fp vs volume)
+            //   (2) sessioned:  is fp STABLE across a conversation's turns? — group
+            //       by session_id and expect ONE fp per session. The Messages API
+            //       is stateless (history is resent each turn) so messages[0] is
+            //       fixed; this verifies that holds for real bodies (catches any
+            //       volatile system-prompt content). Computed before auto-cache
+            //       injection so it reflects the client's original prefix.
+            {
                 let (fp, fps) = content_fingerprints(&parsed);
-                info!(req_id, client_id = %client_id, fp = %fp, fps = %fps, "fingerprint");
+                info!(
+                    req_id,
+                    client_id = %client_id,
+                    session = %session_id,
+                    agent = %agent_id,
+                    fp = %fp,
+                    fps = %fps,
+                    "fingerprint"
+                );
             }
 
             // Debug: dump cache_control structures found in request body


### PR DESCRIPTION
Step 1 of validating `fp(system+first-user)` as a routing key for traffic we can't control (SDK-spawned subagents with no session header).

## Why
Before wiring `fp` into routing, we must confirm it's **stable across a conversation's turns** — otherwise it'd re-key every turn and reintroduce cache thrash. The Messages API is stateless (full history resent each turn → `messages[0]` is fixed), so `hash(system+first_user)` *should* be invariant per conversation. This verifies it on **real bodies** and catches any volatile system-prompt content.

## What
Widen the existing fingerprint instrumentation from headerless-only to **every** request, tagged with `session` + `agent`. Digests only — **no body content logged**.

## How we read it
- **Sessioned traffic** (real `session_id`): group by session → expect **one `fp` per session**. If a session shows multiple `fp`, the prefix mutates per turn (volatile system content) → fp is unsafe as a key, and we learn exactly why.
- **Headerless**: unchanged distinctness measurement.

No routing change — pure logging. 402 tests / fmt / clippy green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging instrumentation to capture fingerprint data for all requests, including session-based traffic, with additional context fields for improved diagnostics and monitoring visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->