### PR TITLE
LAB-366: Redis-sync upstream_transport_errors for fleet visibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -526,10 +526,12 @@ struct AppState {
     /// Priority penalty added to an endpoint's effective priority while it serves
     /// via overage. Default: 10.
     overage_penalty: u32,
-    /// Count of upstream transport send-failures, keyed by kind
-    /// (`timeout`/`connect`/`other`). Surfaces a flaky egress on the dashboard
-    /// (`anthropic_upstream_transport_errors_total`) before it becomes client
-    /// errors. Process-scoped; not persisted or Redis-synced.
+    /// Per-tick DELTA accumulator of upstream transport send-failures, keyed
+    /// by kind (`timeout`/`connect`/`other`). Surfaces a flaky egress on the
+    /// dashboard (`anthropic_upstream_transport_errors_total`) before it
+    /// becomes client errors. Drained into the shared Redis hash each sync
+    /// tick (`flush_transport_errors`); without Redis it simply accumulates
+    /// and feeds `/metrics` directly. Not persisted across restarts.
     upstream_transport_errors: Mutex<HashMap<&'static str, u64>>,
     /// Current sum of reserved in-flight request-body bytes (admission control).
     inflight_body_bytes: AtomicU64,
@@ -3169,6 +3171,22 @@ impl AppState {
         }
     }
 
+    /// Lock the transport-error accumulator, recovering — and clearing — a
+    /// poisoned lock. The map is a plain counter store: a panicking holder
+    /// cannot leave it logically inconsistent, only stale by one increment.
+    /// Clearing the poison matters because the other lock sites (the two
+    /// increment paths and the local `/metrics` fallback) use `if let Ok` /
+    /// `.map()` and would otherwise silently skip forever after one panic.
+    fn lock_transport_errors(&self) -> std::sync::MutexGuard<'_, HashMap<&'static str, u64>> {
+        match self.upstream_transport_errors.lock() {
+            Ok(g) => g,
+            Err(poisoned) => {
+                self.upstream_transport_errors.clear_poison();
+                poisoned.into_inner()
+            }
+        }
+    }
+
     /// Flush this replica's accumulated transport-error deltas into the shared
     /// Redis hash (`TRANSPORT_ERRORS_KEY`) so the fleet-wide count is visible
     /// cluster-wide. `upstream_transport_errors` is a DELTA accumulator: it is
@@ -3177,7 +3195,8 @@ impl AppState {
     /// ticks). On Redis failure the drained deltas are returned to the local
     /// map — they retry next tick and stay visible via the local metrics
     /// fallback rather than being lost. No-op without Redis, so single-instance
-    /// deployments keep accumulating locally.
+    /// deployments keep accumulating locally; on an idle tick the TTL is still
+    /// refreshed so the fleet-wide hash never expires under healthy traffic.
     async fn flush_transport_errors(&self) {
         let redis = match &self.redis {
             Some(r) => r,
@@ -3186,16 +3205,26 @@ impl AppState {
 
         // Drain the accumulator atomically: take the deltas AND reset to empty
         // under one lock, so any increment arriving mid-flush belongs to the
-        // NEXT tick's delta and cannot be double-flushed. Recover a poisoned
-        // lock — a stale count must not wedge the flush loop forever.
+        // NEXT tick's delta and cannot be double-flushed.
         let deltas: Vec<(&'static str, u64)> = {
-            let mut m = match self.upstream_transport_errors.lock() {
-                Ok(m) => m,
-                Err(poisoned) => poisoned.into_inner(),
-            };
+            let mut m = self.lock_transport_errors();
             m.drain().filter(|(_, n)| *n > 0).collect()
         };
         if deltas.is_empty() {
+            // No new errors this tick — still refresh the TTL. The hash must
+            // only expire once the whole fleet has been down for the TTL
+            // window; skipping this would wipe the fleet-wide counter after
+            // 48h of perfectly healthy, error-free traffic. EXPIRE on a
+            // not-yet-existing key is a no-op, so this is safe pre-first-error.
+            let mut conn = redis.clone();
+            let result: redis::RedisResult<()> = redis::cmd("EXPIRE")
+                .arg(TRANSPORT_ERRORS_KEY)
+                .arg(TRANSPORT_ERRORS_TTL_SECS)
+                .query_async(&mut conn)
+                .await;
+            if let Err(e) = result {
+                warn!(error = %e, "redis EXPIRE failed for transport-errors TTL refresh");
+            }
             return;
         }
 
@@ -3227,10 +3256,11 @@ impl AppState {
             // budget would wrongly throttle a client.) The deltas also stay
             // visible via the local metrics fallback until Redis heals.
             warn!(error = %e, "redis HINCRBY failed for transport errors; re-queuing deltas locally");
-            if let Ok(mut m) = self.upstream_transport_errors.lock() {
-                for (kind, n) in deltas {
-                    *m.entry(kind).or_insert(0) += n;
-                }
+            // Poison-recovering lock: an `if let Ok` here would silently DROP
+            // every drained delta if the mutex got poisoned mid-cycle.
+            let mut m = self.lock_transport_errors();
+            for (kind, n) in deltas {
+                *m.entry(kind).or_insert(0) += n;
             }
         }
     }
@@ -13334,6 +13364,42 @@ token = "sk-ant-test"
             "local accumulator must be retained without redis"
         );
         assert_eq!(m.get("connect"), Some(&1));
+    }
+
+    /// A panicked lock-holder must not wedge the accumulator: recovery clears
+    /// the poison so the drain, the re-queue-on-redis-failure path, and every
+    /// `if let Ok` increment/metrics site keep working afterwards.
+    #[tokio::test]
+    async fn transport_errors_lock_recovers_and_clears_poison() {
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-aaa")]);
+        // Poison the mutex by panicking while holding the guard.
+        {
+            let state = state.clone();
+            std::thread::spawn(move || {
+                let _g = state.upstream_transport_errors.lock().unwrap();
+                panic!("poison the transport-error mutex");
+            })
+            .join()
+            .unwrap_err();
+        }
+        assert!(state.upstream_transport_errors.is_poisoned());
+        {
+            let mut m = state.lock_transport_errors();
+            *m.entry("timeout").or_insert(0) += 3;
+        }
+        assert!(
+            !state.upstream_transport_errors.is_poisoned(),
+            "recovery must clear the poison, not just bypass it"
+        );
+        // Plain `lock()` sites (increments, metrics fallback) work again.
+        assert_eq!(
+            state
+                .upstream_transport_errors
+                .lock()
+                .unwrap()
+                .get("timeout"),
+            Some(&3)
+        );
     }
 
     /// AC3 (aggregate exposed): when the sync task has cached a fleet-wide

--- a/src/main.rs
+++ b/src/main.rs
@@ -1486,6 +1486,22 @@ const HARD_LIMIT_CLEARED_SENTINEL: u64 = 0;
 /// enough that the key does not linger past the intended recovery window.
 const HARD_LIMIT_SENTINEL_TTL_SECS: u64 = 60;
 
+/// Redis hash aggregating upstream transport send-failures across all replicas,
+/// keyed by kind (`timeout`/`connect`/`other`). Each replica flushes its local
+/// delta accumulator into this hash via `HINCRBY` every sync tick, so the
+/// dashboard/metrics endpoint reports a fleet-wide count rather than one pod's
+/// local observations. A single fixed key (not per-day like budgets) → one
+/// monotonic counter family that survives pod restarts.
+const TRANSPORT_ERRORS_KEY: &str = "alb:transport_errors";
+
+/// TTL refreshed on every flush of `TRANSPORT_ERRORS_KEY`. Chosen far larger
+/// than the 5s sync interval so the key never expires while any replica is
+/// alive (some pod re-`EXPIRE`s it every 5s). It only lapses once the ENTIRE
+/// fleet has been down for two days, at which point resetting the counter is
+/// correct — there is no live count left to preserve — and it prevents an
+/// orphaned key lingering forever after a permanent teardown.
+const TRANSPORT_ERRORS_TTL_SECS: u64 = 172_800;
+
 /// Maximum request body size (25 MB).
 const MAX_REQUEST_BODY_BYTES: usize = 25 * 1024 * 1024;
 
@@ -3140,10 +3156,82 @@ impl AppState {
             }
         }
 
-        // 4. Refresh cluster info cache for /_stats endpoint
+        // 4. Flush this replica's transport-error deltas into the shared Redis
+        //    hash so the fleet-wide by-kind count is visible cluster-wide.
+        //    Drains the local accumulator; the cluster_info refresh below then
+        //    reads the freshly-flushed total back via HGETALL.
+        self.flush_transport_errors().await;
+
+        // 5. Refresh cluster info cache for /_stats endpoint
         let info = self.cluster_info().await;
         if let Ok(mut cache) = self.cluster_info_cache.lock() {
             *cache = info;
+        }
+    }
+
+    /// Flush this replica's accumulated transport-error deltas into the shared
+    /// Redis hash (`TRANSPORT_ERRORS_KEY`) so the fleet-wide count is visible
+    /// cluster-wide. `upstream_transport_errors` is a DELTA accumulator: it is
+    /// drained here each tick and its counts folded into Redis via `HINCRBY`,
+    /// so the same delta is never pushed twice (no double-counting across
+    /// ticks). On Redis failure the drained deltas are returned to the local
+    /// map — they retry next tick and stay visible via the local metrics
+    /// fallback rather than being lost. No-op without Redis, so single-instance
+    /// deployments keep accumulating locally.
+    async fn flush_transport_errors(&self) {
+        let redis = match &self.redis {
+            Some(r) => r,
+            None => return,
+        };
+
+        // Drain the accumulator atomically: take the deltas AND reset to empty
+        // under one lock, so any increment arriving mid-flush belongs to the
+        // NEXT tick's delta and cannot be double-flushed. Recover a poisoned
+        // lock — a stale count must not wedge the flush loop forever.
+        let deltas: Vec<(&'static str, u64)> = {
+            let mut m = match self.upstream_transport_errors.lock() {
+                Ok(m) => m,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            m.drain().filter(|(_, n)| *n > 0).collect()
+        };
+        if deltas.is_empty() {
+            return;
+        }
+
+        // One round-trip: HINCRBY every kind, then refresh the TTL. Low-level
+        // cmd/arg form so this does not depend on generated fluent pipe methods.
+        let mut conn = redis.clone();
+        let mut pipe = redis::pipe();
+        for (kind, n) in &deltas {
+            pipe.cmd("HINCRBY")
+                .arg(TRANSPORT_ERRORS_KEY)
+                .arg(*kind)
+                .arg(*n)
+                .ignore();
+        }
+        pipe.cmd("EXPIRE")
+            .arg(TRANSPORT_ERRORS_KEY)
+            .arg(TRANSPORT_ERRORS_TTL_SECS)
+            .ignore();
+
+        let result: redis::RedisResult<()> = pipe.query_async(&mut conn).await;
+        if let Err(e) = result {
+            // Redis is unreachable (or the pipeline reply was lost) — return the
+            // drained deltas to the local accumulator so error signal is not
+            // dropped. This is at-least-once: if the connection died AFTER Redis
+            // applied some HINCRBYs, re-queuing can over-count by a few next
+            // tick. For an error *counter* that bias is correct — a slight
+            // over-report beats a silently missed egress fault. (Contrast
+            // record_budget_usage, which deletes-on-failure: over-counting a
+            // budget would wrongly throttle a client.) The deltas also stay
+            // visible via the local metrics fallback until Redis heals.
+            warn!(error = %e, "redis HINCRBY failed for transport errors; re-queuing deltas locally");
+            if let Ok(mut m) = self.upstream_transport_errors.lock() {
+                for (kind, n) in deltas {
+                    *m.entry(kind).or_insert(0) += n;
+                }
+            }
         }
     }
     async fn cluster_info(&self) -> Option<serde_json::Value> {
@@ -3207,11 +3295,41 @@ impl AppState {
             }
         }
 
-        Some(serde_json::json!({
-            "redis_connected": redis_ok,
-            "replicas_seen": replicas,
-            "budget_usage": redis_budgets,
-        }))
+        // Aggregate upstream transport errors from the shared Redis hash so the
+        // fleet-wide by-kind count surfaces on the dashboard/metrics endpoint.
+        // Only included when the HGETALL succeeds: its absence tells the metrics
+        // handler to fall back to this replica's local accumulator.
+        let mut transport_errors: Option<serde_json::Map<String, serde_json::Value>> = None;
+        if redis_ok {
+            match conn
+                .hgetall::<_, HashMap<String, u64>>(TRANSPORT_ERRORS_KEY)
+                .await
+            {
+                Ok(map) => {
+                    let mut te = serde_json::Map::new();
+                    for (kind, n) in map {
+                        te.insert(kind, serde_json::json!(n));
+                    }
+                    transport_errors = Some(te);
+                }
+                Err(e) => {
+                    warn!(error = %e, "redis HGETALL failed for transport-error aggregation");
+                    redis_ok = false;
+                }
+            }
+        }
+
+        let mut out = serde_json::Map::new();
+        out.insert("redis_connected".into(), serde_json::json!(redis_ok));
+        out.insert("replicas_seen".into(), serde_json::json!(replicas));
+        out.insert(
+            "budget_usage".into(),
+            serde_json::Value::Object(redis_budgets),
+        );
+        if let Some(te) = transport_errors {
+            out.insert("transport_errors".into(), serde_json::Value::Object(te));
+        }
+        Some(serde_json::Value::Object(out))
     }
 }
 
@@ -6819,16 +6937,31 @@ async fn metrics_handler(
         "counter",
         "Upstream transport send-failures by kind",
     );
-    let transport_errors: Vec<(&'static str, u64)> = state
-        .upstream_transport_errors
-        .lock()
-        .map(|m| m.iter().map(|(k, v)| (*k, *v)).collect())
-        .unwrap_or_default();
+    // Prefer the Redis fleet-wide aggregate (cached every 5s by the sync task)
+    // so multi-replica deployments report a cluster-wide count; fall back to the
+    // local accumulator when Redis is absent or the aggregate is unavailable
+    // (single-instance, pre-first-sync, or a Redis blip).
+    let transport_errors: Vec<(String, u64)> = cluster_info
+        .as_ref()
+        .and_then(|ci| ci.get("transport_errors"))
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_u64().map(|n| (k.clone(), n)))
+                .collect()
+        })
+        .unwrap_or_else(|| {
+            state
+                .upstream_transport_errors
+                .lock()
+                .map(|m| m.iter().map(|(k, v)| (k.to_string(), *v)).collect())
+                .unwrap_or_default()
+        });
     for (kind, n) in transport_errors {
         prom_counter(
             &mut buf,
             "anthropic_upstream_transport_errors_total",
-            &[("kind", kind)],
+            &[("kind", kind.as_str())],
             n,
         );
     }
@@ -13179,6 +13312,69 @@ token = "sk-ant-test"
         assert!(
             m.contains("anthropic_upstream_transport_errors_total{kind="),
             "by-kind transport-error counter must appear after a transport failure:\n{m}"
+        );
+    }
+
+    /// AC4 (graceful without Redis): a single-instance deployment has no Redis,
+    /// so `flush_transport_errors` must be a no-op that leaves the local
+    /// accumulator intact — otherwise local `/metrics` counts would vanish.
+    #[tokio::test]
+    async fn flush_transport_errors_noop_without_redis() {
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-aaa")]);
+        {
+            let mut m = state.upstream_transport_errors.lock().unwrap();
+            m.insert("timeout", 3);
+            m.insert("connect", 1);
+        }
+        state.flush_transport_errors().await;
+        let m = state.upstream_transport_errors.lock().unwrap();
+        assert_eq!(
+            m.get("timeout"),
+            Some(&3),
+            "local accumulator must be retained without redis"
+        );
+        assert_eq!(m.get("connect"), Some(&1));
+    }
+
+    /// AC3 (aggregate exposed): when the sync task has cached a fleet-wide
+    /// aggregate, `/metrics` must report THOSE counts (cluster-wide), not this
+    /// replica's local unflushed delta. Proves the Redis view supersedes local.
+    #[tokio::test]
+    async fn metrics_prefer_redis_transport_error_aggregate() {
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-aaa")]);
+        // A local (unflushed) delta that must be SUPERSEDED by the fleet view.
+        state
+            .upstream_transport_errors
+            .lock()
+            .unwrap()
+            .insert("timeout", 2);
+        // Simulate the sync task having cached a fleet-wide aggregate.
+        *state.cluster_info_cache.lock().unwrap() = Some(serde_json::json!({
+            "redis_connected": true,
+            "replicas_seen": 3,
+            "transport_errors": { "timeout": 40, "connect": 5 },
+        }));
+        let addr = serve(build_router(state)).await;
+        let c = reqwest::Client::new();
+        let m = c
+            .get(format!("http://{addr}/metrics"))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        assert!(
+            m.contains("anthropic_upstream_transport_errors_total{kind=\"timeout\"} 40"),
+            "fleet aggregate (40) must win over local delta (2):\n{m}"
+        );
+        assert!(
+            m.contains("anthropic_upstream_transport_errors_total{kind=\"connect\"} 5"),
+            "fleet aggregate must include all kinds:\n{m}"
+        );
+        assert!(
+            !m.contains("anthropic_upstream_transport_errors_total{kind=\"timeout\"} 2"),
+            "local delta must not leak once the fleet aggregate is present:\n{m}"
         );
     }
 


### PR DESCRIPTION
Resolves LAB-366 (mirror of #76).

## Problem
`upstream_transport_errors` (introduced in #72) is process-scoped, so `anthropic_upstream_transport_errors_total` only reflects one replica's observations. Operators can't read the fleet-wide egress error rate without summing across instances externally.

## Change
- The in-process `Mutex<HashMap<kind, u64>>` becomes a per-tick **delta accumulator**.
- `sync_from_redis` drains it each 5s tick and folds the counts into a shared Redis hash `alb:transport_errors` via a pipelined `HINCRBY` (+ `EXPIRE` refresh), consistent with the existing budget/rate/hard-limit sync path.
- `cluster_info` reads the hash back via `HGETALL`; `/metrics` and `/_stats` surface the fleet aggregate, **falling back to the local accumulator** when Redis is absent or unavailable.

## Acceptance criteria
- [x] Per-kind counts flushed to a shared Redis hash each sync tick (`HINCRBY`).
- [x] Local map retained as accumulator, drained each tick — no double-count across ticks.
- [x] Aggregated value exposed from Redis in the metrics/dashboard endpoint.
- [x] Graceful without Redis — single-instance still reports local counts.

## Notes / second-order effects
- **Metric semantics shift:** `anthropic_upstream_transport_errors_total` now reports the *fleet total* on every replica (pre-aggregated in-app, per the issue's intent) rather than per-pod local counts. A pre-existing `sum()` across pods in Prometheus would now over-count by replica-count — read the value as-is (or `max()`), not `sum()`. Flagging in case a dashboard query needs updating.
- **At-least-once flush:** on a Redis failure mid-pipeline, drained deltas are re-queued locally (may over-count by a few). Deliberate — over-reporting an egress fault is safer than dropping the signal; contrast `record_budget_usage`'s delete-on-failure, where over-counting a budget would wrongly throttle a client.
- **No security-sensitive surface:** no auth, token-forwarding, redirect/endpoint validation, or routing math touched — pure observability aggregation. Hash field names are static (`timeout`/`connect`/`other`), values are `u64`, and labels are `prom_escape`d on exposition.

## Testing
`cargo fmt --check`, `RUSTFLAGS=-Dwarnings cargo clippy --all-targets`, and the full suite (448 tests) all green. Added `flush_transport_errors_noop_without_redis` (AC4) and `metrics_prefer_redis_transport_error_aggregate` (AC3). The Redis write path itself is exercised by the same low-level pipeline pattern as the existing SCAN/budget code (this repo has no Redis mock harness — a known test gap, not introduced here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fleet-wide aggregation of upstream transport send-failure metrics by error type.
  * Cluster information and the metrics endpoint now use shared transport-error totals when available.
* **Bug Fixes**
  * Improved resilience when aggregation services are unavailable by retaining local error data and using it for metrics.
  * Ensured transport-error deltas aren’t lost if synchronisation/aggregation fails.
* **Tests**
  * Added coverage for no-Redis behaviour, recovery from poisoned locking, and metrics preferring fleet-wide cached totals over local pending values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->