### PR TITLE
fix: non-streaming requests bypass the SSE-tuned read_timeout (LAB-718)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Operational notes that affect the code:
 
 ## Architecture
 
-Single-file Rust binary (`src/main.rs`, ~12000 lines) with inline tests. No library crate — everything lives in one file with section markers.
+Single Rust binary: all implementation in `src/main.rs` (~9800 lines) with section markers; tests live in `src/tests.rs`, wired in as `#[path = "tests.rs"] mod tests;` (extracted from inline in LAB-367/#93). No library crate.
 
 ### Core Data Flow
 
@@ -59,7 +59,7 @@ Request → IP allowlist check → proxy_key auth → pre_request_gate(operator 
 | **Auto-cache** (`inject_cache_breakpoints`) | Injects up to 3 prompt cache breakpoints (last tool, system, last user message) unless cache_control already present |
 | **Handlers** | Four axum handlers: `proxy_handler` (main Anthropic proxy), `stats_handler` (`/_stats` JSON), `metrics_handler` (`/metrics` Prometheus), `openai_chat_handler` (OpenAI→Anthropic format translation) |
 | **OpenAI compatibility** (`translate_*`, `StreamContext`) | Translates `/v1/chat/completions` requests/responses between OpenAI and Anthropic formats, including streaming SSE |
-| **Tests** (`mod tests`) | Inline at bottom — unit + integration tests using mock upstream servers |
+| **Tests** (`mod tests` → `src/tests.rs`) | Unit + integration tests using mock upstream servers |
 
 ### Endpoint Selection (`pick_endpoint`)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,6 +508,15 @@ impl Endpoint {
 
 struct AppState {
     client: Client,
+    /// Upstream client for NON-streaming requests (`"stream"` false/absent).
+    /// A non-streaming `/v1/messages` emits ZERO response bytes until
+    /// generation completes, so `client`'s read_timeout — tuned for SSE
+    /// inter-chunk silence — kills any generation longer than 180s as
+    /// "operation timed out" (LAB-718 GEO judge wedge, 2026-07-24: ~20k-token
+    /// structured-output calls died 18×/hour across 9 accounts and the SDK
+    /// retried for hours). No read_timeout here; the 900s total budget is the
+    /// only cap, and the h2 keep-alive PING still evicts dead connections.
+    client_nonstreaming: Client,
     /// Unified routing endpoints — the sole endpoint pool.
     endpoints: Vec<Endpoint>,
     robin: AtomicUsize,
@@ -4880,6 +4889,34 @@ fn exhaustion_response(last_saw_transient: bool, last_saw_529: bool) -> Response
 /// detached 'static task that must re-borrow the endpoint from a cloned
 /// Arc<AppState> — a borrowed &Endpoint cannot cross the spawn boundary,
 /// so the task captures the Copy `endpoint_idx` and re-indexes.
+/// Shared knob chain for both upstream clients — `client` layers the SSE-tuned
+/// `read_timeout` on top; `client_nonstreaming` takes it as-is (LAB-718).
+fn upstream_client_builder() -> reqwest::ClientBuilder {
+    Client::builder()
+        .timeout(Duration::from_secs(900))
+        // 4s (was 10): a blackholed connect fails fast so the transient
+        // backoff-retry recovers in seconds. pool_idle_timeout stays 300s —
+        // it keeps conns warm across Claude Code think-pauses.
+        .connect_timeout(Duration::from_secs(4))
+        .tcp_keepalive(Duration::from_secs(30))
+        .http2_keep_alive_interval(Duration::from_secs(20))
+        .http2_keep_alive_timeout(Duration::from_secs(10))
+        .http2_keep_alive_while_idle(true)
+        .pool_idle_timeout(Duration::from_secs(300))
+}
+
+/// True when the request body asks for SSE (`"stream": true`). Absent flag or
+/// an unparseable body counts as non-streaming — Anthropic's default. Parsing
+/// the body again here (it was already parsed for fingerprints/cache
+/// injection) costs microseconds against a multi-second LLM call and keeps
+/// the wide `forward_anthropic` signature unchanged.
+fn request_wants_stream(body: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v.get("stream").and_then(|s| s.as_bool()))
+        .unwrap_or(false)
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn forward_anthropic(
     state: &Arc<AppState>,
@@ -4911,7 +4948,15 @@ async fn forward_anthropic(
             .unwrap_or("/")
     );
 
-    let mut upstream_req = state.client.request(parts.method.clone(), &url);
+    // Non-streaming requests get the client WITHOUT the SSE-tuned read_timeout:
+    // their only response bytes arrive when generation completes, so a
+    // read_timeout is a de-facto 180s cap on generation time (LAB-718).
+    let http_client = if request_wants_stream(body_bytes) {
+        &state.client
+    } else {
+        &state.client_nonstreaming
+    };
+    let mut upstream_req = http_client.request(parts.method.clone(), &url);
 
     // Forward headers
     let mut headers = parts.headers.clone();
@@ -5605,8 +5650,13 @@ async fn try_fallback_upstream(
 
     let url = format!("{}/v1/chat/completions", ep.base_url);
 
-    let mut resp = match state
-        .client
+    // Same non-streaming read_timeout exemption as forward_anthropic (LAB-718).
+    let http_client = if is_streaming {
+        &state.client
+    } else {
+        &state.client_nonstreaming
+    };
+    let mut resp = match http_client
         .post(&url)
         .header("authorization", format!("Bearer {}", ep.token))
         .header("content-type", "application/json")
@@ -8598,8 +8648,13 @@ async fn forward_openai_compat_anthropic(
         "openai-compat: upstream request"
     );
 
-    let upstream_req = state
-        .client
+    // Same non-streaming read_timeout exemption as forward_anthropic (LAB-718).
+    let http_client = if is_streaming {
+        &state.client
+    } else {
+        &state.client_nonstreaming
+    };
+    let upstream_req = http_client
         .request(reqwest::Method::POST, &url)
         .headers(headers)
         .body(body_str);
@@ -9500,20 +9555,17 @@ async fn main() {
         // handshake on every burst. read_timeout is set at 180s so Opus's
         // extended-thinking pauses (which can exceed 90s of inter-chunk
         // silence on deep reasoning) don't trip a false-positive interruption.
-        client: Client::builder()
-            .timeout(Duration::from_secs(900))
+        client: upstream_client_builder()
             .read_timeout(Duration::from_secs(180))
-            // 4s (was 10): a blackholed connect fails fast so the transient
-            // backoff-retry recovers in seconds. pool_idle_timeout stays 300s —
-            // it keeps conns warm across Claude Code think-pauses (see above).
-            .connect_timeout(Duration::from_secs(4))
-            .tcp_keepalive(Duration::from_secs(30))
-            .http2_keep_alive_interval(Duration::from_secs(20))
-            .http2_keep_alive_timeout(Duration::from_secs(10))
-            .http2_keep_alive_while_idle(true)
-            .pool_idle_timeout(Duration::from_secs(300))
             .build()
             .expect("failed to build HTTP client"),
+        // Same knobs MINUS read_timeout: a non-streaming response has no
+        // inter-chunk cadence to police — the only bytes arrive when
+        // generation finishes, so a read_timeout is a hard cap on generation
+        // time (LAB-718). The 900s total budget still bounds the request.
+        client_nonstreaming: upstream_client_builder()
+            .build()
+            .expect("failed to build non-streaming HTTP client"),
         endpoints,
         robin: AtomicUsize::new(0),
         routing_strategy,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -297,6 +297,10 @@ fn test_state_base() -> AppState {
             .timeout(Duration::from_secs(5))
             .build()
             .unwrap(),
+        client_nonstreaming: Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap(),
         endpoints: vec![],
         robin: AtomicUsize::new(0),
         routing_strategy: RoutingStrategy::default(),
@@ -8821,6 +8825,7 @@ fn resolve_client_id_falls_back_to_ip_map() {
     client_names.insert("192.168.1.100".to_string(), "mapped-client".to_string());
     let state = Arc::new(AppState {
         client: Client::new(),
+        client_nonstreaming: Client::new(),
         endpoints: vec![mk_endpoint("a", "sk-ant-api-x")],
         state_path: PathBuf::from("/tmp/test.state.json"),
         client_names,
@@ -8870,6 +8875,7 @@ fn resolve_client_id_ignores_dash_header() {
 fn compute_pressure_status_operator_always_healthy() {
     let state = Arc::new(AppState {
         client: Client::new(),
+        client_nonstreaming: Client::new(),
         state_path: PathBuf::from("/tmp/test.state.json"),
         operators: vec!["operator-id".to_string()],
         ..test_state_base()
@@ -8898,6 +8904,7 @@ fn compute_pressure_status_limit_proximity_upgrade() {
     limits.insert("client".to_string(), 0.80);
     let state = Arc::new(AppState {
         client: Client::new(),
+        client_nonstreaming: Client::new(),
         state_path: PathBuf::from("/tmp/test.state.json"),
         client_utilization_limits: limits,
         ..test_state_base()
@@ -9600,6 +9607,7 @@ async fn pick_endpoint_openai_is_last_resort() {
 fn is_operator_checks_configured_operator() {
     let state = Arc::new(AppState {
         client: Client::new(),
+        client_nonstreaming: Client::new(),
         state_path: PathBuf::from("/tmp/test.state.json"),
         operators: vec!["special-operator".to_string()],
         ..test_state_base()
@@ -9619,6 +9627,7 @@ fn is_operator_returns_false_when_no_operator_configured() {
 fn is_operator_supports_multiple_operators() {
     let state = Arc::new(AppState {
         client: Client::new(),
+        client_nonstreaming: Client::new(),
         state_path: PathBuf::from("/tmp/test.state.json"),
         operators: vec![
             "ray".to_string(),
@@ -13092,4 +13101,51 @@ async fn streaming_upstream_disconnect_emits_sse_error_to_client() {
         body_s.contains("\"type\":\"api_error\""),
         "error frame must use Anthropic's documented api_error type, got: {body_s:?}"
     );
+}
+
+// ── LAB-718: non-streaming requests must not ride the SSE-tuned read_timeout ──
+//
+// A non-streaming /v1/messages emits zero response bytes until generation
+// completes; `client`'s read_timeout (180s, tuned for SSE inter-chunk silence)
+// therefore capped generation time and killed the GEO semantic judge's long
+// structured-output calls ("operation timed out", 2026-07-24). Routing keys on
+// the request body's `stream` flag via `request_wants_stream`.
+
+#[test]
+fn request_wants_stream_true_only_for_explicit_stream_true() {
+    assert!(request_wants_stream(br#"{"stream":true,"model":"m"}"#));
+    assert!(!request_wants_stream(br#"{"stream":false,"model":"m"}"#));
+    assert!(
+        !request_wants_stream(br#"{"model":"m"}"#),
+        "absent flag = Anthropic's non-streaming default"
+    );
+    assert!(
+        !request_wants_stream(br#"{"stream":"true"}"#),
+        "non-bool stream is not a stream request"
+    );
+    assert!(
+        !request_wants_stream(b"not json"),
+        "unparseable body counts as non-streaming"
+    );
+    assert!(
+        !request_wants_stream(b""),
+        "empty body counts as non-streaming"
+    );
+}
+
+#[test]
+fn nonstreaming_client_has_no_read_timeout_but_streaming_client_does() {
+    // Structural guard: both clients build from the shared knob chain; only the
+    // streaming client layers read_timeout on top. reqwest doesn't expose its
+    // config, so assert the builders construct successfully and are distinct —
+    // the load-bearing difference is pinned by the builder call sites in main().
+    let streaming = upstream_client_builder()
+        .read_timeout(Duration::from_secs(180))
+        .build()
+        .expect("streaming client builds");
+    let nonstreaming = upstream_client_builder()
+        .build()
+        .expect("non-streaming client builds");
+    // Client is Arc-backed; two builds are distinct pools.
+    assert!(!std::ptr::eq(&streaming, &nonstreaming));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13134,18 +13134,16 @@ fn request_wants_stream_true_only_for_explicit_stream_true() {
 }
 
 #[test]
-fn nonstreaming_client_has_no_read_timeout_but_streaming_client_does() {
+fn upstream_client_builder_composes_with_and_without_read_timeout() {
     // Structural guard: both clients build from the shared knob chain; only the
     // streaming client layers read_timeout on top. reqwest doesn't expose its
-    // config, so assert the builders construct successfully and are distinct —
-    // the load-bearing difference is pinned by the builder call sites in main().
-    let streaming = upstream_client_builder()
+    // config, so all this can assert is that both builders construct — the
+    // load-bearing read_timeout split is pinned by the call sites in main().
+    let _streaming = upstream_client_builder()
         .read_timeout(Duration::from_secs(180))
         .build()
         .expect("streaming client builds");
-    let nonstreaming = upstream_client_builder()
+    let _nonstreaming = upstream_client_builder()
         .build()
         .expect("non-streaming client builds");
-    // Client is Arc-backed; two builds are distinct pools.
-    assert!(!std::ptr::eq(&streaming, &nonstreaming));
 }


### PR DESCRIPTION
## Why

The LAB-718 GEO judge wedge (2026-07-24): the pipeline's semantic judge sends ~20k-token structured-output `/v1/messages` calls **non-streaming**. A non-streaming response delivers zero bytes until generation completes — so the upstream client's `read_timeout(180s)`, tuned to catch mid-stream SSE stalls without false-positives on Opus thinking pauses, silently became a **180s cap on generation time**. Every judge attempt died as `upstream request failed … operation timed out` (18×/hour across 9 accounts, `saw_529=false` in pod logs), the client SDK retried indefinitely, and a 4-technique batch wedged for 3+ hours.

## Fix

- `AppState.client_nonstreaming`: second upstream client from the same shared knob chain (`upstream_client_builder()`) **minus** `read_timeout`. The 900s total budget still bounds the request; h2 keep-alive PING still evicts dead connections.
- `request_wants_stream(body)`: explicit `"stream": true` only; absent / `false` / non-bool / unparseable ⇒ non-streaming (Anthropic's default).
- Client selection applied at all three upstream send sites: `forward_anthropic`, the openai-compat translation path (uses its existing `is_streaming`), and `forward_openai_compat_anthropic`.
- **Streaming traffic (Claude Code) keeps the exact current behavior** — same client, same 180s inter-chunk policing.

## Verification

- `cargo test`: 473 passed (443 + 18 + 12), including 2 new tests (`request_wants_stream` truth table incl. non-bool/garbage bodies; builder split guard).
- `cargo clippy --all-targets` clean (`-D warnings` pre-commit hook passing; `forward_anthropic`'s pre-existing `too_many_arguments` allow retained).

## Companion

Client-side half: Insight-Timer/ambient-intelligence#386 makes the GEO pipeline stream every call — but the LB must independently stop killing long non-streaming calls from any other client.

## Deploy note

Needs an image build + rollout to the `lab` cluster (`mcp` ns) after merge — not done here.

Closes LAB-718 (LB half).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for non-streaming requests by applying the correct timeout behaviour separate from streaming calls.
  * Requests now more reliably route to the correct handling based on whether the request payload explicitly asks for streaming.

* **Tests**
  * Added regression coverage for stream detection (true only when `stream: true`; otherwise not requested).
  * Added tests to confirm streaming vs non-streaming requests use the appropriate client configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->