### PR TITLE
LAB-712: record OpenAI-endpoint non-streaming usage into per-client budget accounting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6059,8 +6059,22 @@ async fn try_fallback_upstream(
     // OpenAI non-streaming bodies carry usage.prompt_tokens/completion_tokens —
     // record them like the Anthropic path so per-client token + budget
     // enforcement (`pre_request_gate`) sees OpenAI-endpoint spend (LAB-712).
-    let openai_resp: serde_json::Value =
-        serde_json::from_slice(&resp_body).unwrap_or(serde_json::json!({}));
+    let openai_resp: serde_json::Value = match serde_json::from_slice(&resp_body) {
+        Ok(v) => v,
+        Err(e) => {
+            // Still serve the response (passthrough forwards the raw bytes),
+            // but the malformed body means usage records as zero — say so.
+            warn!(
+                req_id,
+                client_id,
+                model,
+                upstream = ep.name,
+                error = %e,
+                "fallback: unified endpoint response body is not valid JSON; usage not recorded"
+            );
+            serde_json::json!({})
+        }
+    };
     let usage = TokenUsage::from_openai_response_body(&openai_resp);
     finalize_non_stream(
         state,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3745,6 +3745,23 @@ impl TokenUsage {
         }
     }
 
+    /// Parse usage from an OpenAI-format response body (non-streaming JSON).
+    /// OpenAI reports `prompt_tokens`/`completion_tokens`; there is no
+    /// Anthropic-style cache-token split, so those fields stay 0.
+    fn from_openai_response_body(body: &serde_json::Value) -> Self {
+        Self {
+            input_tokens: body
+                .pointer("/usage/prompt_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+            output_tokens: body
+                .pointer("/usage/completion_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+            ..Self::default()
+        }
+    }
+
     /// Parse usage from SSE chunks (accumulated from streaming response).
     /// Looks for message_start (input_tokens, cache tokens) and message_delta (output_tokens).
     fn from_sse_text(text: &str) -> Self {
@@ -5541,8 +5558,12 @@ async fn proxy_handler(
                                     &body_bytes,
                                     &req_id,
                                     &client_id,
+                                    &client_ip,
+                                    &agent_id,
+                                    &session_id,
                                     &model,
                                     i,
+                                    request_start,
                                     true,
                                 )
                                 .await;
@@ -5595,16 +5616,23 @@ async fn proxy_handler(
 /// per-endpoint circuit breaker; upstream 429/5xx rotate immediately. Other
 /// 4xx (e.g. 400, 401) are `Done` — retry won't help on client-side errors.
 ///
-/// Only increments the endpoint's request counter; it does not call
-/// `record_usage` (OpenAI-compat responses don't carry the same usage signal we
-/// extract for Anthropic).
+/// Non-streaming responses are accounted via `finalize_non_stream`: OpenAI
+/// bodies carry `usage.prompt_tokens`/`completion_tokens`, mapped to
+/// input/output tokens so per-client token + budget enforcement sees this
+/// spend (LAB-712). Streaming responses still record nothing — the SSE
+/// translator does not yet extract incremental usage (rides with LAB-717).
+#[allow(clippy::too_many_arguments)]
 async fn try_fallback_upstream(
     state: &AppState,
     body_bytes: &[u8],
     req_id: &str,
     client_id: &str,
+    client_ip: &std::net::IpAddr,
+    agent_id: &str,
+    session_id: &str,
     model: &str,
     endpoint_idx: usize,
+    request_start: std::time::Instant,
     translate: bool, // true = Anthropic↔OpenAI translation needed
 ) -> ForwardOutcome {
     // Non-transient rotation: skip this endpoint and try the next candidate.
@@ -5917,9 +5945,30 @@ async fn try_fallback_upstream(
         }
     };
 
+    // OpenAI non-streaming bodies carry usage.prompt_tokens/completion_tokens —
+    // record them like the Anthropic path so per-client token + budget
+    // enforcement (`pre_request_gate`) sees OpenAI-endpoint spend (LAB-712).
+    let openai_resp: serde_json::Value =
+        serde_json::from_slice(&resp_body).unwrap_or(serde_json::json!({}));
+    let usage = TokenUsage::from_openai_response_body(&openai_resp);
+    finalize_non_stream(
+        state,
+        ep,
+        req_id,
+        client_id,
+        model,
+        &ep.name,
+        &client_ip.to_string(),
+        agent_id,
+        session_id,
+        status.as_u16(),
+        &usage,
+        request_start.elapsed().as_millis() as u64,
+        !translate, // openai_compat marks the client surface: translate=false ⇒ OpenAI-format caller
+    )
+    .await;
+
     if translate {
-        let openai_resp: serde_json::Value =
-            serde_json::from_slice(&resp_body).unwrap_or(serde_json::json!({}));
         let anthropic_resp = translate_openai_response_to_anthropic(&openai_resp);
         info!(
             req_id,
@@ -9190,8 +9239,12 @@ async fn openai_chat_handler(
                                     &body_bytes,
                                     &req_id,
                                     &client_id,
+                                    &client_ip,
+                                    &agent_id,
+                                    &session_id,
                                     &model,
                                     i,
+                                    request_start,
                                     false,
                                 )
                                 .await;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12753,8 +12753,12 @@ async fn try_fallback_upstream_rotates_on_429() {
         body,
         "req-1",
         "client-1",
+        &"127.0.0.1".parse().unwrap(),
+        "-",
+        "-",
         "claude-opus-4-7",
         0,
+        Instant::now(),
         false,
     )
     .await;
@@ -12793,8 +12797,12 @@ async fn try_fallback_upstream_rotates_on_500() {
         body,
         "req-1",
         "client-1",
+        &"127.0.0.1".parse().unwrap(),
+        "-",
+        "-",
         "claude-opus-4-7",
         0,
+        Instant::now(),
         false,
     )
     .await;
@@ -12828,8 +12836,12 @@ async fn try_fallback_upstream_transport_error_is_transient_and_counted() {
         body,
         "req-1",
         "client-1",
+        &"127.0.0.1".parse().unwrap(),
+        "-",
+        "-",
         "claude-opus-4-7",
         0,
+        Instant::now(),
         false,
     )
     .await;
@@ -12848,6 +12860,81 @@ async fn try_fallback_upstream_transport_error_is_transient_and_counted() {
     assert_eq!(
         info.consecutive_transport_failures, 1,
         "the transport failure must feed the per-endpoint circuit breaker"
+    );
+}
+
+/// LAB-712: a non-streaming response from a `Protocol::OpenAI` endpoint must
+/// record its `usage.prompt_tokens`/`completion_tokens` into per-client
+/// token + budget accounting. Previously this path only bumped `ep.requests`,
+/// leaving `pre_request_gate` budget enforcement blind to OpenAI-endpoint spend.
+#[tokio::test]
+async fn try_fallback_upstream_records_usage_and_budget() {
+    // Mock OpenAI upstream: non-streaming chat completion with usage.
+    let app = Router::new().fallback(any(|| async {
+        axum::Json(serde_json::json!({
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "model": "claude-opus-4-7",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 60, "completion_tokens": 50, "total_tokens": 110}
+        }))
+        .into_response()
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let mut budgets = HashMap::new();
+    budgets.insert("client-1".to_string(), 100u64);
+    let mut ep = make_endpoint("gw", Protocol::OpenAI);
+    ep.base_url = format!("http://{}", addr);
+    let state = Arc::new(AppState {
+        endpoints: vec![ep],
+        client_budgets: budgets,
+        ..test_state_base()
+    });
+
+    assert!(state.check_budget("client-1").await.is_ok());
+
+    let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+    let result = try_fallback_upstream(
+        &state,
+        body,
+        "req-1",
+        "client-1",
+        &"127.0.0.1".parse().unwrap(),
+        "-",
+        "-",
+        "claude-opus-4-7",
+        0,
+        Instant::now(),
+        true,
+    )
+    .await;
+    assert!(matches!(result, ForwardOutcome::Done(_)));
+
+    // Endpoint + per-client token counters advance by the reported usage.
+    assert_eq!(state.endpoints[0].input_tokens.load(Ordering::Relaxed), 60);
+    assert_eq!(state.endpoints[0].output_tokens.load(Ordering::Relaxed), 50);
+    {
+        let map = state.client_usage.lock().unwrap();
+        assert_eq!(map.get("client-1").unwrap(), &[60, 50, 0, 0]);
+    }
+
+    // Budget sees the spend: 110 tokens against a 100-token budget → gate closes.
+    {
+        let map = state.budget_usage.lock().unwrap();
+        assert_eq!(map.get("client-1").unwrap().1, 110);
+    }
+    assert!(
+        state.check_budget("client-1").await.is_err(),
+        "pre_request_gate budget check must see OpenAI-endpoint spend"
     );
 }
 // ── Unified endpoint: cross-protocol handler routing ───────────


### PR DESCRIPTION
Closes #96 · Multica: LAB-712

## Problem

Traffic served by `protocol = "openai"` endpoints bypassed per-client token/budget recording entirely. `try_fallback_upstream` only bumped `ep.requests` and never reached the finalizers, so `pre_request_gate` budget enforcement was blind to OpenAI-endpoint spend. The doc-comment rationale ("OpenAI-compat responses don't carry the same usage signal") is false for non-streaming: the body carries `usage.prompt_tokens`/`completion_tokens`, and `translate_openai_response_to_anthropic` was already mapping them for the client — they just were never recorded. (LAB-708 audit headline finding.)

## Fix

- **`TokenUsage::from_openai_response_body`** — parses `usage.prompt_tokens`/`completion_tokens` from an OpenAI-format body. No Anthropic-style cache split exists, so cache fields stay 0; budget total = input+output+cache, so the recorded total is correct either way (OpenAI's `prompt_tokens` already includes cached tokens).
- **`try_fallback_upstream` non-streaming branch** now parses the response body once — shared by both the translate (`/v1/messages` caller) and passthrough (`/v1/chat/completions` caller) branches — and calls `finalize_non_stream`. That yields endpoint token counters, per-client usage tracking, budget recording (`record_budget_usage`, local + Redis), and shadow-log parity with the Anthropic path. Signature gains `client_ip`/`agent_id`/`session_id`/`request_start`, all already in scope at both call sites.
- Doc comment updated to reflect the new behaviour.

## Explicitly out of scope

Streaming stays unrecorded: `translate_openai_sse_to_anthropic` has no incremental usage extraction yet — that rides with LAB-717 (PR #103) per the grooming scope call on the ticket. This PR keeps the budget-recording fix shippable without waiting on the streaming rework.

## Acceptance criteria → evidence

- ✅ Non-streaming `protocol = "openai"` request records prompt/completion tokens via the finalizer path, reusing the already-parsed usage.
- ✅ Budget state reflects the spend: regression test drives a budgeted client over its limit through a mock OpenAI upstream and asserts `check_budget` flips to `Err`.
- ✅ Regression test `try_fallback_upstream_records_usage_and_budget` asserts endpoint counters, `client_usage`, and `budget_usage` advance by the response's reported usage (60/50 → 110 against a 100 budget).

## Verification

- `cargo test` — 444 + 18 + 12 pass, 0 failed
- `cargo fmt --check` — clean
- `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage from non-streaming OpenAI-compatible responses is now parsed and recorded, including prompt and completion tokens.
  * Recorded usage now feeds into per-endpoint and per-client token tracking, including budget/spend accounting.

* **Bug Fixes**
  * Fixed fallback requests previously not including non-streaming OpenAI token usage in spend and budget calculations.

* **Tests**
  * Added coverage to verify usage tracking is recorded correctly and that budget enforcement fails once the configured budget is exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes LAB-712
