### PR TITLE
LAB-711: gate strip_json_fences on response_format: json_object (GH #95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,18 @@ IP check runs first, then proxy key. Both apply to all endpoints including `/_st
 
 All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
 
+### OpenAI JSON-mode compatibility
+
+> [!IMPORTANT]
+> **Breaking change:** `/v1/chat/completions` now strips surrounding Markdown
+> fences only when the request explicitly sets
+> `response_format: {"type":"json_object"}`. Previously, non-streaming
+> responses were stripped unconditionally, which could alter a legitimate
+> fenced code-block response. To preserve the prior raw-JSON normalization,
+> send `response_format: {"type":"json_object"}`; otherwise consume the
+> model content verbatim. Streaming and non-streaming responses now follow the
+> same rule.
+
 <details>
 <summary><strong>Example <code>/_stats</code> response</strong></summary>
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7613,6 +7613,11 @@ struct StreamContext {
     tool_call_index: i64,
     in_tool_use: bool,
     current_tool_id: String,
+    /// Request asked for `response_format: json_object`.
+    json_mode: bool,
+    /// Text content buffered while `json_mode` is set, flushed fence-stripped
+    /// at end-of-message so streaming content matches the non-streaming strip.
+    text_buffer: String,
 }
 
 impl Default for StreamContext {
@@ -7624,7 +7629,24 @@ impl Default for StreamContext {
             tool_call_index: -1,
             in_tool_use: false,
             current_tool_id: String::new(),
+            json_mode: false,
+            text_buffer: String::new(),
         }
+    }
+}
+
+impl StreamContext {
+    /// In JSON mode, drain the buffered text and strip fences over the whole
+    /// message — the streaming equivalent of the non-streaming strip, applied
+    /// once so fences split across deltas are handled. Returns None when not in
+    /// JSON mode, the buffer is empty, or the strip yields nothing.
+    fn take_stripped_json_content(&mut self) -> Option<String> {
+        if !self.json_mode || self.text_buffer.is_empty() {
+            return None;
+        }
+        let stripped = strip_json_fences(&self.text_buffer);
+        self.text_buffer.clear();
+        (!stripped.is_empty()).then_some(stripped)
     }
 }
 
@@ -8069,6 +8091,14 @@ fn translate_sse_event(raw: &str, ctx: &mut StreamContext) -> Option<String> {
                 if text.is_empty() {
                     return None;
                 }
+                if ctx.json_mode {
+                    // Buffer JSON-mode text; fences are stripped once over the
+                    // whole message at message_delta (they may be split across
+                    // deltas). Partial JSON is unparseable, so deferring the
+                    // emit costs the client nothing.
+                    ctx.text_buffer.push_str(text);
+                    return None;
+                }
                 Some(make_openai_chunk(
                     ctx,
                     serde_json::json!({"content": text}),
@@ -8087,13 +8117,35 @@ fn translate_sse_event(raw: &str, ctx: &mut StreamContext) -> Option<String> {
                 .pointer("/delta/stop_reason")
                 .and_then(|v| v.as_str())
                 .unwrap_or("end_turn");
-            Some(make_openai_chunk(
+            let finish = make_openai_chunk(
                 ctx,
                 serde_json::json!({}),
                 Some(map_stop_reason(stop_reason)),
-            ))
+            );
+            // Flush buffered JSON-mode content (fence-stripped) as its own chunk
+            // before the finish chunk, preserving OpenAI content→finish order.
+            match ctx.take_stripped_json_content() {
+                Some(content) => {
+                    let content_chunk =
+                        make_openai_chunk(ctx, serde_json::json!({ "content": content }), None);
+                    Some(format!("{content_chunk}{finish}"))
+                }
+                None => Some(finish),
+            }
         }
-        "message_stop" => Some("data: [DONE]\n\n".to_string()),
+        "message_stop" => {
+            // Safety net: if message_delta never arrived (abnormal upstream),
+            // flush buffered JSON-mode content before closing so it is never
+            // silently dropped.
+            match ctx.take_stripped_json_content() {
+                Some(content) => {
+                    let content_chunk =
+                        make_openai_chunk(ctx, serde_json::json!({ "content": content }), None);
+                    Some(format!("{content_chunk}data: [DONE]\n\n"))
+                }
+                None => Some("data: [DONE]\n\n".to_string()),
+            }
+        }
         _ => None, // ping
     }
 }
@@ -8938,7 +8990,10 @@ async fn forward_openai_compat_anthropic(
         tokio::spawn(async move {
             let mut buffer: Vec<u8> = Vec::new();
             let mut scanner = SseUsageScanner::default();
-            let mut ctx = StreamContext::default();
+            let mut ctx = StreamContext {
+                json_mode,
+                ..StreamContext::default()
+            };
             let mut sent_done = false;
 
             let mut client_gone = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7564,10 +7564,22 @@ async fn metrics_handler(
 
 // ── OpenAI compatibility ─────────────────────────────────────────────
 
+/// True when an OpenAI-format request asked for `response_format: json_object`.
+/// Single predicate shared by the request-side system nudge and the
+/// response-side fence strip so the two can never disagree on what JSON mode is.
+fn wants_json_object(body: &serde_json::Value) -> bool {
+    body.get("response_format")
+        .and_then(|rf| rf.get("type"))
+        .and_then(|t| t.as_str())
+        == Some("json_object")
+}
+
 /// Strip markdown JSON fences from LLM output.
 /// Claude sometimes wraps JSON in ```json ... ``` even when told not to.
 /// Clients using response_format: json_object (e.g. Vercel AI SDK's generateObject)
 /// need raw JSON or their parse step blows up.
+/// Only applied when the request asked for JSON mode — a normal chat reply
+/// that legitimately is a fenced code block must pass through verbatim.
 fn strip_json_fences(s: &str) -> String {
     let trimmed = s.trim();
     if let Some(rest) = trimmed.strip_prefix("```") {
@@ -7768,12 +7780,10 @@ fn translate_openai_to_anthropic(body: &serde_json::Value) -> serde_json::Value 
     }
 
     // response_format: inject JSON mode instruction into system prompt
-    if let Some(rf) = body.get("response_format") {
-        if rf.get("type").and_then(|t| t.as_str()) == Some("json_object") {
-            system_parts.push(
-                "You must respond with valid JSON only. No markdown, no code fences, no explanation — just raw JSON.".to_string(),
-            );
-        }
+    if wants_json_object(body) {
+        system_parts.push(
+            "You must respond with valid JSON only. No markdown, no code fences, no explanation — just raw JSON.".to_string(),
+        );
     }
 
     if !system_parts.is_empty() {
@@ -7864,7 +7874,7 @@ fn translate_openai_to_anthropic(body: &serde_json::Value) -> serde_json::Value 
     serde_json::Value::Object(out)
 }
 
-fn translate_anthropic_to_openai(body: &serde_json::Value) -> serde_json::Value {
+fn translate_anthropic_to_openai(body: &serde_json::Value, json_mode: bool) -> serde_json::Value {
     let id = body
         .get("id")
         .and_then(|v| v.as_str())
@@ -7876,7 +7886,8 @@ fn translate_anthropic_to_openai(body: &serde_json::Value) -> serde_json::Value 
 
     let blocks = body.get("content").and_then(|c| c.as_array());
 
-    // Concatenate text content blocks, strip markdown JSON fences
+    // Concatenate text content blocks; strip markdown JSON fences only when
+    // the request asked for response_format: json_object.
     let content = blocks
         .map(|blocks| {
             let raw = blocks
@@ -7885,7 +7896,11 @@ fn translate_anthropic_to_openai(body: &serde_json::Value) -> serde_json::Value 
                 .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
                 .collect::<Vec<_>>()
                 .join("");
-            strip_json_fences(&raw)
+            if json_mode {
+                strip_json_fences(&raw)
+            } else {
+                raw
+            }
         })
         .unwrap_or_default();
 
@@ -8690,6 +8705,7 @@ async fn forward_openai_compat_anthropic(
     session_id: &str,
     model: &str,
     is_streaming: bool,
+    json_mode: bool,
     request_start: std::time::Instant,
 ) -> ForwardOutcome {
     let token = ep.token.as_str();
@@ -9069,7 +9085,7 @@ async fn forward_openai_compat_anthropic(
         }
     };
 
-    let openai_resp = translate_anthropic_to_openai(&anthropic_resp);
+    let openai_resp = translate_anthropic_to_openai(&anthropic_resp, json_mode);
 
     // Extract and record token usage from non-streaming response
     let usage = TokenUsage::from_response_body(&anthropic_resp);
@@ -9181,6 +9197,7 @@ async fn openai_chat_handler(
         .get("stream")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    let json_mode = wants_json_object(&openai_body);
     let model = openai_body
         .get("model")
         .and_then(|m| m.as_str())
@@ -9258,6 +9275,7 @@ async fn openai_chat_handler(
                                     &session_id,
                                     &model,
                                     is_streaming,
+                                    json_mode,
                                     request_start,
                                 )
                                 .await;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2956,7 +2956,7 @@ fn translate_response_basic() {
         "stop_reason": "end_turn",
         "usage": {"input_tokens": 10, "output_tokens": 5}
     });
-    let result = translate_anthropic_to_openai(&resp);
+    let result = translate_anthropic_to_openai(&resp, false);
     assert_eq!(result["id"], "chatcmpl-msg_abc123");
     assert_eq!(result["object"], "chat.completion");
     assert_eq!(result["choices"][0]["message"]["role"], "assistant");
@@ -2973,7 +2973,7 @@ fn translate_response_usage_mapping() {
         "stop_reason": "end_turn",
         "usage": {"input_tokens": 25, "output_tokens": 15}
     });
-    let result = translate_anthropic_to_openai(&resp);
+    let result = translate_anthropic_to_openai(&resp, false);
     assert_eq!(result["usage"]["prompt_tokens"], 25);
     assert_eq!(result["usage"]["completion_tokens"], 15);
     assert_eq!(result["usage"]["total_tokens"], 40);
@@ -3015,6 +3015,8 @@ fn strip_json_fences_with_whitespace() {
 
 #[test]
 fn translate_response_strips_markdown_fences() {
+    // Fence stripping is gated on the request having asked for
+    // response_format: json_object (json_mode = true).
     let resp = serde_json::json!({
         "id": "msg_fenced",
         "content": [{"type": "text", "text": "```json\n{\"skipSearch\": true}\n```"}],
@@ -3022,11 +3024,38 @@ fn translate_response_strips_markdown_fences() {
         "stop_reason": "end_turn",
         "usage": {"input_tokens": 10, "output_tokens": 5}
     });
-    let result = translate_anthropic_to_openai(&resp);
+    let result = translate_anthropic_to_openai(&resp, true);
     assert_eq!(
         result["choices"][0]["message"]["content"],
         r#"{"skipSearch": true}"#
     );
+}
+
+#[test]
+fn translate_response_preserves_fences_without_json_mode() {
+    // A normal chat reply that IS a fenced code block must pass through
+    // verbatim — fences, language tag, and surrounding whitespace intact.
+    let text = "```python\nprint(\"hi\")\n```";
+    let resp = serde_json::json!({
+        "id": "msg_code",
+        "content": [{"type": "text", "text": text}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5}
+    });
+    let result = translate_anthropic_to_openai(&resp, false);
+    assert_eq!(result["choices"][0]["message"]["content"], text);
+}
+
+#[test]
+fn wants_json_object_detection() {
+    assert!(wants_json_object(&serde_json::json!({
+        "response_format": {"type": "json_object"}
+    })));
+    assert!(!wants_json_object(&serde_json::json!({
+        "response_format": {"type": "text"}
+    })));
+    assert!(!wants_json_object(&serde_json::json!({})));
 }
 
 #[test]
@@ -3041,7 +3070,7 @@ fn translate_response_tool_use_blocks() {
         "stop_reason": "tool_use",
         "usage": {"input_tokens": 20, "output_tokens": 15}
     });
-    let result = translate_anthropic_to_openai(&resp);
+    let result = translate_anthropic_to_openai(&resp, false);
     assert_eq!(result["choices"][0]["finish_reason"], "tool_calls");
     assert!(result["choices"][0]["message"]["content"].is_null());
     let tcs = result["choices"][0]["message"]["tool_calls"]
@@ -3069,7 +3098,7 @@ fn translate_response_mixed_text_and_tool_use() {
         "stop_reason": "tool_use",
         "usage": {"input_tokens": 10, "output_tokens": 10}
     });
-    let result = translate_anthropic_to_openai(&resp);
+    let result = translate_anthropic_to_openai(&resp, false);
     assert_eq!(result["choices"][0]["message"]["content"], "Let me check.");
     let tcs = result["choices"][0]["message"]["tool_calls"]
         .as_array()
@@ -4575,6 +4604,72 @@ async fn openai_chat_non_streaming() {
     assert_eq!(body["usage"]["prompt_tokens"], 10);
     assert_eq!(body["usage"]["completion_tokens"], 5);
     assert_eq!(body["usage"]["total_tokens"], 15);
+}
+
+/// Mock whose reply IS a fenced code block — exercises the json_mode gate
+/// end-to-end (GH #95 / LAB-711).
+async fn mock_anthropic_fenced_handler(_req: Request<Body>) -> Response {
+    axum::Json(serde_json::json!({
+        "id": "msg_fenced",
+        "type": "message",
+        "content": [{"type": "text", "text": "```json\n{\"a\": 1}\n```"}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5}
+    }))
+    .into_response()
+}
+
+#[tokio::test]
+async fn openai_chat_fence_strip_gated_on_response_format() {
+    let mock_app = Router::new().fallback(any(mock_anthropic_fenced_handler));
+    let mock_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mock_addr = mock_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(mock_listener, mock_app).await.unwrap();
+    });
+
+    let (app, _state) = test_openai_app(&format!("http://{}", mock_addr), None);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let client = Client::new();
+
+    // Without response_format: fenced content passes through verbatim.
+    let resp = client
+        .post(format!("http://{}/v1/chat/completions", addr))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["choices"][0]["message"]["content"], "```json\n{\"a\": 1}\n```",
+        "non-JSON-mode reply must not be mutated"
+    );
+
+    // With response_format json_object: fences stripped.
+    let resp = client
+        .post(format!("http://{}/v1/chat/completions", addr))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"json_object"}}"#)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["choices"][0]["message"]["content"], r#"{"a": 1}"#,
+        "JSON-mode reply must have fences stripped"
+    );
 }
 
 #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3402,6 +3402,39 @@ fn json_mode_stream_buffers_deltas_then_flushes_content_before_finish() {
     );
 }
 
+#[test]
+fn json_mode_stream_message_stop_safety_net_flushes_buffer() {
+    // Abnormal upstream: message_stop arrives without a preceding
+    // message_delta. The buffered JSON-mode content must still be flushed
+    // (fence-stripped) ahead of [DONE], never silently dropped.
+    let mut ctx = StreamContext {
+        json_mode: true,
+        ..Default::default()
+    };
+    let payload = serde_json::json!({
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "```json\n{\"ok\":true}\n```"},
+    });
+    assert!(translate_sse_event(
+        &format!("event: content_block_delta\ndata: {payload}"),
+        &mut ctx
+    )
+    .is_none());
+
+    let output = translate_sse_event(
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}",
+        &mut ctx,
+    )
+    .unwrap();
+    let mut frames = output
+        .split("\n\n")
+        .filter_map(|f| f.strip_prefix("data: "));
+    let content: serde_json::Value = serde_json::from_str(frames.next().unwrap()).unwrap();
+    assert_eq!(content["choices"][0]["delta"]["content"], r#"{"ok":true}"#);
+    assert_eq!(frames.next(), Some("[DONE]"));
+}
+
 // ── Reverse translation: Anthropic → OpenAI ──────────────────────
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3352,6 +3352,56 @@ fn stream_nonstream_content_parity_default_mode() {
     assert_eq!(stream_default, nonstream_default);
 }
 
+#[test]
+fn json_mode_stream_buffers_deltas_then_flushes_content_before_finish() {
+    let mut ctx = StreamContext {
+        json_mode: true,
+        ..Default::default()
+    };
+
+    let start = "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}";
+    translate_sse_event(start, &mut ctx);
+
+    // The complete fenced JSON reply spans two deltas. Neither partial delta
+    // may be forwarded, because fence removal is applied to the whole reply.
+    for text in ["```json\n{\"first\":", "true}\n```"] {
+        let payload = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": text},
+        });
+        let event = format!("event: content_block_delta\ndata: {payload}");
+        assert!(translate_sse_event(&event, &mut ctx).is_none());
+    }
+
+    let finish = "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}";
+    let output = translate_sse_event(finish, &mut ctx).unwrap();
+    let frames: Vec<_> = output
+        .split("\n\n")
+        .filter_map(|frame| frame.strip_prefix("data: "))
+        .map(|frame| serde_json::from_str::<serde_json::Value>(frame).unwrap())
+        .collect();
+
+    // The buffered, fence-stripped content is emitted exactly once and always
+    // precedes the OpenAI finish chunk.
+    assert_eq!(frames.len(), 2);
+    assert_eq!(
+        frames[0]["choices"][0]["delta"]["content"],
+        r#"{"first":true}"#
+    );
+    assert!(frames[0]["choices"][0]["finish_reason"].is_null());
+    assert_eq!(frames[1]["choices"][0]["delta"], serde_json::json!({}));
+    assert_eq!(frames[1]["choices"][0]["finish_reason"], "stop");
+    assert_eq!(
+        translate_sse_event(
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}",
+            &mut ctx
+        )
+        .as_deref(),
+        Some("data: [DONE]\n\n")
+    );
+}
+
 // ── Reverse translation: Anthropic → OpenAI ──────────────────────
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3255,6 +3255,103 @@ fn translate_sse_multiple_tool_calls() {
     );
 }
 
+// ── Regression: streaming ↔ non-streaming content parity (LAB-711) ──
+// A fenced reply must yield identical assembled content whether the client
+// used stream:true or stream:false, in both default and json_object modes.
+// Fences can be split across SSE deltas, so the streaming path buffers text
+// and strips the whole message once — the same strip the non-streaming path
+// applies. See GH #95 / codex-sol review.
+
+/// Reconstruct the OpenAI `content` a client would assemble from an Anthropic
+/// text reply delivered as `text_deltas` SSE frames.
+fn reconstruct_stream_content(text_deltas: &[&str], json_mode: bool) -> String {
+    let mut ctx = StreamContext {
+        json_mode,
+        ..Default::default()
+    };
+    let mut events: Vec<String> = vec![
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_x\",\"model\":\"claude-sonnet-4-6\",\"role\":\"assistant\"}}".to_string(),
+        "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}".to_string(),
+    ];
+    for d in text_deltas {
+        let payload = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": d},
+        });
+        events.push(format!("event: content_block_delta\ndata: {payload}"));
+    }
+    events.push(
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}"
+            .to_string(),
+    );
+    events.push("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}".to_string());
+    events.push("event: message_stop\ndata: {\"type\":\"message_stop\"}".to_string());
+
+    let mut content = String::new();
+    for ev in &events {
+        let Some(out) = translate_sse_event(ev, &mut ctx) else {
+            continue;
+        };
+        // One translation may carry multiple `data:` frames (buffered content
+        // flushed together with the finish chunk).
+        for frame in out.split("\n\n") {
+            let Some(json) = frame.trim().strip_prefix("data: ") else {
+                continue;
+            };
+            if json == "[DONE]" {
+                continue;
+            }
+            let chunk: serde_json::Value = serde_json::from_str(json).unwrap();
+            if let Some(c) = chunk["choices"][0]["delta"]["content"].as_str() {
+                content.push_str(c);
+            }
+        }
+    }
+    content
+}
+
+/// Non-streaming assembled content for the same reply text.
+fn nonstream_content(full_text: &str, json_mode: bool) -> String {
+    let resp = serde_json::json!({
+        "id": "msg_x",
+        "content": [{"type": "text", "text": full_text}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    });
+    translate_anthropic_to_openai(&resp, json_mode)["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn stream_nonstream_content_parity_json_mode() {
+    // Fence deliberately split across three SSE deltas.
+    let deltas = ["```jso", "n\n{\"ok\":true}\n``", "`"];
+    let full: String = deltas.concat();
+    assert_eq!(full, "```json\n{\"ok\":true}\n```");
+
+    let stream_json = reconstruct_stream_content(&deltas, true);
+    let nonstream_json = nonstream_content(&full, true);
+    // Both transports strip the fence down to raw JSON, and agree.
+    assert_eq!(stream_json, r#"{"ok":true}"#);
+    assert_eq!(stream_json, nonstream_json);
+}
+
+#[test]
+fn stream_nonstream_content_parity_default_mode() {
+    // Same reply, default (non-JSON) mode: fences preserved on both transports.
+    let deltas = ["```jso", "n\n{\"ok\":true}\n``", "`"];
+    let full: String = deltas.concat();
+
+    let stream_default = reconstruct_stream_content(&deltas, false);
+    let nonstream_default = nonstream_content(&full, false);
+    assert_eq!(stream_default, full);
+    assert_eq!(stream_default, nonstream_default);
+}
+
 // ── Reverse translation: Anthropic → OpenAI ──────────────────────
 
 #[test]
@@ -4669,6 +4766,117 @@ async fn openai_chat_fence_strip_gated_on_response_format() {
     assert_eq!(
         body["choices"][0]["message"]["content"], r#"{"a": 1}"#,
         "JSON-mode reply must have fences stripped"
+    );
+}
+
+/// Streaming mock whose reply IS a fenced code block, split across three text
+/// deltas so a fence spans SSE frame boundaries. Same reply as
+/// `mock_anthropic_fenced_handler` for a direct stream/non-stream comparison.
+async fn mock_anthropic_streaming_fenced_handler(req: Request<Body>) -> Response {
+    let has_auth =
+        req.headers().contains_key("x-api-key") || req.headers().contains_key("authorization");
+    if !has_auth {
+        return (StatusCode::UNAUTHORIZED, "missing auth").into_response();
+    }
+    let deltas = ["```js", "on\n{\"a\": 1}", "\n```"];
+    let mut body = String::from(
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_fenced_stream\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-6\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    );
+    for d in deltas {
+        let payload = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": d},
+        });
+        body.push_str(&format!("event: content_block_delta\ndata: {payload}\n\n"));
+    }
+    body.push_str(
+        "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    );
+    body.push_str("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n");
+    body.push_str("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/event-stream")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+/// End-to-end: the streaming path must honour the same json_mode gate as
+/// non-streaming, so a fenced reply yields identical assembled content across
+/// transports (GH #95 / LAB-711 — closes the handler-plumbing gap that unit
+/// tests on translate_sse_event alone cannot cover).
+#[tokio::test]
+async fn openai_chat_streaming_fence_strip_gated_on_response_format() {
+    let mock_app = Router::new().fallback(any(mock_anthropic_streaming_fenced_handler));
+    let mock_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mock_addr = mock_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(mock_listener, mock_app).await.unwrap();
+    });
+
+    let (app, _state) = test_openai_app(&format!("http://{}", mock_addr), None);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let client = Client::new();
+
+    // Assemble the `content` a client would see from an SSE response body.
+    fn assemble(body: &str) -> String {
+        let mut content = String::new();
+        for line in body.lines() {
+            let Some(data) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            if data == "[DONE]" {
+                continue;
+            }
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
+                if let Some(c) = v["choices"][0]["delta"]["content"].as_str() {
+                    content.push_str(c);
+                }
+            }
+        }
+        content
+    }
+
+    // stream:true without response_format → fenced content passes verbatim.
+    let resp = client
+        .post(format!("http://{}/v1/chat/completions", addr))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Hi"}],"stream":true}"#)
+        .send()
+        .await
+        .unwrap();
+    let body = resp.text().await.unwrap();
+    assert_eq!(
+        assemble(&body),
+        "```json\n{\"a\": 1}\n```",
+        "streaming non-JSON-mode must not mutate content"
+    );
+
+    // stream:true with response_format json_object → fences stripped, matching
+    // the non-streaming json_object result exactly.
+    let resp = client
+        .post(format!("http://{}/v1/chat/completions", addr))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Hi"}],"stream":true,"response_format":{"type":"json_object"}}"#)
+        .send()
+        .await
+        .unwrap();
+    let body = resp.text().await.unwrap();
+    assert_eq!(
+        assemble(&body),
+        r#"{"a": 1}"#,
+        "streaming JSON-mode must strip fences, matching non-streaming"
     );
 }
 


### PR DESCRIPTION
Fixes #95 · Multica LAB-711

## Problem

`translate_anthropic_to_openai` ran `strip_json_fences` on **every** non-streaming response:

1. **Content mutation** — a reply that legitimately *is* a fenced code block had its fences and language tag stripped and the content re-trimmed.
2. **Transport inconsistency** — streaming passes text deltas verbatim, so the same reply differed between `stream: true` and `stream: false`.

## Fix

Fence stripping is now gated on the request having asked for `response_format: json_object`:

- New `wants_json_object()` predicate — shared by the request-side JSON-mode system nudge and the response-side strip, so the two can never disagree on what JSON mode is.
- `openai_chat_handler` computes `json_mode` from the original OpenAI body and threads it through `forward_openai_compat_anthropic` → `translate_anthropic_to_openai(body, json_mode)`.
- No streaming-translator changes needed: streaming already passes content verbatim, which now matches non-streaming default behaviour.

## Acceptance criteria

- [x] Non-streaming without `json_object` → verbatim content (`translate_response_preserves_fences_without_json_mode`, plus end-to-end `openai_chat_fence_strip_gated_on_response_format`)
- [x] Non-streaming with `json_object` → fences still stripped (same tests, `json_mode = true` leg)
- [x] `stream: true` / `stream: false` equivalent content — both now verbatim by default
- [x] `translate_response_strips_markdown_fences` updated to assert the gated behaviour

## Testing

- `cargo fmt --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` ✓
- `cargo test` — 446 + 18 + 12 passed, 0 failed. Includes a new integration test driving the full router with a mock upstream whose reply is a fenced code block, asserting both gate directions end-to-end.

Note: the `json_object` + `stream: true` corner still passes fences through (stripping SSE deltas would require buffering the whole stream, defeating streaming). This matches the issue's scope ("streaming translator changes beyond achieving parity" are out) and the GH #95 fix sketch.
