### PR TITLE
LAB-714: OpenAI-compat translation drops multimodal + array-form system content

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4881,6 +4881,24 @@ fn exhaustion_response(last_saw_transient: bool, last_saw_529: bool) -> Response
     (StatusCode::TOO_MANY_REQUESTS, "exhausted all endpoints").into_response()
 }
 
+/// 400 in Anthropic's error envelope when an Anthropic request can't be
+/// faithfully translated for an OpenAI-compat fallback endpoint (e.g. an
+/// image source type the translator doesn't support). The caller's request
+/// was Anthropic Messages API shaped, so the error response matches that,
+/// regardless of which protocol the fallback endpoint speaks.
+fn untranslatable_request_response(message: &str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        [("content-type", "application/json")],
+        serde_json::json!({
+            "type": "error",
+            "error": { "type": "invalid_request_error", "message": message }
+        })
+        .to_string(),
+    )
+        .into_response()
+}
+
 /// Forward one Anthropic-protocol request to a single `Endpoint`. The caller
 /// passes the picked endpoint and its pool index (used for `skip` and usage
 /// accounting).
@@ -5639,7 +5657,20 @@ async fn try_fallback_upstream(
 
     // Build request body
     let request_body = if translate {
-        let openai_body = translate_anthropic_request_to_openai(&parsed);
+        let openai_body = match translate_anthropic_request_to_openai(&parsed) {
+            Ok(v) => v,
+            Err(msg) => {
+                warn!(
+                    req_id,
+                    upstream = ep.name,
+                    error = %msg,
+                    "fallback: request not representable in OpenAI format"
+                );
+                // Terminal, not a retry: the request itself is the problem, so
+                // rotating to another endpoint would just fail the same way.
+                return ForwardOutcome::Done(untranslatable_request_response(&msg));
+            }
+        };
         match serde_json::to_vec(&openai_body) {
             Ok(b) => b,
             Err(_) => return ROTATE,
@@ -8072,26 +8103,51 @@ fn reverse_map_stop_reason(reason: &str) -> &'static str {
 /// Translate an Anthropic Messages API request body to OpenAI Chat Completions format.
 /// Reverse of `translate_openai_to_anthropic`.
 /// Anthropic `image` block → OpenAI `image_url` part. Base64 sources repack as a
-/// `data:` URL. None only for structurally invalid blocks (missing source fields)
-/// that Anthropic itself would have rejected.
-fn anthropic_image_block_to_openai(block: &serde_json::Value) -> Option<serde_json::Value> {
-    let source = block.get("source")?;
-    let url = match source.get("type").and_then(|t| t.as_str())? {
-        "url" => source.get("url")?.as_str()?.to_string(),
+/// `data:` URL. Err when the source can't be represented faithfully — missing
+/// fields, or a source type this translator doesn't handle (e.g. Anthropic's
+/// `file` source) — so the caller fails the request loudly instead of silently
+/// dropping the image.
+fn anthropic_image_block_to_openai(block: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let source = block
+        .get("source")
+        .ok_or("image block missing \"source\"")?;
+    let source_type = source
+        .get("type")
+        .and_then(|t| t.as_str())
+        .ok_or("image source missing \"type\"")?;
+    let url = match source_type {
+        "url" => source
+            .get("url")
+            .and_then(|u| u.as_str())
+            .ok_or("image url source missing \"url\"")?
+            .to_string(),
         "base64" => {
-            let media_type = source.get("media_type").and_then(|m| m.as_str())?;
-            let data = source.get("data").and_then(|d| d.as_str())?;
+            let media_type = source
+                .get("media_type")
+                .and_then(|m| m.as_str())
+                .ok_or("image base64 source missing \"media_type\"")?;
+            let data = source
+                .get("data")
+                .and_then(|d| d.as_str())
+                .ok_or("image base64 source missing \"data\"")?;
             format!("data:{};base64,{}", media_type, data)
         }
-        _ => return None,
+        other => {
+            return Err(format!(
+                "image source type \"{other}\" is not supported by the OpenAI-compat translator"
+            ));
+        }
     };
-    Some(serde_json::json!({"type": "image_url", "image_url": {"url": url}}))
+    Ok(serde_json::json!({"type": "image_url", "image_url": {"url": url}}))
 }
 
 /// Anthropic user content blocks → OpenAI content: a plain string when text-only
 /// (the common case, and what OpenAI-compat upstreams handle most reliably), a
 /// content-part array when image blocks are present so images survive translation.
-fn anthropic_user_blocks_to_openai_content(blocks: &[&serde_json::Value]) -> serde_json::Value {
+/// Err propagates from an unrepresentable image rather than dropping it silently.
+fn anthropic_user_blocks_to_openai_content(
+    blocks: &[&serde_json::Value],
+) -> Result<serde_json::Value, String> {
     let mut parts: Vec<serde_json::Value> = Vec::new();
     let mut has_image = false;
     for b in blocks {
@@ -8102,15 +8158,13 @@ fn anthropic_user_blocks_to_openai_content(blocks: &[&serde_json::Value]) -> ser
                 }
             }
             Some("image") => {
-                if let Some(p) = anthropic_image_block_to_openai(b) {
-                    parts.push(p);
-                    has_image = true;
-                }
+                parts.push(anthropic_image_block_to_openai(b)?);
+                has_image = true;
             }
             _ => {}
         }
     }
-    if has_image {
+    Ok(if has_image {
         serde_json::Value::Array(parts)
     } else {
         let text: String = parts
@@ -8119,10 +8173,15 @@ fn anthropic_user_blocks_to_openai_content(blocks: &[&serde_json::Value]) -> ser
             .collect::<Vec<_>>()
             .join("");
         serde_json::Value::String(text)
-    }
+    })
 }
 
-fn translate_anthropic_request_to_openai(body: &serde_json::Value) -> serde_json::Value {
+/// Err (with a client-facing message) when a message contains an image this
+/// translator can't represent faithfully — the caller must surface a real
+/// error instead of silently forwarding a request with the image dropped.
+fn translate_anthropic_request_to_openai(
+    body: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
     let mut out = serde_json::Map::new();
 
     if let Some(model) = body.get("model") {
@@ -8260,7 +8319,7 @@ fn translate_anthropic_request_to_openai(body: &serde_json::Value) -> serde_json
                                 b.get("type").and_then(|t| t.as_str()) != Some("tool_result")
                             })
                             .collect();
-                        let user_content = anthropic_user_blocks_to_openai_content(&leftover);
+                        let user_content = anthropic_user_blocks_to_openai_content(&leftover)?;
                         let non_empty = match &user_content {
                             serde_json::Value::String(s) => !s.is_empty(),
                             serde_json::Value::Array(a) => !a.is_empty(),
@@ -8282,7 +8341,7 @@ fn translate_anthropic_request_to_openai(body: &serde_json::Value) -> serde_json
                         messages.push(serde_json::json!({"role": "user", "content": s}));
                     } else if let Some(arr) = c.as_array() {
                         let block_refs: Vec<&serde_json::Value> = arr.iter().collect();
-                        let user_content = anthropic_user_blocks_to_openai_content(&block_refs);
+                        let user_content = anthropic_user_blocks_to_openai_content(&block_refs)?;
                         messages.push(serde_json::json!({"role": "user", "content": user_content}));
                     }
                 }
@@ -8347,7 +8406,7 @@ fn translate_anthropic_request_to_openai(body: &serde_json::Value) -> serde_json
         }
     }
 
-    serde_json::Value::Object(out)
+    Ok(serde_json::Value::Object(out))
 }
 
 /// Translate an OpenAI Chat Completions response to Anthropic Messages API format.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7555,6 +7555,24 @@ fn make_openai_chunk(
     format!("data: {}\n\n", chunk)
 }
 
+/// OpenAI `image_url` part → Anthropic `image` block. `data:` URLs unpack into a
+/// base64 source; anything else (including malformed data URLs) becomes a url
+/// source so upstream rejects it with a real error instead of us dropping it.
+fn openai_image_part_to_anthropic(url: &str) -> serde_json::Value {
+    if let Some(rest) = url.strip_prefix("data:") {
+        if let Some((media_type, data)) = rest.split_once(";base64,") {
+            return serde_json::json!({
+                "type": "image",
+                "source": {"type": "base64", "media_type": media_type, "data": data},
+            });
+        }
+    }
+    serde_json::json!({
+        "type": "image",
+        "source": {"type": "url", "url": url},
+    })
+}
+
 fn translate_openai_to_anthropic(body: &serde_json::Value) -> serde_json::Value {
     let mut out = serde_json::Map::new();
 
@@ -7571,8 +7589,22 @@ fn translate_openai_to_anthropic(body: &serde_json::Value) -> serde_json::Value 
         for msg in msgs {
             let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
             if role == "system" {
-                if let Some(content) = msg.get("content").and_then(|c| c.as_str()) {
-                    system_parts.push(content.to_string());
+                // content can be a string or an array of text parts
+                let content_val = msg.get("content");
+                let content_str = content_val
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        content_val?.as_array().map(|parts| {
+                            parts
+                                .iter()
+                                .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                                .collect::<Vec<_>>()
+                                .join("")
+                        })
+                    });
+                if let Some(s) = content_str {
+                    system_parts.push(s);
                 }
             } else if role == "tool" {
                 // OpenAI tool result → Anthropic user message with tool_result block
@@ -7673,14 +7705,36 @@ fn translate_openai_to_anthropic(body: &serde_json::Value) -> serde_json::Value 
                 }
                 messages.push(serde_json::json!({"role": "assistant", "content": blocks}));
             } else {
-                // Standard message — strip "name" field, keep role + content
+                // Standard message — strip "name" field, keep role + content.
+                // Array content: translate OpenAI image_url parts to Anthropic
+                // image blocks (untranslated they 400 the whole request upstream).
                 let mut clean = serde_json::Map::new();
                 clean.insert(
                     "role".to_string(),
                     serde_json::Value::String(role.to_string()),
                 );
                 if let Some(content) = msg.get("content") {
-                    clean.insert("content".to_string(), content.clone());
+                    let translated = if let Some(parts) = content.as_array() {
+                        serde_json::Value::Array(
+                            parts
+                                .iter()
+                                .map(|p| {
+                                    if p.get("type").and_then(|t| t.as_str()) == Some("image_url") {
+                                        let url = p
+                                            .pointer("/image_url/url")
+                                            .and_then(|u| u.as_str())
+                                            .unwrap_or("");
+                                        openai_image_part_to_anthropic(url)
+                                    } else {
+                                        p.clone()
+                                    }
+                                })
+                                .collect(),
+                        )
+                    } else {
+                        content.clone()
+                    };
+                    clean.insert("content".to_string(), translated);
                 }
                 messages.push(serde_json::Value::Object(clean));
             }
@@ -8017,6 +8071,57 @@ fn reverse_map_stop_reason(reason: &str) -> &'static str {
 
 /// Translate an Anthropic Messages API request body to OpenAI Chat Completions format.
 /// Reverse of `translate_openai_to_anthropic`.
+/// Anthropic `image` block → OpenAI `image_url` part. Base64 sources repack as a
+/// `data:` URL. None only for structurally invalid blocks (missing source fields)
+/// that Anthropic itself would have rejected.
+fn anthropic_image_block_to_openai(block: &serde_json::Value) -> Option<serde_json::Value> {
+    let source = block.get("source")?;
+    let url = match source.get("type").and_then(|t| t.as_str())? {
+        "url" => source.get("url")?.as_str()?.to_string(),
+        "base64" => {
+            let media_type = source.get("media_type").and_then(|m| m.as_str())?;
+            let data = source.get("data").and_then(|d| d.as_str())?;
+            format!("data:{};base64,{}", media_type, data)
+        }
+        _ => return None,
+    };
+    Some(serde_json::json!({"type": "image_url", "image_url": {"url": url}}))
+}
+
+/// Anthropic user content blocks → OpenAI content: a plain string when text-only
+/// (the common case, and what OpenAI-compat upstreams handle most reliably), a
+/// content-part array when image blocks are present so images survive translation.
+fn anthropic_user_blocks_to_openai_content(blocks: &[&serde_json::Value]) -> serde_json::Value {
+    let mut parts: Vec<serde_json::Value> = Vec::new();
+    let mut has_image = false;
+    for b in blocks {
+        match b.get("type").and_then(|t| t.as_str()) {
+            Some("text") => {
+                if let Some(t) = b.get("text").and_then(|t| t.as_str()) {
+                    parts.push(serde_json::json!({"type": "text", "text": t}));
+                }
+            }
+            Some("image") => {
+                if let Some(p) = anthropic_image_block_to_openai(b) {
+                    parts.push(p);
+                    has_image = true;
+                }
+            }
+            _ => {}
+        }
+    }
+    if has_image {
+        serde_json::Value::Array(parts)
+    } else {
+        let text: String = parts
+            .iter()
+            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join("");
+        serde_json::Value::String(text)
+    }
+}
+
 fn translate_anthropic_request_to_openai(body: &serde_json::Value) -> serde_json::Value {
     let mut out = serde_json::Map::new();
 
@@ -8148,33 +8253,37 @@ fn translate_anthropic_request_to_openai(body: &serde_json::Value) -> serde_json
                             }));
                         }
 
-                        // Also emit any non-tool_result text blocks as a user message
-                        let text_blocks: Vec<&str> = blocks
+                        // Also emit any non-tool_result blocks (text + images) as a user message
+                        let leftover: Vec<&serde_json::Value> = blocks
                             .iter()
-                            .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
-                            .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                            .filter(|b| {
+                                b.get("type").and_then(|t| t.as_str()) != Some("tool_result")
+                            })
                             .collect();
-                        if !text_blocks.is_empty() {
+                        let user_content = anthropic_user_blocks_to_openai_content(&leftover);
+                        let non_empty = match &user_content {
+                            serde_json::Value::String(s) => !s.is_empty(),
+                            serde_json::Value::Array(a) => !a.is_empty(),
+                            _ => false,
+                        };
+                        if non_empty {
                             messages.push(serde_json::json!({
                                 "role": "user",
-                                "content": text_blocks.join(""),
+                                "content": user_content,
                             }));
                         }
                         continue;
                     }
                 }
-                // Plain user message — pass through content as-is
+                // Plain user message — string passes through; block arrays keep
+                // text AND images (images previously filtered out silently)
                 if let Some(c) = content {
                     if let Some(s) = c.as_str() {
                         messages.push(serde_json::json!({"role": "user", "content": s}));
                     } else if let Some(arr) = c.as_array() {
-                        let text: String = arr
-                            .iter()
-                            .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
-                            .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
-                            .collect::<Vec<_>>()
-                            .join("");
-                        messages.push(serde_json::json!({"role": "user", "content": text}));
+                        let block_refs: Vec<&serde_json::Value> = arr.iter().collect();
+                        let user_content = anthropic_user_blocks_to_openai_content(&block_refs);
+                        messages.push(serde_json::json!({"role": "user", "content": user_content}));
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8291,7 +8291,8 @@ fn anthropic_image_block_to_openai(block: &serde_json::Value) -> Result<serde_js
 /// Anthropic user content blocks → OpenAI content: a plain string when text-only
 /// (the common case, and what OpenAI-compat upstreams handle most reliably), a
 /// content-part array when image blocks are present so images survive translation.
-/// Err propagates from an unrepresentable image rather than dropping it silently.
+/// Err on an unrepresentable image or an unsupported block type (e.g. `document`)
+/// rather than dropping content silently.
 fn anthropic_user_blocks_to_openai_content(
     blocks: &[&serde_json::Value],
 ) -> Result<serde_json::Value, String> {
@@ -8308,7 +8309,12 @@ fn anthropic_user_blocks_to_openai_content(
                 parts.push(anthropic_image_block_to_openai(b)?);
                 has_image = true;
             }
-            _ => {}
+            Some(other) => {
+                return Err(format!(
+                    "content block type \"{other}\" is not supported by the OpenAI-compat translator"
+                ));
+            }
+            None => {}
         }
     }
     Ok(if has_image {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3807,6 +3807,30 @@ fn translate_anthropic_request_malformed_image_source_fails_loudly() {
 }
 
 #[test]
+fn translate_anthropic_request_unsupported_block_type_fails_loudly() {
+    // A content block type this translator can't represent (e.g. `document`)
+    // must fail the whole request, not be silently dropped from the message.
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Summarize this"},
+                {"type": "document", "source": {
+                    "type": "base64", "media_type": "application/pdf", "data": "JVBERi0="
+                }}
+            ]}
+        ],
+        "max_tokens": 1024
+    });
+
+    let err = translate_anthropic_request_to_openai(&body).unwrap_err();
+    assert!(
+        err.contains("document"),
+        "error should name the unsupported block type: {err}"
+    );
+}
+
+#[test]
 fn translate_openai_response_basic() {
     let body = serde_json::json!({
         "id": "chatcmpl-abc123",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3301,7 +3301,7 @@ fn translate_anthropic_request_basic() {
         "stream": true
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     assert_eq!(result["model"], "claude-sonnet-4-6");
     assert_eq!(result["max_tokens"], 1024);
     assert_eq!(result["temperature"], 0.7);
@@ -3347,7 +3347,7 @@ fn translate_anthropic_request_tool_use() {
         "max_tokens": 1024
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     let msgs = result["messages"].as_array().unwrap();
 
     // Assistant with tool_calls
@@ -3382,7 +3382,7 @@ fn translate_anthropic_request_tools() {
         "tool_choice": {"type": "auto"}
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     let tools = result["tools"].as_array().unwrap();
     assert_eq!(tools[0]["type"], "function");
     assert_eq!(tools[0]["function"]["name"], "get_weather");
@@ -3412,7 +3412,7 @@ fn translate_anthropic_request_tool_result_array_content() {
         "max_tokens": 1024
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     let msgs = result["messages"].as_array().unwrap();
     assert_eq!(msgs[0]["role"], "tool");
     assert_eq!(msgs[0]["content"], "Result line 1Result line 2");
@@ -3437,7 +3437,7 @@ fn translate_anthropic_request_image_blocks() {
         "max_tokens": 1024
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     let content = result["messages"][0]["content"].as_array().unwrap();
     assert_eq!(
         content[0],
@@ -3469,7 +3469,7 @@ fn translate_anthropic_request_text_only_array_stays_string() {
         "max_tokens": 1024
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     assert_eq!(result["messages"][0]["content"], "part one part two");
 }
 
@@ -3491,7 +3491,7 @@ fn translate_anthropic_request_image_beside_tool_result_survives() {
         "max_tokens": 1024
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     let msgs = result["messages"].as_array().unwrap();
     assert_eq!(msgs[0]["role"], "tool");
     assert_eq!(msgs[0]["content"], "done");
@@ -3553,8 +3553,48 @@ fn translate_anthropic_request_stop_sequences() {
         "stop_sequences": ["END", "STOP"]
     });
 
-    let result = translate_anthropic_request_to_openai(&body);
+    let result = translate_anthropic_request_to_openai(&body).unwrap();
     assert_eq!(result["stop"], serde_json::json!(["END", "STOP"]));
+}
+
+#[test]
+fn translate_anthropic_request_unsupported_image_source_fails_loudly() {
+    // An image source type this translator can't represent (e.g. Anthropic's
+    // `file` source) must fail the whole request, not silently drop the image
+    // while keeping the surrounding text.
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Describe this"},
+                {"type": "image", "source": {"type": "file", "file_id": "file_abc"}}
+            ]}
+        ],
+        "max_tokens": 1024
+    });
+
+    let err = translate_anthropic_request_to_openai(&body).unwrap_err();
+    assert!(
+        err.contains("file"),
+        "error should name the unsupported source type: {err}"
+    );
+}
+
+#[test]
+fn translate_anthropic_request_malformed_image_source_fails_loudly() {
+    // A structurally invalid image source (missing required fields) must also
+    // fail loudly rather than being silently dropped.
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png"}}
+            ]}
+        ],
+        "max_tokens": 1024
+    });
+
+    assert!(translate_anthropic_request_to_openai(&body).is_err());
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2584,6 +2584,56 @@ fn translate_request_multi_system_concat() {
 }
 
 #[test]
+fn translate_request_system_array_content() {
+    // OpenAI permits system content as an array of text parts — must not be dropped
+    let req = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "system", "content": [
+                {"type": "text", "text": "You are "},
+                {"type": "text", "text": "helpful"}
+            ]},
+            {"role": "user", "content": "Hello"}
+        ],
+        "max_tokens": 100
+    });
+    let result = translate_openai_to_anthropic(&req);
+    assert_eq!(result["system"], "You are helpful");
+    assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn translate_request_image_url_to_image_block() {
+    // OpenAI image_url parts must become Anthropic image blocks, not pass through raw
+    let req = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "text", "text": "What is this?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="}},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}
+            ]}
+        ],
+        "max_tokens": 100
+    });
+    let result = translate_openai_to_anthropic(&req);
+    let content = result["messages"][0]["content"].as_array().unwrap();
+    assert_eq!(
+        content[0],
+        serde_json::json!({"type": "text", "text": "What is this?"})
+    );
+    // data: URL → base64 source
+    assert_eq!(content[1]["type"], "image");
+    assert_eq!(content[1]["source"]["type"], "base64");
+    assert_eq!(content[1]["source"]["media_type"], "image/png");
+    assert_eq!(content[1]["source"]["data"], "iVBORw0KGgo=");
+    // plain URL → url source
+    assert_eq!(content[2]["type"], "image");
+    assert_eq!(content[2]["source"]["type"], "url");
+    assert_eq!(content[2]["source"]["url"], "https://example.com/cat.jpg");
+}
+
+#[test]
 fn translate_request_no_system() {
     let req = serde_json::json!({
         "model": "claude-sonnet-4-6",
@@ -3366,6 +3416,96 @@ fn translate_anthropic_request_tool_result_array_content() {
     let msgs = result["messages"].as_array().unwrap();
     assert_eq!(msgs[0]["role"], "tool");
     assert_eq!(msgs[0]["content"], "Result line 1Result line 2");
+}
+
+#[test]
+fn translate_anthropic_request_image_blocks() {
+    // Anthropic image blocks must become OpenAI image_url parts, not be filtered out
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Describe this"},
+                {"type": "image", "source": {
+                    "type": "base64", "media_type": "image/jpeg", "data": "abc123"
+                }},
+                {"type": "image", "source": {
+                    "type": "url", "url": "https://example.com/dog.png"
+                }}
+            ]}
+        ],
+        "max_tokens": 1024
+    });
+
+    let result = translate_anthropic_request_to_openai(&body);
+    let content = result["messages"][0]["content"].as_array().unwrap();
+    assert_eq!(
+        content[0],
+        serde_json::json!({"type": "text", "text": "Describe this"})
+    );
+    assert_eq!(content[1]["type"], "image_url");
+    assert_eq!(
+        content[1]["image_url"]["url"],
+        "data:image/jpeg;base64,abc123"
+    );
+    assert_eq!(content[2]["type"], "image_url");
+    assert_eq!(
+        content[2]["image_url"]["url"],
+        "https://example.com/dog.png"
+    );
+}
+
+#[test]
+fn translate_anthropic_request_text_only_array_stays_string() {
+    // Text-only block arrays keep the plain-string content form (no behavior change)
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "text", "text": "part one "},
+                {"type": "text", "text": "part two"}
+            ]}
+        ],
+        "max_tokens": 1024
+    });
+
+    let result = translate_anthropic_request_to_openai(&body);
+    assert_eq!(result["messages"][0]["content"], "part one part two");
+}
+
+#[test]
+fn translate_anthropic_request_image_beside_tool_result_survives() {
+    // Images sharing a user message with tool_results must survive into the
+    // leftover user message, not be text-filtered away
+    let body = serde_json::json!({
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_789", "content": "done"},
+                {"type": "text", "text": "And this image:"},
+                {"type": "image", "source": {
+                    "type": "url", "url": "https://example.com/chart.png"
+                }}
+            ]}
+        ],
+        "max_tokens": 1024
+    });
+
+    let result = translate_anthropic_request_to_openai(&body);
+    let msgs = result["messages"].as_array().unwrap();
+    assert_eq!(msgs[0]["role"], "tool");
+    assert_eq!(msgs[0]["content"], "done");
+    assert_eq!(msgs[1]["role"], "user");
+    let content = msgs[1]["content"].as_array().unwrap();
+    assert_eq!(
+        content[0],
+        serde_json::json!({"type": "text", "text": "And this image:"})
+    );
+    assert_eq!(content[1]["type"], "image_url");
+    assert_eq!(
+        content[1]["image_url"]["url"],
+        "https://example.com/chart.png"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #98 (LAB-714).

Three silent-drop defects in the OpenAI-compat request translation, both directions:

1. **O→A: array-form system content dropped.** `translate_openai_to_anthropic` only read `content.as_str()` for `role: "system"`, so OpenAI's legal `content: [{"type":"text","text":...}]` form vanished silently. Now uses the same string-or-array extraction as the existing `tool`-role handler.
2. **O→A: `image_url` parts passed through untranslated.** Standard messages cloned `content` as-is, so an OpenAI `{"type":"image_url",...}` part reached Anthropic verbatim and 400'd the whole request. Now translated to Anthropic `image` blocks: `data:` URLs unpack into `base64` sources, other URLs become `url` sources. Malformed data URLs fall through to a `url` source so upstream rejects them with a real error instead of us dropping them.
3. **A→O: image blocks filtered out silently.** `translate_anthropic_request_to_openai` kept only `type == "text"` blocks in user content (worst case an empty `content: ""` message) — in both the plain-user path and the tool_result-leftover path. Both now route through a shared helper that emits OpenAI `image_url` parts; text-only arrays keep the plain-string content form, so existing behavior is unchanged when no images are present.

## Tests

Five new regression tests: array-form system content, O→A image translation (data: and https URLs), A→O image translation (base64 and url sources), text-only-array-stays-string invariant, and image-beside-tool_result survival. Full suite: 478 passed, 0 failed. `cargo fmt --check` and `clippy -Dwarnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved request translation for image content, including correct handling of URL and base64 (data URL) sources.
  * Added support for system messages provided as multiple text parts.
  * Preserved mixed text, image, and tool-result content when translating requests.

* **Bug Fixes**
  * When translation fails during fallback routing, the app now returns a clear HTTP 400 `invalid_request_error` instead of retrying or rotating endpoints.
  * Better error surfacing for unsupported or malformed image/content blocks.

* **Tests**
  * Expanded coverage for translation edge cases and stricter assertions for stop-sequence formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->