### PR TITLE
LAB-466: recover poisoned lock in /metrics transport-error fallback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7285,10 +7285,10 @@ async fn metrics_handler(
         })
         .unwrap_or_else(|| {
             state
-                .upstream_transport_errors
-                .lock()
-                .map(|m| m.iter().map(|(k, v)| (k.to_string(), *v)).collect())
-                .unwrap_or_default()
+                .lock_transport_errors()
+                .iter()
+                .map(|(k, v)| (k.to_string(), *v))
+                .collect()
         });
     for (kind, n) in transport_errors {
         prom_counter(
@@ -14058,6 +14058,51 @@ token = "sk-ant-test"
         assert!(
             !m.contains("anthropic_upstream_transport_errors_total{kind=\"timeout\"} 2"),
             "local delta must not leak once the fleet aggregate is present:\n{m}"
+        );
+    }
+
+    /// LAB-466: the `/metrics` local-fallback branch must recover a poisoned
+    /// `upstream_transport_errors` lock instead of reporting zero. Poisons the
+    /// mutex directly (not via `lock_transport_errors()`) so this proves the
+    /// FALLBACK itself recovers, not just the helper in isolation.
+    #[tokio::test]
+    async fn metrics_local_fallback_recovers_poisoned_lock() {
+        let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-aaa")]);
+        // Seed local counts, then poison the mutex from a panicking thread —
+        // bypassing `lock_transport_errors()` so the poison isn't pre-cleared.
+        state
+            .upstream_transport_errors
+            .lock()
+            .unwrap()
+            .insert("timeout", 40);
+        {
+            let state = state.clone();
+            std::thread::spawn(move || {
+                let _g = state.upstream_transport_errors.lock().unwrap();
+                panic!("poison the transport-error mutex");
+            })
+            .join()
+            .unwrap_err();
+        }
+        assert!(state.upstream_transport_errors.is_poisoned());
+        // No fleet aggregate cached, so /metrics must take the local fallback path.
+        assert!(state.cluster_info_cache.lock().unwrap().is_none());
+
+        let addr = serve(build_router(state)).await;
+        let c = reqwest::Client::new();
+        let resp = c
+            .get(format!("http://{addr}/metrics"))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "metrics endpoint must stay usable after a poisoned lock"
+        );
+        let m = resp.text().await.unwrap();
+        assert!(
+            m.contains("anthropic_upstream_transport_errors_total{kind=\"timeout\"} 40"),
+            "poisoned local counts must survive the fallback, not be reported as zero:\n{m}"
         );
     }
 


### PR DESCRIPTION
## Problem
CR feedback on PR #88 (merged as b8907a1, GH #76 / LAB-366) flagged that the `/metrics` local-fallback branch for `anthropic_upstream_transport_errors_total` reads `state.upstream_transport_errors.lock().map(...).unwrap_or_default()`. On a poisoned mutex `lock()` returns `Err`, so `unwrap_or_default()` silently returns an empty map — `/metrics` reports zero transport errors in single-instance deployments exactly when a panic (which poisons the lock) has occurred.

Every other lock site already recovers via `AppState::lock_transport_errors()` (clears poison + `into_inner()`) or degrades gracefully with `if let Ok`. This was the one site returning silently-wrong data.

Note: PR #88 merged into `main` shortly before this ticket (LAB-466) was created, so this lands as a stacked follow-up PR rather than a commit on #88's now-closed branch, per the ticket's fallback instructions.

## Change
- `/metrics` fallback now calls `state.lock_transport_errors()` instead of the raw `.lock()...unwrap_or_default()`. Behavior otherwise unchanged (map→vector conversion, empty map ⇒ no counter lines, Redis-aggregate-preferred path untouched).
- New regression test `metrics_local_fallback_recovers_poisoned_lock`: poisons the mutex directly from a panicking thread (bypassing the helper), leaves `cluster_info_cache` empty to force the local-fallback path, issues a real `GET /metrics`, and asserts the response is served and the poisoned local counts are exposed. Verified this test fails against the pre-fix raw-lock fallback and passes after the fix.

## Out of scope (per LAB-466)
- The two write-path increment sites (`if let Ok(mut m) = ...lock()`) — they degrade gracefully by design (skip one increment on poison, never wedge or return wrong data). CR finding didn't name them.
- Redis sync / `flush_transport_errors` semantics — unchanged.
- No auth/token-forwarding/redirect/routing surface touched — no security review gate needed.

## Testing
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and full `cargo test` (439 unit + 18 config + 30 dependency/other) all green.