### PR TITLE
LAB-717: perf — extract streaming usage incrementally, drop whole-stream SSE buffers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3745,49 +3745,15 @@ impl TokenUsage {
         }
     }
 
-    /// Parse usage from SSE chunks (accumulated from streaming response).
-    /// Looks for message_start (input_tokens, cache tokens) and message_delta (output_tokens).
+    /// Parse usage from a complete SSE transcript. Test convenience wrapper —
+    /// production streaming paths feed chunks through `SseUsageScanner`
+    /// incrementally instead of buffering the stream.
+    #[cfg(test)]
     fn from_sse_text(text: &str) -> Self {
-        let mut usage = Self::default();
-        for line in text.lines() {
-            let line = line.trim();
-            if !line.starts_with("data: ") {
-                continue;
-            }
-            let data = &line[6..];
-            let Ok(event) = serde_json::from_str::<serde_json::Value>(data) else {
-                continue;
-            };
-            let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
-            match event_type {
-                "message_start" => {
-                    if let Some(msg_usage) = event.get("message").and_then(|m| m.get("usage")) {
-                        usage.input_tokens = msg_usage
-                            .get("input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        usage.cache_creation_input_tokens = msg_usage
-                            .get("cache_creation_input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        usage.cache_read_input_tokens = msg_usage
-                            .get("cache_read_input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                    }
-                }
-                "message_delta" => {
-                    if let Some(delta_usage) = event.get("usage") {
-                        usage.output_tokens = delta_usage
-                            .get("output_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                    }
-                }
-                _ => {}
-            }
-        }
-        usage
+        let mut scanner = SseUsageScanner::default();
+        scanner.push(text.as_bytes());
+        scanner.finish();
+        scanner.usage
     }
 
     fn is_empty(&self) -> bool {
@@ -3795,6 +3761,124 @@ impl TokenUsage {
             && self.output_tokens == 0
             && self.cache_creation_input_tokens == 0
             && self.cache_read_input_tokens == 0
+    }
+}
+
+/// Cap on the partial-line carry held between chunks by `SseUsageScanner`.
+/// Usage-bearing lines (`message_start` / `message_delta`) are well under
+/// 1 KiB; anything larger is content we don't need, and a malformed upstream
+/// must not be able to grow the carry without bound (LAB-717).
+const SSE_SCAN_MAX_LINE: usize = 64 * 1024;
+
+/// Incremental SSE token-usage extractor: O(1) memory per in-flight stream.
+///
+/// Replaces the old whole-stream `sse_buf` / `raw_sse` accumulation (LAB-717):
+/// each upstream chunk is line-scanned as it passes through, keeping only a
+/// capped partial-line carry, the running `TokenUsage` (last `message_start` /
+/// `message_delta` wins, matching the old post-hoc parse), and bounded event
+/// metadata for the `stream_end_no_usage` diagnostic.
+#[derive(Default)]
+struct SseUsageScanner {
+    usage: TokenUsage,
+    /// Bytes of the current line seen so far, awaiting its `\n`.
+    carry: Vec<u8>,
+    /// Set when a line overflows `SSE_SCAN_MAX_LINE`; the rest of that line
+    /// is discarded up to the next newline.
+    skipping_oversized_line: bool,
+    /// First five `event:` types, for the `stream_end_no_usage` preview.
+    event_preview: Vec<String>,
+    event_count: usize,
+    bytes_seen: usize,
+}
+
+impl SseUsageScanner {
+    fn push(&mut self, chunk: &[u8]) {
+        self.bytes_seen = self.bytes_seen.saturating_add(chunk.len());
+        let mut rest = chunk;
+        while let Some(nl) = rest.iter().position(|&b| b == b'\n') {
+            let (head, tail) = rest.split_at(nl);
+            rest = &tail[1..];
+            if self.skipping_oversized_line {
+                // `head` is the tail of a discarded oversized line.
+                self.skipping_oversized_line = false;
+            } else if self.carry.is_empty() {
+                self.scan_line(head);
+            } else {
+                self.carry.extend_from_slice(head);
+                let line = std::mem::take(&mut self.carry);
+                self.scan_line(&line);
+                self.carry = line;
+                self.carry.clear(); // reuse the allocation, drop the contents
+            }
+        }
+        if rest.is_empty() || self.skipping_oversized_line {
+            return;
+        }
+        self.carry.extend_from_slice(rest);
+        if self.carry.len() > SSE_SCAN_MAX_LINE {
+            self.carry = Vec::new();
+            self.skipping_oversized_line = true;
+        }
+    }
+
+    /// Flush the trailing unterminated line (a stream may not end with `\n`).
+    fn finish(&mut self) {
+        if !self.carry.is_empty() {
+            let line = std::mem::take(&mut self.carry);
+            self.scan_line(&line);
+        }
+    }
+
+    fn scan_line(&mut self, raw: &[u8]) {
+        let line = String::from_utf8_lossy(raw);
+        let line = line.trim();
+        if let Some(ev) = line.strip_prefix("event:") {
+            self.event_count += 1;
+            if self.event_preview.len() < 5 {
+                self.event_preview.push(ev.trim_start().to_string());
+            }
+            return;
+        }
+        let Some(data) = line.strip_prefix("data: ") else {
+            return;
+        };
+        // Cheap pre-filter: only usage-bearing event types are worth a JSON
+        // parse, and their type string must appear literally in the payload.
+        // False positives (a content delta mentioning "message_start") fall
+        // through to the type match below and are ignored, same as before.
+        if !data.contains("message_start") && !data.contains("message_delta") {
+            return;
+        }
+        let Ok(event) = serde_json::from_str::<serde_json::Value>(data) else {
+            return;
+        };
+        match event.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+            "message_start" => {
+                if let Some(msg_usage) = event.get("message").and_then(|m| m.get("usage")) {
+                    self.usage.input_tokens = msg_usage
+                        .get("input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    self.usage.cache_creation_input_tokens = msg_usage
+                        .get("cache_creation_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    self.usage.cache_read_input_tokens = msg_usage
+                        .get("cache_read_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                }
+            }
+            "message_delta" => {
+                if let Some(delta_usage) = event.get("usage") {
+                    self.usage.output_tokens = delta_usage
+                        .get("output_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                }
+            }
+            _ => {}
+        }
     }
 }
 
@@ -3962,18 +4046,18 @@ async fn finalize_stream(
     agent: &str,
     session: &str,
     status_code: u16,
-    sse_buf: &[u8],
+    mut scanner: SseUsageScanner,
     request_start: std::time::Instant,
     client_disconnected: bool,
     upstream_error: bool,
     openai_compat: bool,
 ) {
-    let text = String::from_utf8_lossy(sse_buf);
-    let usage = TokenUsage::from_sse_text(&text);
+    scanner.finish();
+    let usage = &scanner.usage;
     let elapsed_ms = request_start.elapsed().as_millis() as u64;
     if !usage.is_empty() {
-        state.record_usage(ep, client_id, &usage).await;
-        log_usage(req_id, client_id, model, acct_name, &usage);
+        state.record_usage(ep, client_id, usage).await;
+        log_usage(req_id, client_id, model, acct_name, usage);
     } else {
         let reason = if upstream_error {
             "upstream_error"
@@ -3983,17 +4067,7 @@ async fn finalize_stream(
             "no_usage_event"
         };
         // Log structural metadata only — SSE payloads contain user content.
-        let sse_text = String::from_utf8_lossy(sse_buf);
-        let sse_event_types: Vec<&str> = sse_text
-            .lines()
-            .filter_map(|l| {
-                l.strip_prefix("event: ")
-                    .or_else(|| l.strip_prefix("event:"))
-            })
-            .collect();
-        let total_events = sse_event_types.len();
-        let truncated = total_events > 5;
-        let preview: Vec<&str> = sse_event_types.into_iter().take(5).collect();
+        let truncated = scanner.event_count > 5;
         warn!(
             req_id,
             client_id,
@@ -4001,9 +4075,9 @@ async fn finalize_stream(
             account = acct_name,
             reason,
             elapsed_ms,
-            sse_bytes = sse_buf.len(),
-            sse_event_count = total_events,
-            sse_events = ?preview,
+            sse_bytes = scanner.bytes_seen,
+            sse_event_count = scanner.event_count,
+            sse_events = ?scanner.event_preview,
             truncated,
             "stream_end_no_usage"
         );
@@ -5166,13 +5240,13 @@ async fn forward_anthropic(
         let status_code = status.as_u16();
 
         tokio::spawn(async move {
-            let mut sse_buf = Vec::new();
+            let mut scanner = SseUsageScanner::default();
             let mut client_disconnected = false;
             let mut upstream_error = false;
             loop {
                 match resp.chunk().await {
                     Ok(Some(chunk)) => {
-                        sse_buf.extend_from_slice(&chunk);
+                        scanner.push(&chunk);
                         if tx.send(Ok(chunk)).await.is_err() {
                             client_disconnected = true;
                             break;
@@ -5195,8 +5269,8 @@ async fn forward_anthropic(
                     }
                 }
             }
-            // Parse accumulated SSE data for usage. The detached task only
-            // holds a cloned Arc<AppState>; re-index it to recover &Endpoint.
+            // Record scanned usage. The detached task only holds a cloned
+            // Arc<AppState>; re-index it to recover &Endpoint.
             let ep = &state_clone.endpoints[endpoint_idx];
             finalize_stream(
                 &state_clone,
@@ -5209,7 +5283,7 @@ async fn forward_anthropic(
                 &agent_clone,
                 &session_clone,
                 status_code,
-                &sse_buf,
+                scanner,
                 request_start,
                 client_disconnected,
                 upstream_error,
@@ -8841,7 +8915,7 @@ async fn forward_openai_compat_anthropic(
 
         tokio::spawn(async move {
             let mut buffer: Vec<u8> = Vec::new();
-            let mut raw_sse: Vec<u8> = Vec::new();
+            let mut scanner = SseUsageScanner::default();
             let mut ctx = StreamContext::default();
             let mut sent_done = false;
 
@@ -8851,8 +8925,8 @@ async fn forward_openai_compat_anthropic(
             loop {
                 match resp.chunk().await {
                     Ok(Some(chunk)) => {
+                        scanner.push(&chunk);
                         buffer.extend_from_slice(&chunk);
-                        raw_sse.extend_from_slice(&chunk);
 
                         while let Some(pos) = buffer.windows(2).position(|w| w == b"\n\n") {
                             let event = String::from_utf8_lossy(&buffer[..pos]).into_owned();
@@ -8926,7 +9000,7 @@ async fn forward_openai_compat_anthropic(
                 client_gone = true;
             }
 
-            // Extract and record token usage from accumulated SSE data. The
+            // Record token usage scanned from the raw upstream SSE. The
             // detached task only holds a cloned Arc<AppState>; re-index it.
             let ep = &state_clone.endpoints[endpoint_idx];
             finalize_stream(
@@ -8940,7 +9014,7 @@ async fn forward_openai_compat_anthropic(
                 &agent_clone,
                 &session_clone,
                 status_code,
-                &raw_sse,
+                scanner,
                 request_start,
                 client_gone,
                 upstream_error,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3764,10 +3764,11 @@ impl TokenUsage {
     }
 }
 
-/// Cap on the partial-line carry held between chunks by `SseUsageScanner`.
-/// Usage-bearing lines (`message_start` / `message_delta`) are well under
-/// 1 KiB; anything larger is content we don't need, and a malformed upstream
-/// must not be able to grow the carry without bound (LAB-717).
+/// Cap on any single SSE line `SseUsageScanner` will hold or scan — applied
+/// uniformly whether the line completes within one chunk or is carried across
+/// chunks. Usage-bearing lines (`message_start` / `message_delta`) are well
+/// under 1 KiB; anything larger is content we don't need, and a malformed
+/// upstream must not be able to grow scanner memory without bound (LAB-717).
 const SSE_SCAN_MAX_LINE: usize = 64 * 1024;
 
 /// Incremental SSE token-usage extractor: O(1) memory per in-flight stream.
@@ -3801,6 +3802,11 @@ impl SseUsageScanner {
             if self.skipping_oversized_line {
                 // `head` is the tail of a discarded oversized line.
                 self.skipping_oversized_line = false;
+            } else if self.carry.len() + head.len() > SSE_SCAN_MAX_LINE {
+                // Line exceeds the cap even though it terminated within this
+                // chunk — discard it like the cross-chunk case, and release
+                // the backing allocation rather than retaining its capacity.
+                self.carry = Vec::new();
             } else if self.carry.is_empty() {
                 self.scan_line(head);
             } else {
@@ -9000,8 +9006,9 @@ async fn forward_openai_compat_anthropic(
                 client_gone = true;
             }
 
-            // Record token usage scanned from the raw upstream SSE. The
-            // detached task only holds a cloned Arc<AppState>; re-index it.
+            // Record usage scanned incrementally from the upstream SSE
+            // (LAB-717). The detached task only holds a cloned
+            // Arc<AppState>; re-index it.
             let ep = &state_clone.endpoints[endpoint_idx];
             finalize_stream(
                 &state_clone,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4587,7 +4587,7 @@ async fn openai_chat_streaming() {
     });
 
     let mock_url = format!("http://{}", mock_addr);
-    let (app, _state) = test_openai_app(&mock_url, None);
+    let (app, state) = test_openai_app(&mock_url, None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -4652,6 +4652,84 @@ async fn openai_chat_streaming() {
     // Last data chunk: finish_reason
     let last = chunks.last().unwrap();
     assert_eq!(last["choices"][0]["finish_reason"], "stop");
+
+    // LAB-717: usage is scanned incrementally (no raw_sse buffering) and
+    // recorded by the detached finalize task after the stream closes — poll
+    // briefly for it to land. The mock stream carries input=10 / output=5.
+    assert_eq!(
+        poll_streamed_usage(&state).await,
+        (10, 5),
+        "streamed usage must be recorded from the incremental scan"
+    );
+}
+
+/// Poll endpoint token counters until streamed usage lands (the finalize
+/// task is detached, so recording races the client seeing end-of-stream).
+async fn poll_streamed_usage(state: &Arc<AppState>) -> (u64, u64) {
+    let mut recorded = (0, 0);
+    for _ in 0..40 {
+        let input: u64 = state
+            .endpoints
+            .iter()
+            .map(|e| e.input_tokens.load(Ordering::Relaxed))
+            .sum();
+        let output: u64 = state
+            .endpoints
+            .iter()
+            .map(|e| e.output_tokens.load(Ordering::Relaxed))
+            .sum();
+        recorded = (input, output);
+        if input > 0 && output > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    recorded
+}
+
+/// LAB-717: native-path (/v1/messages) streaming — the passthrough stream is
+/// scanned incrementally and usage recorded without buffering the response.
+#[tokio::test]
+async fn anthropic_streaming_records_usage() {
+    let mock_app = Router::new().fallback(any(mock_anthropic_streaming_handler));
+    let mock_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mock_addr = mock_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(mock_listener, mock_app).await.unwrap();
+    });
+
+    let (app, state) = test_app(&format!("http://{}", mock_addr), None);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let resp = Client::new()
+        .post(format!("http://{}/v1/messages", addr))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-sonnet-4-6","stream":true,"messages":[{"role":"user","content":"hi"}],"max_tokens":100}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("message_stop"),
+        "stream should pass through untouched, got: {body:?}"
+    );
+
+    assert_eq!(
+        poll_streamed_usage(&state).await,
+        (10, 5),
+        "streamed usage must be recorded from the incremental scan"
+    );
 }
 
 #[tokio::test]
@@ -5036,6 +5114,86 @@ data: {\"type\":\"message_stop\"}\n\n";
 fn usage_from_empty_sse() {
     let usage = TokenUsage::from_sse_text("");
     assert!(usage.is_empty());
+}
+
+/// LAB-717: the incremental scanner must produce the same usage regardless of
+/// how the stream is fragmented into chunks — including splits mid-line,
+/// mid-JSON, and down to one byte per push.
+#[test]
+fn sse_scanner_chunk_boundaries_do_not_affect_usage() {
+    let sse: &[u8] = b"event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":150,\"cache_creation_input_tokens\":10,\"cache_read_input_tokens\":5}}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"mentions message_delta harmlessly\"}}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":75}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\n";
+
+    // Every chunk size from pathological (1 byte) to whole-stream.
+    for chunk_size in [1, 3, 7, 64, sse.len()] {
+        let mut scanner = SseUsageScanner::default();
+        for chunk in sse.chunks(chunk_size) {
+            scanner.push(chunk);
+        }
+        scanner.finish();
+        assert_eq!(scanner.usage.input_tokens, 150, "chunk_size={chunk_size}");
+        assert_eq!(scanner.usage.output_tokens, 75, "chunk_size={chunk_size}");
+        assert_eq!(scanner.usage.cache_creation_input_tokens, 10);
+        assert_eq!(scanner.usage.cache_read_input_tokens, 5);
+        assert_eq!(scanner.bytes_seen, sse.len());
+        assert_eq!(scanner.event_count, 4);
+    }
+}
+
+/// LAB-717: the trailing line is scanned even when the stream ends without a
+/// final newline (finish() flushes the carry).
+#[test]
+fn sse_scanner_flushes_unterminated_final_line() {
+    let mut scanner = SseUsageScanner::default();
+    scanner.push(b"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":42}}");
+    scanner.finish();
+    assert_eq!(scanner.usage.output_tokens, 42);
+}
+
+/// LAB-717: a single line larger than SSE_SCAN_MAX_LINE must not grow the
+/// carry without bound — it is discarded up to its newline, and scanning
+/// resumes cleanly on the following lines.
+#[test]
+fn sse_scanner_discards_oversized_line_and_recovers() {
+    let mut scanner = SseUsageScanner::default();
+    // Oversized junk line delivered across several pushes, no newline yet.
+    let junk = vec![b'x'; SSE_SCAN_MAX_LINE / 2 + 1];
+    scanner.push(&junk);
+    scanner.push(&junk); // crosses the cap → carry dropped, skip mode
+    assert!(
+        scanner.carry.is_empty(),
+        "carry must not hold oversized line"
+    );
+    scanner.push(b"more of the same line\n"); // newline ends the skipped line
+    scanner.push(b"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":9}}\n");
+    scanner.finish();
+    assert_eq!(scanner.usage.output_tokens, 9);
+}
+
+/// LAB-717: diagnostic metadata for stream_end_no_usage is bounded — full
+/// event count, but only the first five event types retained.
+#[test]
+fn sse_scanner_event_preview_bounded_to_five() {
+    let mut scanner = SseUsageScanner::default();
+    for i in 0..7 {
+        scanner.push(format!("event: ev{i}\ndata: {{}}\n\n").as_bytes());
+    }
+    scanner.finish();
+    assert_eq!(scanner.event_count, 7);
+    assert_eq!(
+        scanner.event_preview,
+        vec!["ev0", "ev1", "ev2", "ev3", "ev4"]
+    );
+    assert!(scanner.usage.is_empty());
 }
 
 #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5179,6 +5179,35 @@ fn sse_scanner_discards_oversized_line_and_recovers() {
     assert_eq!(scanner.usage.output_tokens, 9);
 }
 
+/// LAB-717: the cap applies uniformly when the oversized line terminates
+/// within a single push — both when it completes a cross-chunk carry and
+/// when it arrives whole — and the carry allocation must not retain the
+/// oversized capacity afterwards.
+#[test]
+fn sse_scanner_caps_oversized_line_completed_in_one_push() {
+    // Whole oversized line (with newline) in one push.
+    let mut scanner = SseUsageScanner::default();
+    let mut blob = vec![b'x'; SSE_SCAN_MAX_LINE + 1];
+    blob.push(b'\n');
+    scanner.push(&blob);
+    scanner.push(b"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":7}}\n");
+    scanner.finish();
+    assert_eq!(scanner.usage.output_tokens, 7);
+    assert!(scanner.carry.capacity() <= SSE_SCAN_MAX_LINE);
+
+    // Carry just under the cap, then a chunk whose newline completes the
+    // combined oversized line.
+    let mut scanner = SseUsageScanner::default();
+    scanner.push(&vec![b'x'; SSE_SCAN_MAX_LINE]); // fills carry to the cap
+    scanner.push(b"y\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":8}}\n");
+    scanner.finish();
+    assert_eq!(scanner.usage.output_tokens, 8);
+    assert!(
+        scanner.carry.capacity() <= SSE_SCAN_MAX_LINE,
+        "oversized merge must not balloon the retained carry allocation"
+    );
+}
+
 /// LAB-717: diagnostic metadata for stream_end_no_usage is bounded — full
 /// event count, but only the first five event types retained.
 #[test]


### PR DESCRIPTION
Closes #101. Multica: LAB-717.

## Problem

Both Anthropic-protocol streaming paths held the **entire upstream SSE response in RAM** solely to parse token usage after end-of-stream:

- `forward_anthropic`: `sse_buf.extend_from_slice(&chunk)` for every chunk, parsed post-hoc by `TokenUsage::from_sse_text`.
- `forward_openai_compat_anthropic`: a full `raw_sse` copy alongside its event-translation `buffer`. (Note: `buffer` itself already drains per-event at the `\n\n` boundary, so the true full-stream copy on this path was `raw_sse`, not both — the fix removes the full-stream copy either way.)

A long generation (64k+ output tokens ≈ multi-MB of SSE framing) × concurrent streams is the same OOM amplifier LAB-448 closed on the request side.

## Fix

New `SseUsageScanner`, fed per-chunk on both paths: **O(stream) → O(1) memory per in-flight streaming request.** It keeps only:

- a **capped partial-line carry** (64 KiB; an oversized line is discarded up to its newline, so a malformed upstream can't grow it unbounded),
- the **running `TokenUsage`** — last `message_start` / `message_delta` wins, byte-for-byte matching the old post-hoc parse semantics,
- **bounded event metadata** (total count + first-5 `event:` type preview + byte count) feeding the `stream_end_no_usage` diagnostic, which keeps its exact log fields.

`sse_buf` and `raw_sse` are deleted. `finalize_stream` now takes the scanner instead of `&[u8]`.

Only `message_start`/`message_delta` events carry usage and their type string must appear literally in the JSON, so a substring pre-filter skips the JSON parse on the `content_block_delta` firehose (the old code only paid that parse once at end-of-stream; incremental extraction would otherwise put it on the hot path). False positives (content mentioning "message_start") fall through to the type match and are ignored — identical outcome.

`TokenUsage::from_sse_text` remains as a `#[cfg(test)]` wrapper over the scanner, so the pre-existing parse tests exercise the production code path.

## Tests

- `sse_scanner_chunk_boundaries_do_not_affect_usage` — same result for every fragmentation from 1 byte/chunk to whole-stream, including splits mid-JSON.
- `sse_scanner_flushes_unterminated_final_line` — trailing line without `\n` still scanned.
- `sse_scanner_discards_oversized_line_and_recovers` — carry stays bounded past the cap; scanning resumes after the newline.
- `sse_scanner_event_preview_bounded_to_five` — diagnostic metadata is O(1).
- `anthropic_streaming_records_usage` — **new end-to-end**: `/v1/messages` stream through the full router + mock upstream, asserts usage (10/5) lands on the endpoint counters.
- `openai_chat_streaming` — extended with the same end-to-end usage assertion on the compat path.

478 tests green; `cargo fmt --check` and `clippy -Dwarnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved streaming token-usage tracking without buffering complete event streams.
  * Added safeguards to limit memory use when processing unusually large or fragmented stream data.

* **Bug Fixes**
  * Improved recording of token usage for native and OpenAI-compatible streaming responses.
  * Ensured usage is captured correctly when streams end with incomplete final lines.
  * Enhanced diagnostics when usage data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->