### PR TITLE
LAB-713: 429 from Protocol::OpenAI endpoint sets hard-limit cooldown (GH #97)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2170,13 +2170,24 @@ impl AppState {
             }
             match ep.protocol {
                 Protocol::OpenAI => {
-                    // OpenAI endpoints carry no rate-limit data, but they DO
-                    // carry transport health — a circuit-broken endpoint leaves
-                    // the pool the same way an Anthropic one does. If the whole
-                    // pool is circuit-broken this fails closed (429), matching
-                    // the hard-limited precedent; the cooldown bounds the window.
+                    // OpenAI endpoints carry no utilization data, but they DO
+                    // carry 429 hard-limit state and transport health — an
+                    // endpoint that told us to back off, or is circuit-broken,
+                    // leaves the pool the same way an Anthropic one does. If
+                    // the whole pool is excluded this fails closed (429); the
+                    // cooldown bounds the window.
                     {
                         let info = ep.rate_info.read().await;
+                        if let Some(until) = info.hard_limited_until {
+                            if now < until {
+                                trace!(
+                                    endpoint = ep.name,
+                                    hard_limited_secs = until.duration_since(now).as_secs(),
+                                    "pick: skipping hard-limited endpoint"
+                                );
+                                continue;
+                            }
+                        }
                         if let Some(until) = info.transport_unhealthy_until {
                             if now < until {
                                 trace!(
@@ -4817,14 +4828,15 @@ fn describe_reqwest_error(e: &reqwest::Error) -> String {
 
 /// Classify an upstream Anthropic response status into a retry decision.
 ///
-/// Shared by both `forward_anthropic` and `forward_openai_compat_anthropic`,
-/// whose retry-classification logic is byte-identical. For 429 / 529 / other
-/// 5xx it records hard-limit state, persists, and logs exactly as the prior
-/// inline blocks did, returning `Err(ForwardOutcome::Retry { .. })`. For any
-/// non-retry status (2xx success or 4xx client error) it returns
-/// `Ok(resp)` — handing the response back so the caller can continue.
+/// Shared by `forward_anthropic`, `forward_openai_compat_anthropic`, and
+/// `try_fallback_upstream`, so retry classification cannot drift between
+/// protocols. For 429 / 529 / other 5xx it records hard-limit state,
+/// persists, and logs exactly as the prior inline blocks did, returning
+/// `Err(ForwardOutcome::Retry { .. })`. For any non-retry status (2xx
+/// success or 4xx client error) it returns `Ok(resp)` — handing the
+/// response back so the caller can continue.
 async fn classify_retry_status(
-    state: &Arc<AppState>,
+    state: &AppState,
     status: StatusCode,
     rate_info: &RwLock<RateLimitInfo>,
     endpoint_name: &str,
@@ -5795,7 +5807,7 @@ async fn try_fallback_upstream(
     } else {
         &state.client_nonstreaming
     };
-    let mut resp = match http_client
+    let resp = match http_client
         .post(&url)
         .header("authorization", format!("Bearer {}", ep.token))
         .header("content-type", "application/json")
@@ -5839,23 +5851,23 @@ async fn try_fallback_upstream(
     state.record_transport_success(endpoint_idx).await;
 
     let status = resp.status();
+
+    // Classify 429 / 529 / other 5xx via the shared helper so OpenAI
+    // endpoints get the same policy as the Anthropic paths: a 429 marks the
+    // endpoint hard-limited (honouring retry-after) so `pick_endpoint` skips
+    // it for the cooldown window, and a 529 flags the long-base BEBO backoff.
+    // Previously this was a bare rotate — every subsequent request re-hammered
+    // the still-rate-limited endpoint before rotating (GH #97).
+    let mut resp = match classify_retry_status(state, status, &ep.rate_info, &ep.name, resp).await {
+        Ok(resp) => resp,
+        Err(outcome) => return outcome,
+    };
+
     if !status.is_success() {
         let err_body = resp
             .text()
             .await
             .unwrap_or_else(|_| "upstream error".to_string());
-        // Retry-eligible: 429 or 5xx → rotate so the retry loop advances
-        // to the next candidate.
-        if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
-            warn!(
-                req_id,
-                upstream = ep.name,
-                status = status.as_u16(),
-                body = %err_body,
-                "fallback: unified endpoint returned retry-eligible error, advancing"
-            );
-            return ROTATE;
-        }
         warn!(
             req_id,
             upstream = ep.name,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4598,10 +4598,13 @@ async fn openai_429_sets_cooldown_and_next_request_skips_endpoint() {
     let until = info
         .hard_limited_until
         .expect("a 429 from an OpenAI endpoint must set hard_limited_until");
+    // Measured AFTER both round-trips, so the lower bound leaves ~20s of
+    // slack for a loaded CI runner while staying far above the 60s default;
+    // the upper bound is exact (until = t_429 + 120s, and t_429 < now).
     let cooldown = until.duration_since(Instant::now());
     assert!(
-        cooldown > Duration::from_secs(115) && cooldown <= Duration::from_secs(120),
-        "cooldown must honour retry-after: 120 (within test overhead), got {cooldown:?}"
+        cooldown > Duration::from_secs(100) && cooldown <= Duration::from_secs(120),
+        "cooldown must honour retry-after: 120, not fall back to the 60s default, got {cooldown:?}"
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4509,6 +4509,133 @@ async fn openai_endpoint_rides_out_transient_blip() {
     );
 }
 
+// ── GH #97: OpenAI-endpoint 429 hard-limit cooldown + 529 BEBO ───────
+
+/// Raw-TCP upstream that serves `bad_head` (a complete pre-formatted HTTP
+/// response head with an empty body) for its first `bad_first` connections,
+/// then `ok_body` as a 200 on every later connection. Returns
+/// `(base_url, per_connection_hits)`. `usize::MAX` = bad forever.
+async fn spawn_status_then_ok_upstream(
+    bad_first: usize,
+    bad_head: &'static str,
+    ok_body: &'static [u8],
+) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let hits = Arc::new(AtomicUsize::new(0));
+    let h = hits.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut s, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = s.read(&mut buf).await; // drain the request before responding
+            if h.fetch_add(1, Ordering::SeqCst) < bad_first {
+                let _ = s.write_all(bad_head.as_bytes()).await;
+            } else {
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    ok_body.len()
+                );
+                let _ = s.write_all(head.as_bytes()).await;
+                let _ = s.write_all(ok_body).await;
+            }
+            let _ = s.flush().await;
+        }
+    });
+    (format!("http://{addr}"), hits)
+}
+
+/// GH #97 regression: a 429 from a `Protocol::OpenAI` endpoint must set a
+/// hard-limit cooldown (honouring `retry-after`) so a SUBSEQUENT request
+/// skips it at `pick_endpoint` instead of re-hammering an upstream that
+/// told us to back off. Previously the 429 only rotated within the current
+/// request's retry loop — every new request re-attempted the endpoint.
+#[tokio::test]
+async fn openai_429_sets_cooldown_and_next_request_skips_endpoint() {
+    use std::sync::atomic::Ordering;
+    const HEAD_429: &str = "HTTP/1.1 429 Too Many Requests\r\nretry-after: 120\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+    let (limited_url, limited_hits) =
+        spawn_status_then_ok_upstream(usize::MAX, HEAD_429, OPENAI_OK_BODY).await;
+    let (healthy_url, healthy_hits) = spawn_flaky_upstream(0, OPENAI_OK_BODY).await;
+
+    let mut limited = make_endpoint("limited", Protocol::OpenAI);
+    limited.base_url = limited_url;
+    let mut healthy = make_endpoint("healthy", Protocol::OpenAI);
+    healthy.base_url = healthy_url;
+    // Priority forces routing to prefer `limited` until it leaves the pool —
+    // deterministic without depending on affinity hashing.
+    healthy.priority = 1;
+    let state = test_state_with(vec![limited, healthy]);
+    let addr = serve(build_router(state.clone())).await;
+
+    let client = reqwest::Client::new();
+    for _ in 0..2 {
+        let resp = client
+            .post(format!("http://{addr}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::OK,
+            "both requests must succeed via the healthy endpoint"
+        );
+    }
+
+    assert_eq!(
+        limited_hits.load(Ordering::SeqCst),
+        1,
+        "the second request must skip the hard-limited endpoint, not re-hammer it"
+    );
+    assert!(healthy_hits.load(Ordering::SeqCst) >= 2);
+
+    let info = state.endpoints[0].rate_info.read().await;
+    let until = info
+        .hard_limited_until
+        .expect("a 429 from an OpenAI endpoint must set hard_limited_until");
+    assert!(
+        until.duration_since(Instant::now()) > Duration::from_secs(60),
+        "cooldown must honour retry-after: 120, not fall back to the 60s default"
+    );
+}
+
+/// GH #97: a 529 from an OpenAI endpoint must flag `saw_529` so the retry
+/// loop BEBO-retries the pool (long base) instead of exhausting straight to
+/// a 429 — aligned with the Anthropic path via `classify_retry_status`.
+#[tokio::test]
+async fn openai_529_triggers_bebo_backoff_retry() {
+    use std::sync::atomic::Ordering;
+    const HEAD_529: &str =
+        "HTTP/1.1 529 Overloaded\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+    let (url, hits) = spawn_status_then_ok_upstream(1, HEAD_529, OPENAI_OK_BODY).await;
+    let mut gw = make_endpoint("gw", Protocol::OpenAI);
+    gw.base_url = url;
+    let state = test_state_with(vec![gw]);
+    let addr = serve(build_router(state)).await;
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "a 529 that recovers must be BEBO-retried to a 200, not exhausted to a 429"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "exactly one 529 then one successful retry"
+    );
+}
+
 // ── P1-01: in-flight request-body memory admission ──────────────────
 
 /// Reservation accounting: reserve adds, over-budget sheds (None), drop releases.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4598,9 +4598,10 @@ async fn openai_429_sets_cooldown_and_next_request_skips_endpoint() {
     let until = info
         .hard_limited_until
         .expect("a 429 from an OpenAI endpoint must set hard_limited_until");
+    let cooldown = until.duration_since(Instant::now());
     assert!(
-        until.duration_since(Instant::now()) > Duration::from_secs(60),
-        "cooldown must honour retry-after: 120, not fall back to the 60s default"
+        cooldown > Duration::from_secs(115) && cooldown <= Duration::from_secs(120),
+        "cooldown must honour retry-after: 120 (within test overhead), got {cooldown:?}"
     );
 }
 


### PR DESCRIPTION
Closes #97. LAB-713.

## Problem

A 429 from a `protocol = "openai"` endpoint only rotated within the current request's retry loop — `hard_limited_until` was never set, so every subsequent request re-attempted the rate-limited endpoint before rotating: wasted latency plus hammering an upstream that told us to back off. A 529 was likewise folded into generic 5xx rotation with no `saw_529` flag, so no long-base BEBO backoff.

## Fix

The divergence existed because `try_fallback_upstream` predates `classify_retry_status` — so the fix is reuse, not new policy:

- `try_fallback_upstream` now routes 429/529/5xx through the shared `classify_retry_status` helper: a 429 calls `mark_hard_limited_for` (honouring `retry-after`, including burst-429 detection and Redis cross-replica propagation), a 529 sets `saw_529` for the long-base BEBO backoff — identical to the Anthropic forward paths, and the classification can no longer drift between protocols.
- `classify_retry_status`'s `state` parameter relaxed from `&Arc<AppState>` to `&AppState`; existing callers coerce, zero churn.
- `routing_candidates`' `Protocol::OpenAI` branch now skips endpoints with an active `hard_limited_until` (it previously only checked transport health) — without this, setting the cooldown would have been write-only.

## Acceptance criteria

- [x] 429 from an OpenAI endpoint calls `mark_hard_limited_for` (honouring `retry-after`) before returning a rotate outcome — via `classify_retry_status` reuse.
- [x] A subsequent request skips the still-cooling endpoint at `pick_endpoint` — `routing_candidates` OpenAI branch checks `hard_limited_until`.
- [x] 529 from an OpenAI endpoint triggers the long-base BEBO backoff (`saw_529`).
- [x] Regression test: two sequential 429s — the second request never touches the limited endpoint (`openai_429_sets_cooldown_and_next_request_skips_endpoint`), plus `openai_529_triggers_bebo_backoff_retry` proving the BEBO path (test runtime ~1.1s = the 1s long-base delay actually firing).

## Testing

`cargo fmt --check`, `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets`, full suite: **498 passed, 0 failed** (468 unit/integration + 30 aux).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OpenAI endpoint routing now respects cooldown windows after rate-limit responses (e.g., HTTP 429 with `retry-after`), reducing repeated retries during the cooldown period.
  - Upstream retry decisions are now consistent across forwarding paths.
  - Fallback handling now uses shared retry classification, with improved logging for non-success responses.

- **Tests**
  - Added regression coverage for OpenAI endpoints: verifies 429 creates a persistent cooldown that skips the next request, and 529 recovers after a single upstream failure and subsequent retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->