### PR TITLE
LAB-715: docs — remove [[upstreams]]/upstream surface, fix brake status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Routes requests across multiple Anthropic accounts using dynamic capacity-based 
 | **5xx retry** | Automatic retry on 500/502/503/504/529 (picks different account) |
 | **Token tracking** | Per-account and per-client input/output/cache token counters |
 | **Client budgets** | Daily per-client token budgets with automatic reset |
-| **Utilization limits** | Per-client utilization ceiling — 429 when all accounts exceed limit |
+| **Utilization limits** | Per-client utilization ceiling — 429 when all Anthropic endpoints exceed limit |
 | **Operator bypass** | Designated client bypasses all budget, utilization, and emergency checks |
-| **Emergency brake** | Auto-block all non-operator traffic when all accounts exceed threshold |
+| **Emergency brake** | Auto-block all non-operator traffic when all Anthropic endpoints exceed threshold |
 | **Distributed state** | Optional Redis/Valkey backend for cross-replica budget + hard-limit sync |
 | **Auto-cache** | Injects prompt caching beta header automatically |
 | **Shadow logging** | Optional JSONL file with request metadata, tokens, latency |
@@ -108,7 +108,7 @@ probe_interval_secs = 300
 # "bob" = 1000000      # 1M tokens/day
 
 # Per-client utilization limits (optional, 0.0–1.0)
-# Client gets 429 when ALL model-compatible accounts exceed their limit.
+# Client gets 429 when ALL model-compatible Anthropic endpoints exceed their limit.
 # [client_utilization_limits]
 # "gastown" = 0.85
 # "openclaw" = 0.95
@@ -116,8 +116,9 @@ probe_interval_secs = 300
 # Operators — bypass all budget, utilization, and emergency checks
 # operators = ["ray", "openclaw", "claude"]
 
-# Emergency brake — auto-block non-operator traffic when all accounts
-# exceed this threshold. Default: 0.88
+# Emergency brake — auto-block non-operator traffic when all Anthropic
+# endpoints exceed this threshold (OpenAI endpoints carry no rate-limit
+# data and are excluded). Default: 0.88
 # emergency_threshold = 0.88
 
 # Redis/Valkey for distributed state across replicas (optional)
@@ -350,7 +351,7 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
 
 ## OpenAI-Compatible Upstreams
 
-Route to non-Anthropic, OpenAI-compatible APIs (OpenRouter, Portkey, local models) by adding an endpoint with `protocol = "openai"`. There is no separate upstream pool and no `/upstream/<name>/` route — an OpenAI endpoint is a first-class member of the unified `[[endpoints]]` pool, selected by the same headroom routing as any other endpoint.
+Route to non-Anthropic, OpenAI-compatible APIs (OpenRouter, Portkey, local models) by adding an endpoint with `protocol = "openai"`. There is no separate upstream pool and no `/upstream/<name>/` route — an OpenAI endpoint is a first-class member of the unified `[[endpoints]]` pool. Because these endpoints carry no Anthropic rate-limit data, they are not selected by headroom: each enters routing as a fixed-weight candidate at its configured `priority` (the transport circuit breaker still applies).
 
 ```toml
 [[endpoints]]
@@ -373,8 +374,8 @@ The configured `token` is injected as `Authorization: Bearer`, and the request i
 3. Pre-request gate:
    a. Operator? → bypass all checks
    b. Check per-client daily token budget (429 if exceeded)
-   c. Check per-client utilization limit (429 if all accounts above limit)
-   d. Emergency brake (429 if all accounts above emergency_threshold)
+   c. Check per-client utilization limit (429 if all Anthropic endpoints above limit)
+   d. Emergency brake (429 if all Anthropic endpoints above emergency_threshold)
 4. Extract model from request body
 5. Filter accounts by model allowlist
 6. Compute time-adjusted utilization per claim window (5h, 7d per model)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ token = "sk-ant-api03-..."
 | `redis_url` | `String?` | `None` | Redis/Valkey URL for distributed state |
 | `endpoints[].name` | `String` | — | Display name for the endpoint |
 | `endpoints[].protocol` | `String` | `"anthropic"` | `"anthropic"` (default) or `"openai"` |
-| `endpoints[].base_url` | `String?` | `api.anthropic.com` | Base URL; required and must be `https://` for `openai` |
+| `endpoints[].base_url` | `String?` | `https://api.anthropic.com` | Base URL; required and must be `https://` for `openai` |
 | `endpoints[].token` | `String` | — | API key, OAuth token, or `"passthrough"` |
 | `endpoints[].models` | `[String]` | `[]` | Model allowlist (empty = all) |
 | `endpoints[].priority` | `u32` | `0` | Priority tier (lower tried first) |
@@ -308,7 +308,7 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
       "priority": 100,
       "passthrough": false,
       "requests_total": 87,
-      "utilization": 0.0,
+      "utilization": null,
       "token_usage": {
         "input_tokens": 210000,
         "output_tokens": 15000,
@@ -329,7 +329,7 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
     "alice": { "daily_limit": 5000000, "used_today": 1915000, "remaining": 3085000 }
   },
   "aggregate": {
-    "total_headroom_requests": 84000,
+    "total_headroom_requests": null,
     "consumers": {
       "alice": { "share": 0.65, "requests_per_minute": 4.2 }
     }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Routes requests across multiple Anthropic accounts using dynamic capacity-based 
 | **Client identification** | Via `X-Client-ID` header or IP-based mapping |
 | **Streaming** | SSE/streaming responses flow through with usage extraction |
 | **State persistence** | Utilization + reset times + status survive restarts |
-| **Upstream routing** | Forward to OpenAI-compatible APIs via `/upstream/<name>/...` |
+| **OpenAI-compatible endpoints** | Route to OpenAI-format APIs as first-class endpoints (`protocol = "openai"`) |
 | **~6 MB binary** | Zero runtime dependencies |
 
 ---
@@ -83,7 +83,6 @@ cargo build --release
 
 ```toml
 listen = "127.0.0.1:8082"
-upstream = "https://api.anthropic.com"
 rate_limit_cooldown_secs = 60
 probe_interval_secs = 300
 
@@ -130,12 +129,13 @@ probe_interval_secs = 300
 # "10.0.0.5" = "alice-desktop"
 # "10.0.0.6" = "bob-laptop"
 
-[[accounts]]
+[[endpoints]]
 name = "primary"
 token = "sk-ant-oat01-..."
+# protocol = "anthropic"   # default; "openai" for OpenAI-compatible upstreams
 # models = ["claude-sonnet-4-6", "claude-opus-*"]
 
-[[accounts]]
+[[endpoints]]
 name = "secondary"
 token = "sk-ant-api03-..."
 ```
@@ -145,7 +145,6 @@ token = "sk-ant-api03-..."
 | Field | Type | Default | Description |
 |:------|:-----|:--------|:------------|
 | `listen` | `String` | — | Bind address (e.g. `"127.0.0.1:8082"`) |
-| `upstream` | `String` | — | Anthropic API base URL |
 | `rate_limit_cooldown_secs` | `u64` | `60` | Seconds to cool down after 429 |
 | `probe_interval_secs` | `u64` | `300` | Seconds between utilization probes (0 = disabled) |
 | `proxy_key` | `String?` | `None` | Shared secret for proxy access |
@@ -160,9 +159,13 @@ token = "sk-ant-api03-..."
 | `strategy` | `String` | `dynamic-capacity-v1` | Routing strategy (see note below) |
 | `emergency_threshold` | `f64` | `0.88` | Utilization threshold for emergency brake |
 | `redis_url` | `String?` | `None` | Redis/Valkey URL for distributed state |
-| `accounts[].name` | `String` | — | Display name for the account |
-| `accounts[].token` | `String` | — | API key or `"passthrough"` |
-| `accounts[].models` | `[String]` | `[]` | Model allowlist (empty = all) |
+| `endpoints[].name` | `String` | — | Display name for the endpoint |
+| `endpoints[].protocol` | `String` | `"anthropic"` | `"anthropic"` (default) or `"openai"` |
+| `endpoints[].base_url` | `String?` | `api.anthropic.com` | Base URL; required and must be `https://` for `openai` |
+| `endpoints[].token` | `String` | — | API key, OAuth token, or `"passthrough"` |
+| `endpoints[].models` | `[String]` | `[]` | Model allowlist (empty = all) |
+| `endpoints[].priority` | `u32` | `0` | Priority tier (lower tried first) |
+| `endpoints[].fable_included` | `bool` | `true` | Plan includes Fable band; set `false` for Pro / standard Team |
 
 > [!NOTE]
 > **Strategy normalization**: Both `"dynamic-capacity"` and `"dynamic-capacity-v1"` are accepted in config, but the runtime normalizes to `"dynamic-capacity-v1"` in logs and `/_stats` output. Similarly, `"sticky-weighted"` normalizes to `"sticky-weighted-v2"`.
@@ -183,17 +186,17 @@ token = "sk-ant-api03-..."
 Restrict accounts to specific models with the `models` field:
 
 ```toml
-[[accounts]]
+[[endpoints]]
 name = "opus-only"
 token = "sk-ant-oat01-..."
 models = ["claude-opus-*"]  # Wildcard prefix match
 
-[[accounts]]
+[[endpoints]]
 name = "sonnet-only"
 token = "sk-ant-api03-..."
 models = ["claude-sonnet-4-6"]  # Exact match
 
-[[accounts]]
+[[endpoints]]
 name = "general"
 token = "sk-ant-oat01-..."
 # Empty models = serves all models
@@ -267,7 +270,6 @@ IP check runs first, then proxy key. Both apply to all endpoints including `/_st
 |:------|:-------|:------------|
 | `/*` | Any | Proxied to upstream Anthropic API |
 | `/v1/chat/completions` | POST | OpenAI-compatible → Anthropic translation |
-| `/upstream/{name}/*` | Any | Forwarded to named OpenAI-compatible upstream |
 | `/_stats` | GET | JSON stats (utilization, tokens, budgets) |
 | `/metrics` | GET | Prometheus-format metrics |
 
@@ -278,9 +280,11 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
 
 ```json
 {
-  "accounts": [
+  "endpoints": [
     {
       "name": "primary",
+      "protocol": "anthropic",
+      "priority": 0,
       "passthrough": false,
       "requests_total": 1042,
       "utilization": 0.25,
@@ -288,7 +292,7 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
       "remaining_requests": 950,
       "remaining_tokens": 4800000,
       "hard_limited_remaining_secs": null,
-      "burn_rate": { "1m": 12.5, "5m": 10.2, "15m": 8.7 },
+      "burn_rate": { "last_5m": 12.5, "last_1h": 10.2, "last_6h": 8.7 },
       "headroom_requests": 42000,
       "token_usage": {
         "input_tokens": 2450000,
@@ -296,13 +300,20 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
         "cache_creation_input_tokens": 50000,
         "cache_read_input_tokens": 1200000
       }
-    }
-  ],
-  "upstreams": [
+    },
     {
       "name": "portkey",
-      "base_url": "https://portkey.example.com/v1",
-      "requests_total": 87
+      "protocol": "openai",
+      "priority": 100,
+      "passthrough": false,
+      "requests_total": 87,
+      "utilization": 0.0,
+      "token_usage": {
+        "input_tokens": 210000,
+        "output_tokens": 15000,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0
+      }
     }
   ],
   "client_usage": {
@@ -314,12 +325,12 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
     }
   },
   "client_budgets": {
-    "alice": { "limit": 5000000, "used": 1915000, "remaining": 3085000 }
+    "alice": { "daily_limit": 5000000, "used_today": 1915000, "remaining": 3085000 }
   },
   "aggregate": {
     "total_headroom_requests": 84000,
     "consumers": {
-      "alice": { "share": 0.65, "rpm": 4.2 }
+      "alice": { "share": 0.65, "requests_per_minute": 4.2 }
     }
   },
   "cluster": {
@@ -339,16 +350,18 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
 
 ## OpenAI-Compatible Upstreams
 
-Route requests to non-Anthropic APIs (OpenRouter, Portkey, local models) via named upstreams:
+Route to non-Anthropic, OpenAI-compatible APIs (OpenRouter, Portkey, local models) by adding an endpoint with `protocol = "openai"`. There is no separate upstream pool and no `/upstream/<name>/` route — an OpenAI endpoint is a first-class member of the unified `[[endpoints]]` pool, selected by the same headroom routing as any other endpoint.
 
 ```toml
-[[upstreams]]
+[[endpoints]]
 name = "openrouter"
-base_url = "https://openrouter.ai/api"
-api_key = "sk-or-..."
+protocol = "openai"
+base_url = "https://openrouter.ai/api"   # required for openai; must be https://
+token = "sk-or-..."
+priority = 100   # tried only after Anthropic tiers are exhausted
 ```
 
-Requests to `/upstream/openrouter/v1/chat/completions` are forwarded to `https://openrouter.ai/api/v1/chat/completions` with the API key injected as `Authorization: Bearer`.
+The configured `token` is injected as `Authorization: Bearer`, and the request is forwarded to `base_url` with automatic Anthropic↔OpenAI translation (any proxied path) or direct passthrough (`POST /v1/chat/completions`). Routing by `priority` is how an OpenAI endpoint replaces the old `fallback_upstream`: give it a high `priority` so free Anthropic capacity drains first.
 
 ---
 
@@ -361,7 +374,7 @@ Requests to `/upstream/openrouter/v1/chat/completions` are forwarded to `https:/
    a. Operator? → bypass all checks
    b. Check per-client daily token budget (429 if exceeded)
    c. Check per-client utilization limit (429 if all accounts above limit)
-   d. Emergency brake (503 if all accounts above emergency_threshold)
+   d. Emergency brake (429 if all accounts above emergency_threshold)
 4. Extract model from request body
 5. Filter accounts by model allowlist
 6. Compute time-adjusted utilization per claim window (5h, 7d per model)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ token = "sk-ant-api03-..."
 
 ### Model Routing
 
-Restrict accounts to specific models with the `models` field:
+Restrict endpoints to specific models with the `models` field:
 
 ```toml
 [[endpoints]]

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,5 +1,29 @@
 # Testing Guide for anthropic-lb
 
+> Commands and patterns for running, filtering, and debugging the test suite.
+
+---
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Test Organization](#test-organization)
+- [Test Categories](#test-categories)
+- [Running Tests in CI/CD](#running-tests-in-cicd)
+- [Coverage Analysis](#coverage-analysis)
+- [Debugging Tests](#debugging-tests)
+- [Test Structure](#test-structure)
+- [Common Test Patterns](#common-test-patterns)
+- [Troubleshooting](#troubleshooting)
+- [Performance Testing](#performance-testing)
+- [Test Best Practices](#test-best-practices)
+- [Example Test Session](#example-test-session)
+- [Continuous Integration](#continuous-integration)
+- [Test Documentation](#test-documentation)
+- [Support](#support)
+
+---
+
 ## Quick Start
 
 To run all tests:
@@ -7,27 +31,27 @@ To run all tests:
 cargo test
 ```
 
-To run tests with output visible:
-```bash
-cargo test -- --nocapture
-```
-
 To run a specific test:
 ```bash
 cargo test test_minimal_valid_config
 ```
 
+> [!TIP]
+> Add `-- --nocapture` to any `cargo test` invocation to see `println!`/`dbg!` output from passing tests, not just failures.
+
+---
+
 ## Test Organization
 
-### 1. Unit Tests in src/main.rs
-These tests are embedded in the main source file within a `#[cfg(test)]` module.
+| # | Location | Purpose | Run only these |
+|:-:|:---------|:--------|:----------------|
+| 1 | `src/main.rs` — `#[cfg(test)]` module | Unit tests: individual functions and algorithms | `cargo test --lib` |
+| 2 | `tests/config_test.rs` | TOML configuration parsing and validation | `cargo test --test config_test` |
+| 3 | `tests/dependency_test.rs` | `Cargo.lock` integrity and dependency management | `cargo test --test dependency_test` |
 
-Run only the library tests:
-```bash
-cargo test --lib
-```
+<details>
+<summary><strong>Running specific test modules</strong></summary>
 
-Run specific test modules:
 ```bash
 # EWMA tests
 cargo test --lib ewma
@@ -40,84 +64,39 @@ cargo test --lib pick
 
 # IP allowlist tests
 cargo test --lib ip_allow
-```
 
-### 2. Configuration Tests (tests/config_test.rs)
-Tests for TOML configuration parsing and validation.
-
-Run configuration tests:
-```bash
-cargo test --test config_test
-```
-
-Run specific config test:
-```bash
+# One specific config test
 cargo test --test config_test test_minimal_valid_config
 ```
 
-### 3. Dependency Tests (tests/dependency_test.rs)
-Tests for Cargo.lock integrity and dependency management.
+</details>
 
-Run dependency tests:
-```bash
-cargo test --test dependency_test
-```
+---
 
 ## Test Categories
 
 ### By Functionality
 
-#### Routing Tests
-```bash
-cargo test pick_endpoint
-```
-
-#### Time & Utilization Tests
-```bash
-cargo test time_adjusted
-cargo test effective_util
-```
-
-#### Configuration Tests
-```bash
-cargo test --test config_test
-```
-
-#### Client Identity Tests
-```bash
-cargo test resolve_client_id
-cargo test is_operator
-```
-
-#### Budget & Limits Tests
-```bash
-cargo test budget
-cargo test emergency
-cargo test utilization_limit
-```
+| Category | Command |
+|:---------|:--------|
+| Routing | `cargo test pick_endpoint` |
+| Time & utilization | `cargo test time_adjusted`, `cargo test effective_util` |
+| Configuration | `cargo test --test config_test` |
+| Client identity | `cargo test resolve_client_id`, `cargo test is_operator` |
+| Budget & limits | `cargo test budget`, `cargo test emergency`, `cargo test utilization_limit` |
 
 ### By Test Type
 
-#### All Unit Tests
-```bash
-cargo test --lib
-```
+| Type | Command |
+|:---------|:--------|
+| All unit tests | `cargo test --lib` |
+| All integration tests | `cargo test --test '*'` |
+| HTTP handler tests | `cargo test proxy_`, `cargo test openai_`, `cargo test upstream_` |
 
-#### All Integration Tests
-```bash
-cargo test --test '*'
-```
-
-#### HTTP Handler Tests
-```bash
-cargo test proxy_
-cargo test openai_
-cargo test upstream_
-```
+---
 
 ## Running Tests in CI/CD
 
-For continuous integration:
 ```bash
 # Run all tests with one thread (more stable for CI)
 cargo test -- --test-threads=1
@@ -129,11 +108,15 @@ cargo test -- --nocapture --test-threads=1
 cargo test -- --nocapture --show-output --test-threads=1
 ```
 
+---
+
 ## Coverage Analysis
 
-To generate a test coverage report (requires cargo-tarpaulin):
+<details>
+<summary><strong>tarpaulin</strong> (requires <code>cargo-tarpaulin</code>)</summary>
+
 ```bash
-# Install tarpaulin
+# Install
 cargo install cargo-tarpaulin
 
 # Generate HTML coverage report
@@ -145,9 +128,13 @@ cargo tarpaulin --out Html --line --ignore-tests
 # View report (opens report/index.html in browser)
 ```
 
-Alternative with llvm-cov:
+</details>
+
+<details>
+<summary><strong>llvm-cov (alternative)</strong></summary>
+
 ```bash
-# Install llvm-cov
+# Install
 cargo install cargo-llvm-cov
 
 # Generate coverage
@@ -157,71 +144,64 @@ cargo llvm-cov --html
 cargo llvm-cov --open
 ```
 
+</details>
+
+---
+
 ## Debugging Tests
 
-### Run a Single Test with Output
-```bash
-cargo test test_name -- --nocapture
-```
+| Goal | Command |
+|:-----|:--------|
+| Single test with output | `cargo test test_name -- --nocapture` |
+| Match a name pattern | `cargo test ewma -- --nocapture` |
+| Show execution time | `cargo test -- --nocapture --test-threads=1 --show-output` |
+| Run `#[ignore]`d tests | `cargo test -- --ignored` |
+| Release mode (faster) | `cargo test --release` |
 
-### Run Tests Matching a Pattern
-```bash
-cargo test ewma -- --nocapture
-```
-
-### Show Test Execution Time
-```bash
-cargo test -- --nocapture --test-threads=1 --show-output
-```
-
-### Run Ignored Tests
-```bash
-cargo test -- --ignored
-```
-
-### Run in Release Mode (faster)
-```bash
-cargo test --release
-```
+---
 
 ## Test Structure
 
 ### Unit Tests
-- **Location**: src/main.rs in `#[cfg(test)]` module
+- **Location**: `src/main.rs` in `#[cfg(test)]` module
 - **Purpose**: Test individual functions and algorithms
-- **Example**:
-  ```rust
-  #[test]
-  fn ewma_single_update() {
-      // Test code
-  }
-  ```
+
+```rust
+#[test]
+fn ewma_single_update() {
+    // Test code
+}
+```
 
 ### Integration Tests
-- **Location**: tests/ directory
+- **Location**: `tests/` directory
 - **Purpose**: Test configuration parsing and file operations
-- **Example**:
-  ```rust
-  #[test]
-  fn test_minimal_valid_config() {
-      // Test code
-  }
-  ```
+
+```rust
+#[test]
+fn test_minimal_valid_config() {
+    // Test code
+}
+```
 
 ### Async Tests
 - **Marker**: `#[tokio::test]` instead of `#[test]`
 - **Purpose**: Test async functions with tokio runtime
-- **Example**:
-  ```rust
-  #[tokio::test]
-  async fn pick_prefers_lowest_utilization() {
-      // Async test code
-  }
-  ```
+
+```rust
+#[tokio::test]
+async fn pick_prefers_lowest_utilization() {
+    // Async test code
+}
+```
+
+---
 
 ## Common Test Patterns
 
-### Testing Configuration Parsing
+<details>
+<summary><strong>Testing configuration parsing</strong></summary>
+
 ```rust
 let config_content = r#"
 listen = "127.0.0.1:8082"
@@ -231,7 +211,11 @@ let result: Result<toml::Value, _> = toml::from_str(&config_content);
 assert!(result.is_ok());
 ```
 
-### Testing HTTP Handlers
+</details>
+
+<details>
+<summary><strong>Testing HTTP handlers</strong></summary>
+
 ```rust
 #[tokio::test]
 async fn test_handler() {
@@ -252,7 +236,11 @@ async fn test_handler() {
 }
 ```
 
-### Testing Algorithm Behavior
+</details>
+
+<details>
+<summary><strong>Testing algorithm behavior</strong></summary>
+
 ```rust
 #[tokio::test]
 async fn test_routing() {
@@ -283,27 +271,23 @@ async fn test_routing() {
 }
 ```
 
+</details>
+
+---
+
 ## Troubleshooting
 
-### Tests Fail with "Connection Refused"
-- Check if tests are trying to bind to already-used ports
-- Tests use random ports, so this should be rare
-- Ensure no other instances are running
+| Symptom | Check |
+|:--------|:------|
+| Tests fail with "Connection Refused" | Tests bind random ports, so collisions should be rare — confirm no other instance is already running |
+| Tests fail with "File Not Found" | Some tests expect files like `config.toml.example` to exist — run tests from the project root, and confirm the test uses temp files correctly |
+| Async tests hang | Check for deadlocks in `RwLock`/`Mutex` usage; isolate with `--test-threads=1` |
+| Tests pass locally but fail in CI | Look for timing-sensitive tests, tests depending on specific system state, or missing CI dependencies |
 
-### Tests Fail with "File Not Found"
-- Some tests expect files like `config.toml.example` to exist
-- Run tests from the project root directory
-- Check that test uses temporary files correctly
+> [!IMPORTANT]
+> Run tests from the project root — several integration tests resolve paths (like `config.toml.example`) relative to it.
 
-### Async Tests Hang
-- Ensure tokio runtime is properly initialized
-- Check for deadlocks in RwLock/Mutex usage
-- Use `--test-threads=1` to isolate hanging test
-
-### Tests Pass Locally but Fail in CI
-- Check for timing-sensitive tests
-- Ensure tests don't depend on specific system state
-- Verify all dependencies are available in CI environment
+---
 
 ## Performance Testing
 
@@ -316,10 +300,12 @@ cargo +nightly bench
 cargo +nightly bench bench_name
 ```
 
-Alternative with criterion (add to Cargo.toml):
+Alternative with criterion (add to `Cargo.toml`):
 ```bash
 cargo bench
 ```
+
+---
 
 ## Test Best Practices
 
@@ -330,6 +316,8 @@ cargo bench
 5. **Coverage**: Test both success and failure paths
 6. **Edge Cases**: Test boundary conditions (0, 1.0, empty, null)
 7. **Documentation**: Comment complex test logic
+
+---
 
 ## Example Test Session
 
@@ -350,6 +338,8 @@ cargo tarpaulin --out Html
 open tarpaulin-report.html
 ```
 
+---
+
 ## Continuous Integration
 
 Example GitHub Actions workflow:
@@ -369,18 +359,26 @@ jobs:
       - run: cargo test --release --verbose
 ```
 
+---
+
 ## Test Documentation
 
 For detailed test documentation, see:
-- `TEST_SUMMARY.md` - Comprehensive test coverage summary
-- `tests/config_test.rs` - Configuration test examples
-- `tests/dependency_test.rs` - Dependency test examples
-- `src/main.rs` (#[cfg(test)] module) - Unit test examples
+
+| Resource | Description |
+|:---------|:-------------|
+| [`TEST_SUMMARY.md`](TEST_SUMMARY.md) | Comprehensive test coverage summary |
+| `tests/config_test.rs` | Configuration test examples |
+| `tests/dependency_test.rs` | Dependency test examples |
+| `src/main.rs` (`#[cfg(test)]` module) | Unit test examples |
+
+---
 
 ## Support
 
 For issues or questions about tests:
-1. Check test output with `--nocapture` flag
-2. Review TEST_SUMMARY.md for test descriptions
+
+1. Check test output with the `--nocapture` flag
+2. Review `TEST_SUMMARY.md` for test descriptions
 3. Examine test source code for examples
-4. Check Cargo.toml for test dependencies
+4. Check `Cargo.toml` for test dependencies

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -69,7 +69,7 @@ cargo test --test dependency_test
 
 #### Routing Tests
 ```bash
-cargo test pick_account
+cargo test pick_endpoint
 ```
 
 #### Time & Utilization Tests
@@ -257,19 +257,29 @@ async fn test_handler() {
 #[tokio::test]
 async fn test_routing() {
     let state = test_state_with(vec![
-        make_account("a", "sk-ant-api-a"),
-        make_account("b", "sk-ant-api-b"),
+        mk_endpoint("high", "sk-ant-api-high"),
+        mk_endpoint("low", "sk-ant-api-low"),
     ]);
 
-    // Set utilization
+    // high=0.8 (headroom 0.2), low=0.2 (headroom 0.8) → ~80% should go to "low"
     {
-        let mut info = state.accounts[0].rate_info.write().await;
+        let mut info = state.endpoints[0].rate_info.write().await;
         info.utilization = Some(0.8);
     }
+    {
+        let mut info = state.endpoints[1].rate_info.write().await;
+        info.utilization = Some(0.2);
+    }
 
-    // Test routing behavior
-    let idx = state.pick_account(None, "").await.unwrap();
-    assert_eq!(idx, 1); // Should pick account b
+    // Routing is headroom-proportional weighted bucket hashing — assert the
+    // traffic share, not a single deterministic pick
+    let mut counts = [0u32; 2];
+    for _ in 0..1000 {
+        let idx = state.pick_endpoint(None, "", &[]).await.unwrap();
+        counts[idx] += 1;
+    }
+    let low_pct = counts[1] as f64 / 1000.0;
+    assert!((0.75..=0.85).contains(&low_pct));
 }
 ```
 

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -27,11 +27,13 @@
 ## Quick Start
 
 To run all tests:
+
 ```bash
 cargo test
 ```
 
 To run a specific test:
+
 ```bash
 cargo test test_minimal_valid_config
 ```
@@ -163,6 +165,7 @@ cargo llvm-cov --open
 ## Test Structure
 
 ### Unit Tests
+
 - **Location**: `src/main.rs` in `#[cfg(test)]` module
 - **Purpose**: Test individual functions and algorithms
 
@@ -174,6 +177,7 @@ fn ewma_single_update() {
 ```
 
 ### Integration Tests
+
 - **Location**: `tests/` directory
 - **Purpose**: Test configuration parsing and file operations
 
@@ -185,6 +189,7 @@ fn test_minimal_valid_config() {
 ```
 
 ### Async Tests
+
 - **Marker**: `#[tokio::test]` instead of `#[test]`
 - **Purpose**: Test async functions with tokio runtime
 
@@ -292,6 +297,7 @@ async fn test_routing() {
 ## Performance Testing
 
 For benchmarking (requires nightly Rust):
+
 ```bash
 # Run benchmarks
 cargo +nightly bench
@@ -301,6 +307,7 @@ cargo +nightly bench bench_name
 ```
 
 Alternative with criterion (add to `Cargo.toml`):
+
 ```bash
 cargo bench
 ```

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -225,7 +225,7 @@ cargo test --release
 ```rust
 let config_content = r#"
 listen = "127.0.0.1:8082"
-upstream = "https://api.anthropic.com"
+strategy = "dynamic-capacity-v1"
 "#;
 let result: Result<toml::Value, _> = toml::from_str(&config_content);
 assert!(result.is_ok());

--- a/config-debug.toml.example
+++ b/config-debug.toml.example
@@ -3,13 +3,12 @@
 # Run:   cargo build && ./target/debug/anthropic-lb config-debug.toml
 # Tail:  tail -f debug.log
 listen = "127.0.0.1:8083"
-upstream = "https://api.anthropic.com"
 auto_cache = true
 debug_log = "debug.log"
 
-# Single account for clean signal
+# Single endpoint for clean signal
 # Copy this file to config-debug.toml and set your token below.
 # config-debug.toml is gitignored and will not be committed.
-[[accounts]]
+[[endpoints]]
 name = "debug"
 token = "YOUR_TOKEN_HERE"


### PR DESCRIPTION
Closes LAB-715. Fixes GitHub #99.

## Problem

The README documented a config surface and routes that the code now **hard-errors on or never serves** — verified against `src/main.rs` @ `18ee187` (one commit past the `ce0d44c` audit; that commit is an unrelated read-timeout fix):

| Doc claim | Reality in code |
|:--|:--|
| `[[upstreams]]` + `/upstream/<name>/...` | `reject_legacy_config_keys` rejects `upstreams`; router has no such route |
| top-level `upstream` key | not a `Config` field; base URL is per-endpoint `base_url` |
| `[[accounts]]` config blocks | `reject_legacy_config_keys` rejects `accounts` — copy-pasting the example hard-errors at startup |
| `/_stats` `accounts` + `upstreams` arrays | one unified `endpoints` array (`stats_handler`); `base_url` isn't even emitted per-entry |
| `burn_rate` `{1m,5m,15m}`, `client_budgets` `{limit,used}`, `aggregate` `{rpm}` | real keys: `{last_5m,last_1h,last_6h}`, `{daily_limit,used_today}`, `{requests_per_minute}` |
| emergency brake returns **503** | `pre_request_gate` returns **429** (`StatusCode::TOO_MANY_REQUESTS`) |

## Fix (docs-only)

- Rewrote **OpenAI-Compatible Upstreams** around the unified `[[endpoints]]` model with `protocol = "openai"` (routes by `priority`, replaces the old `fallback_upstream`).
- Feature table, **Endpoints** route table, and **Config Reference** table: dropped `/upstream/...` and `upstream`; documented the real `endpoints[].{protocol,base_url,priority,fable_included}` schema.
- Config examples (main + **Model Routing**): `[[accounts]]` -> `[[endpoints]]`, removed phantom `upstream`.
- Refreshed the `/_stats` example to the unified `endpoints` array with correct keys.
- Emergency brake `503` -> `429`.

Extended beyond the README to two sibling files carrying the **identical** removed-key defect (same root cause, not scope creep): `config-debug.toml.example` (`[[accounts]]`/`upstream` -> `[[endpoints]]`) and a `TESTING_GUIDE.md` parse example. `config.toml.example` was already on the current schema and is the template these were reconciled against.

Kept fields the code still has (`strategy`, `rate_limit_cooldown_secs`, `probe_interval_secs`) and left prose use of "account" as a concept — this PR corrects the *config surface*, not terminology.

## Verification

- Every claim checked against `src/main.rs` (`Config`/`EndpointConfig` structs, `reject_legacy_config_keys`, `Router::new`, `pre_request_gate`, `stats_handler`/`build_stats_entry`).
- Parsed both `*.toml.example` files with `tomllib`: valid TOML, **zero** rejected legacy keys, `[[endpoints]]` have required `name`+`token` — a copy-paste of either no longer hard-errors.
- pre-commit hooks green on all changed files.

## Out of scope (flagged for follow-up)

`TESTING_GUIDE.md` has unrelated staleness (references the pre-`LAB-367` inline `#[cfg(test)]` location and old `make_account`/`pick_account` names from before the endpoint unification). Not touched here — separate concern from the removed config surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README to replace the legacy accounts/upstreams model with a unified **endpoints** pool, including per-endpoint configuration (protocol, base URL, tokens, model matching, priority) and updated routing behaviour.
  * Added/clarified OpenAI-compatible routing via `protocol = "openai"` (including `/v1/chat/completions`) and revised the `/_stats` example to reflect endpoint-level usage and new budgeting fields.
  * Adjusted emergency-brake behaviour to use status code **429** (Anthropic endpoints only).
* **Documentation**
  * Reorganised and reformatted the testing guide to match the new configuration approach.
  * Updated the debug example configuration to use `[[endpoints]]`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->