### PR TITLE
LAB-916: session context-window visibility (/_stats sessions) + prompt-too-long detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ token = "sk-ant-api03-..."
 | `endpoints[].models` | `[String]` | `[]` | Model allowlist (empty = all) |
 | `endpoints[].priority` | `u32` | `0` | Priority tier (lower tried first) |
 | `endpoints[].fable_included` | `bool` | `true` | Plan includes Fable band; set `false` for Pro / standard Team |
+| `session_registry_max` | `usize` | `1000` | Max live-session entries tracked for `/_stats` `sessions` (0 = disabled) |
+| `session_registry_ttl_secs` | `u64` | `1800` | Seconds after a session's last request before its entry is evicted |
 
 > [!NOTE]
 > **Strategy normalization**: Both `"dynamic-capacity"` and `"dynamic-capacity-v1"` are accepted in config, but the runtime normalizes to `"dynamic-capacity-v1"` in logs and `/_stats` output. Similarly, `"sticky-weighted"` normalizes to `"sticky-weighted-v2"`.
@@ -271,10 +273,39 @@ IP check runs first, then proxy key. Both apply to all endpoints including `/_st
 |:------|:-------|:------------|
 | `/*` | Any | Proxied to upstream Anthropic API |
 | `/v1/chat/completions` | POST | OpenAI-compatible → Anthropic translation |
-| `/_stats` | GET | JSON stats (utilization, tokens, budgets) |
+| `/_stats` | GET | JSON stats (utilization, tokens, budgets, live sessions) |
 | `/metrics` | GET | Prometheus-format metrics |
 
 All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
+
+### Session context-window visibility
+
+`/_stats` includes a `sessions` array — the live sessions seen by this
+replica (Anthropic-protocol traffic), sorted by context-window occupancy
+descending, capped to the top 50. A "session" is one affinity routing pin,
+so fan-out subagents sharing a coarse session id appear as distinct entries.
+Each entry:
+
+| Field | Meaning |
+|:------|:--------|
+| `session` | Redacted session label — hash of the affinity key (also appears in `prompt too long` WARN logs for joining) |
+| `client_id` | Resolved client id (operators masked as `_operator`) |
+| `agent` / `session_prefix` | First 8 chars of the `x-agent-id` / session-id headers as sent |
+| `model` / `endpoint` | Model and the endpoint the session is currently pinned to |
+| `last_prompt_tokens` | `input + cache_read + cache_creation` from the last successful response — the prompt's window occupancy |
+| `context_window` | Model context window: 200k, or 1M when the request carries the `context-1m` beta |
+| `context_window_pct` | Occupancy percent — sessions near/over 100 are about to hit `prompt is too long` |
+| `requests` / `last_seen` | Request count and epoch of last activity |
+
+The registry is in-memory, per-replica, bounded (`session_registry_max`) and
+TTL-evicted (`session_registry_ttl_secs`); raw IPs and session ids never
+leave the process. Routing does not read it.
+
+Upstream `400 invalid_request_error` responses matching *"prompt is too
+long"* are additionally counted as `anthropic_prompt_too_long_total{model}`
+on `/metrics` and logged as a structured WARN with the redacted session
+label plus the observed-vs-max token counts parsed from the error message.
+The 400 itself is forwarded to the client unchanged.
 
 ### OpenAI JSON-mode compatibility
 
@@ -346,6 +377,21 @@ All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
       "alice": { "share": 0.65, "requests_per_minute": 4.2 }
     }
   },
+  "sessions": [
+    {
+      "session": "9f2c4a1b8e3d5f07",
+      "client_id": "alice",
+      "agent": "d3adbeef",
+      "session_prefix": "a1b2c3d4",
+      "model": "claude-sonnet-4-5",
+      "endpoint": "primary",
+      "last_prompt_tokens": 187000,
+      "context_window": 200000,
+      "context_window_pct": 93.5,
+      "requests": 42,
+      "last_seen": 1753600000
+    }
+  ],
   "cluster": {
     "redis_connected": true,
     "replicas_seen": 3,

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,13 @@ struct Config {
     /// handful of hung uploads could pin the `max_inflight_body_mb` budget
     /// indefinitely. Default: 60. Set to 0 to disable.
     body_read_timeout_secs: Option<u64>,
+    /// Max entries in the live session registry (context-window visibility on
+    /// `/_stats`). Registry keys are affinity routing keys, so fan-out agents
+    /// each get an entry. Default: 1000. Set to 0 to disable the registry.
+    session_registry_max: Option<usize>,
+    /// Seconds after a session's last request before its registry entry is
+    /// evicted. Default: 1800 (30 min).
+    session_registry_ttl_secs: Option<u64>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -589,6 +596,18 @@ struct AppState {
     /// Count of requests shed because the body was not fully received within
     /// `body_read_timeout`. Exposed as `anthropic_body_read_timeout_total`.
     body_read_timeout_total: AtomicU64,
+    /// Live session registry: affinity routing key → last-seen context-window
+    /// occupancy (LAB-916). Visibility only — routing never reads it. Sync
+    /// mutex, never held across `.await`; bounded by `session_registry_max`
+    /// + TTL eviction.
+    sessions: Mutex<HashMap<String, SessionEntry>>,
+    /// Session registry entry cap. 0 disables the registry.
+    session_registry_max: usize,
+    /// Seconds since last request before a session entry is evicted.
+    session_registry_ttl_secs: u64,
+    /// Upstream "prompt is too long" 400s by model (LAB-916). Exposed as
+    /// `anthropic_prompt_too_long_total`; bounded via `_other` overflow.
+    prompt_too_long: Mutex<HashMap<String, u64>>,
 }
 
 /// RAII reservation against `AppState::inflight_body_bytes`. Holding it keeps the
@@ -4045,6 +4064,257 @@ impl RequestContext {
     }
 }
 
+// ── Session registry: context-window visibility (LAB-916) ──────────
+//
+// The affinity "pin" is recomputed per request and never stored, so before
+// this section there was no way to see which live sessions are close to
+// their model's context window — only the resulting upstream "prompt is too
+// long" 400s, which were forwarded without a trace. The registry is
+// visibility state ONLY: it is written after responses and read by
+// `/_stats`; routing never consults it.
+
+/// Default cap on live session registry entries.
+const DEFAULT_SESSION_REGISTRY_MAX: usize = 1000;
+/// Default seconds after a session's last request before eviction.
+const DEFAULT_SESSION_REGISTRY_TTL_SECS: u64 = 1800;
+/// Max sessions returned in the `/_stats` `sessions` array (highest
+/// context-window % first).
+const SESSIONS_STATS_TOP_N: usize = 50;
+/// Cap on distinct model labels in the prompt-too-long counter map (the model
+/// string is client-controlled; overflow buckets into `_other`).
+const MAX_PROMPT_TOO_LONG_MODELS: usize = 32;
+
+/// Default model context window (tokens). Every current Claude model ships
+/// with a 200k window unless the 1M beta is active on the request.
+const DEFAULT_CONTEXT_WINDOW: u64 = 200_000;
+/// Context window when the request carries the `context-1m` beta flag.
+const CONTEXT_WINDOW_1M: u64 = 1_000_000;
+
+/// Live per-session state, keyed by the affinity routing key — the same key
+/// `pick_endpoint` pins on, so "session" here has exactly the granularity of
+/// a routing pin (fan-out subagents that share a coarse session-id but carry
+/// distinct content fingerprints appear as distinct entries).
+struct SessionEntry {
+    client_id: String,
+    agent_id: String,
+    session_id: String,
+    model: String,
+    /// Endpoint the session's last request was served by (its current pin).
+    endpoint: String,
+    /// `input + cache_read + cache_creation` from the last successful
+    /// `Usage` — the prompt's occupancy of the model context window.
+    last_prompt_tokens: u64,
+    context_window: u64,
+    requests: u64,
+    last_seen: u64,
+}
+
+/// Redacted session label: hash of the affinity key, safe for `/_stats` and
+/// logs (the raw key embeds the client IP and session id).
+fn session_label(affinity_key: &str) -> String {
+    format!("{:016x}", stable_affinity_hash(affinity_key))
+}
+
+/// True when any `anthropic-beta` header value activates the 1M context
+/// window (flag shape: `context-1m-YYYY-MM-DD`; values may be comma-joined).
+fn request_has_1m_beta(headers: &axum::http::HeaderMap) -> bool {
+    headers
+        .get_all("anthropic-beta")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|v| v.split(','))
+        .any(|flag| flag.trim().starts_with("context-1m"))
+}
+
+/// Model → context window size. All known Claude models are 200k unless the
+/// request carries the `context-1m` beta. Unknown model families fall back to
+/// 200k with a once-per-model warning so a new family can't silently skew
+/// the `/_stats` context-window % view.
+fn context_window_for(model: &str, has_1m_beta: bool) -> u64 {
+    if has_1m_beta {
+        return CONTEXT_WINDOW_1M;
+    }
+    if !model.is_empty() && !model.starts_with("claude") {
+        static WARNED: std::sync::OnceLock<Mutex<std::collections::HashSet<String>>> =
+            std::sync::OnceLock::new();
+        if let Ok(mut warned) = WARNED.get_or_init(Default::default).lock() {
+            // Bounded like the client maps: model is client-controlled input.
+            if warned.len() < MAX_PROMPT_TOO_LONG_MODELS && warned.insert(model.to_string()) {
+                warn!(model, "unknown model family, assuming 200k context window");
+            }
+        }
+    }
+    DEFAULT_CONTEXT_WINDOW
+}
+
+/// Context-window occupancy as a percentage, one decimal. Can exceed 100
+/// (that's the signal: the next request will 400).
+fn window_pct(tokens: u64, window: u64) -> f64 {
+    if window == 0 {
+        return 0.0;
+    }
+    (tokens as f64 / window as f64 * 1000.0).round() / 10.0
+}
+
+/// If `body` is the Anthropic "prompt is too long" 400 shape, return its
+/// message. `{"type":"error","error":{"type":"invalid_request_error",
+/// "message":"prompt is too long: 213462 tokens > 200000 maximum"}}`
+fn prompt_too_long_message(body: &serde_json::Value) -> Option<&str> {
+    let err = body.get("error")?;
+    if err.get("type")?.as_str()? != "invalid_request_error" {
+        return None;
+    }
+    let msg = err.get("message")?.as_str()?;
+    msg.contains("prompt is too long").then_some(msg)
+}
+
+/// Parse `(observed, max)` token counts from a prompt-too-long message —
+/// the first two integers in the text ("… 213462 tokens > 200000 maximum").
+fn parse_prompt_too_long(msg: &str) -> Option<(u64, u64)> {
+    let mut nums = msg
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| s.parse::<u64>().ok());
+    Some((nums.next()?, nums.next()?))
+}
+
+impl AppState {
+    /// Record a completed request into the session registry. Sync-locked,
+    /// never held across `.await` (AC7); TTL prune + oldest-eviction run only
+    /// on NEW-key inserts, so steady-state traffic is a single map update.
+    #[allow(clippy::too_many_arguments)]
+    fn record_session(
+        &self,
+        affinity_key: &str,
+        rctx: (&str, &str, &str),
+        model: &str,
+        endpoint: &str,
+        prompt_tokens: u64,
+        context_window: u64,
+        now: u64,
+    ) {
+        if self.session_registry_max == 0 {
+            return;
+        }
+        let (client_id, agent_id, session_id) = rctx;
+        let Ok(mut map) = self.sessions.lock() else {
+            return;
+        };
+        if !map.contains_key(affinity_key) {
+            let ttl = self.session_registry_ttl_secs;
+            map.retain(|_, e| now.saturating_sub(e.last_seen) <= ttl);
+            if map.len() >= self.session_registry_max {
+                // ponytail: O(n) min-scan eviction on new-key insert past the
+                // cap; fine at the 1000-entry default, index by last_seen if
+                // the cap ever needs to grow orders of magnitude.
+                if let Some(oldest) = map
+                    .iter()
+                    .min_by_key(|(_, e)| e.last_seen)
+                    .map(|(k, _)| k.clone())
+                {
+                    map.remove(&oldest);
+                }
+            }
+        }
+        let entry = map
+            .entry(affinity_key.to_owned())
+            .or_insert_with(|| SessionEntry {
+                client_id: client_id.to_owned(),
+                agent_id: agent_id.to_owned(),
+                session_id: session_id.to_owned(),
+                model: String::new(),
+                endpoint: String::new(),
+                last_prompt_tokens: 0,
+                context_window: DEFAULT_CONTEXT_WINDOW,
+                requests: 0,
+                last_seen: 0,
+            });
+        model.clone_into(&mut entry.model);
+        endpoint.clone_into(&mut entry.endpoint);
+        entry.last_prompt_tokens = prompt_tokens;
+        entry.context_window = context_window;
+        entry.requests += 1;
+        entry.last_seen = now;
+    }
+
+    /// Count + log an upstream "prompt is too long" 400. The response itself
+    /// is forwarded to the client unchanged by the caller; this is the
+    /// operator-side trace that previously didn't exist.
+    fn note_prompt_too_long(
+        &self,
+        req_id: &str,
+        model: &str,
+        affinity_key: Option<&str>,
+        message: &str,
+    ) {
+        if let Ok(mut counts) = self.prompt_too_long.lock() {
+            let label = if counts.len() < MAX_PROMPT_TOO_LONG_MODELS || counts.contains_key(model) {
+                model
+            } else {
+                "_other"
+            };
+            *counts.entry(label.to_owned()).or_insert(0) += 1;
+        }
+        let (observed, max) = parse_prompt_too_long(message)
+            .map(|(o, m)| (Some(o), Some(m)))
+            .unwrap_or((None, None));
+        warn!(
+            req_id,
+            model,
+            session = affinity_key.map(session_label).as_deref().unwrap_or("-"),
+            observed_tokens = observed,
+            max_tokens = max,
+            "prompt too long"
+        );
+    }
+
+    /// Snapshot the session registry for `/_stats`: TTL-filtered, sorted by
+    /// context-window % desc, capped to `SESSIONS_STATS_TOP_N`. Raw IPs and
+    /// session ids never leave the registry — the label is a hash of the
+    /// affinity key and agent/session ids are truncated to 8 chars.
+    fn sessions_snapshot(&self, now: u64) -> Vec<serde_json::Value> {
+        let mut rows: Vec<(f64, serde_json::Value)> = self
+            .sessions
+            .lock()
+            .map(|map| {
+                map.iter()
+                    .filter(|(_, e)| {
+                        now.saturating_sub(e.last_seen) <= self.session_registry_ttl_secs
+                    })
+                    .map(|(key, e)| {
+                        let pct = window_pct(e.last_prompt_tokens, e.context_window);
+                        let client_id = if self.is_operator(&e.client_id) {
+                            "_operator"
+                        } else {
+                            &e.client_id
+                        };
+                        let truncate8 = |s: &str| -> String { s.chars().take(8).collect() };
+                        (
+                            pct,
+                            serde_json::json!({
+                                "session": session_label(key),
+                                "client_id": client_id,
+                                "agent": truncate8(&e.agent_id),
+                                "session_prefix": truncate8(&e.session_id),
+                                "model": e.model,
+                                "endpoint": e.endpoint,
+                                "last_prompt_tokens": e.last_prompt_tokens,
+                                "context_window": e.context_window,
+                                "context_window_pct": pct,
+                                "requests": e.requests,
+                                "last_seen": e.last_seen,
+                            }),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        rows.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        rows.truncate(SESSIONS_STATS_TOP_N);
+        rows.into_iter().map(|(_, v)| v).collect()
+    }
+}
+
 fn log_usage(req_id: &str, client_id: &str, model: &str, account: &str, usage: &TokenUsage) {
     // INFO (temporarily): surfaces per-request cache_read vs cache_write so we can
     // join it to the `fingerprint` line by req_id and learn whether fan-out agents
@@ -4085,6 +4355,8 @@ async fn finalize_stream(
     client_disconnected: bool,
     upstream_error: bool,
     openai_compat: bool,
+    session_key: Option<&str>,
+    context_window: u64,
 ) {
     scanner.finish();
     let usage = &scanner.usage;
@@ -4092,6 +4364,19 @@ async fn finalize_stream(
     if !usage.is_empty() {
         state.record_usage(ep, client_id, usage).await;
         log_usage(req_id, client_id, model, acct_name, usage);
+        if let Some(key) = session_key {
+            state.record_session(
+                key,
+                (client_id, agent, session),
+                model,
+                acct_name,
+                usage.input_tokens
+                    + usage.cache_read_input_tokens
+                    + usage.cache_creation_input_tokens,
+                context_window,
+                AppState::now_epoch(),
+            );
+        }
     } else {
         let reason = if upstream_error {
             "upstream_error"
@@ -4155,10 +4440,25 @@ async fn finalize_non_stream(
     usage: &TokenUsage,
     latency_ms: u64,
     openai_compat: bool,
+    session_key: Option<&str>,
+    context_window: u64,
 ) {
     if !usage.is_empty() {
         state.record_usage(ep, client_id, usage).await;
         log_usage(req_id, client_id, model, acct_name, usage);
+        if let Some(key) = session_key {
+            state.record_session(
+                key,
+                (client_id, agent, session),
+                model,
+                acct_name,
+                usage.input_tokens
+                    + usage.cache_read_input_tokens
+                    + usage.cache_creation_input_tokens,
+                context_window,
+                AppState::now_epoch(),
+            );
+        }
     }
     let mut log = serde_json::json!({
         "ts": AppState::now_epoch(),
@@ -5059,8 +5359,13 @@ async fn forward_anthropic(
     agent_id: &str,
     session_id: &str,
     model: &str,
+    session_key: Option<&str>,
     request_start: std::time::Instant,
 ) -> ForwardOutcome {
+    // Context window for the session registry: 200k, or 1M when the request
+    // carries the `context-1m` beta (per-request, so a mixed client is
+    // tracked at the window each request actually ran under).
+    let context_window = context_window_for(model, request_has_1m_beta(&parts.headers));
     let token = ep.token.as_str();
     let passthrough = ep.passthrough;
     let endpoint_name = ep.name.as_str();
@@ -5290,6 +5595,7 @@ async fn forward_anthropic(
         let agent_clone = agent_id.to_owned();
         let session_clone = session_id.to_owned();
         let req_id_clone = req_id.to_owned();
+        let session_key_clone = session_key.map(str::to_owned);
         let status_code = status.as_u16();
 
         tokio::spawn(async move {
@@ -5341,6 +5647,8 @@ async fn forward_anthropic(
                 client_disconnected,
                 upstream_error,
                 false,
+                session_key_clone.as_deref(),
+                context_window,
             )
             .await;
         });
@@ -5406,6 +5714,13 @@ async fn forward_anthropic(
         let mut usage = TokenUsage::default();
         if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&resp_body_bytes) {
             usage = TokenUsage::from_response_body(&parsed);
+            // Count + trace upstream context-window overflows (LAB-916). The
+            // 400 itself is forwarded below byte-for-byte, as before.
+            if status.as_u16() == 400 {
+                if let Some(msg) = prompt_too_long_message(&parsed) {
+                    state.note_prompt_too_long(req_id, model, session_key, msg);
+                }
+            }
         }
         finalize_non_stream(
             state,
@@ -5421,6 +5736,8 @@ async fn forward_anthropic(
             &usage,
             latency_ms,
             false,
+            session_key,
+            context_window,
         )
         .await;
         let response = builder
@@ -5657,6 +5974,7 @@ async fn proxy_handler(
                                     &agent_id,
                                     &session_id,
                                     &model,
+                                    affinity,
                                     request_start,
                                 )
                                 .await;
@@ -6102,6 +6420,10 @@ async fn try_fallback_upstream(
         &usage,
         request_start.elapsed().as_millis() as u64,
         !translate, // openai_compat marks the client surface: translate=false ⇒ OpenAI-format caller
+        // OpenAI-protocol endpoints don't consume Anthropic context windows —
+        // the session registry (LAB-916) tracks Anthropic-bound traffic only.
+        None,
+        0,
     )
     .await;
 
@@ -6448,6 +6770,10 @@ async fn stats_handler(
         "client_budgets": budgets,
         "aggregate": aggregate,
         "strategy": state.routing_strategy.as_str(),
+        // Live sessions by context-window occupancy, hottest first (LAB-916).
+        // Session labels are hashes of the affinity key; raw IPs/session ids
+        // never leave the process.
+        "sessions": state.sessions_snapshot(now_epoch),
     });
     if let Some(cluster_info) = cluster {
         response["cluster"] = cluster_info;
@@ -6811,6 +7137,12 @@ async fn metrics_handler(
         .map(|g| g.clone())
         .unwrap_or_default();
     let cluster_info = state.cluster_info_cache.lock().ok().and_then(|g| g.clone());
+    let prompt_too_long: Vec<(String, u64)> = state
+        .prompt_too_long
+        .lock()
+        .ok()
+        .map(|g| g.iter().map(|(k, v)| (k.clone(), *v)).collect())
+        .unwrap_or_default();
 
     // ── Phase 2: Serialize (sync — no locks held) ──────────────────
 
@@ -7602,6 +7934,24 @@ async fn metrics_handler(
             "anthropic_upstream_transport_errors_total",
             &[("kind", kind.as_str())],
             n,
+        );
+    }
+
+    // Upstream context-window overflows (LAB-916). Per-replica, in-memory —
+    // sessions themselves stay on `/_stats` (per-session Prometheus labels
+    // would be a cardinality anti-pattern).
+    prom_header(
+        &mut buf,
+        "anthropic_prompt_too_long_total",
+        "counter",
+        "Upstream 'prompt is too long' 400 responses by model",
+    );
+    for (model, n) in &prompt_too_long {
+        prom_counter(
+            &mut buf,
+            "anthropic_prompt_too_long_total",
+            &[("model", model.as_str())],
+            *n,
         );
     }
 
@@ -9005,10 +9355,15 @@ async fn forward_openai_compat_anthropic(
     agent_id: &str,
     session_id: &str,
     model: &str,
+    session_key: Option<&str>,
     is_streaming: bool,
     json_mode: bool,
     request_start: std::time::Instant,
 ) -> ForwardOutcome {
+    // Session registry window (LAB-916). OpenAI-compat callers can't send the
+    // `context-1m` beta through translation, but check anyway — the header is
+    // forwarded when present.
+    let context_window = context_window_for(model, request_has_1m_beta(&parts.headers));
     let token = ep.token.as_str();
     let passthrough = ep.passthrough;
     let endpoint_name = ep.name.as_str();
@@ -9180,6 +9535,13 @@ async fn forward_openai_compat_anthropic(
         // (LiteLLM, etc.) can parse the actual error message.
         let openai_error =
             if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&error_body) {
+                // Count + trace context-window overflows here too (LAB-916) —
+                // this path consumes the same Anthropic windows as the native one.
+                if status.as_u16() == 400 {
+                    if let Some(msg) = prompt_too_long_message(&parsed) {
+                        state.note_prompt_too_long(req_id, model, session_key, msg);
+                    }
+                }
                 // Anthropic: {"type":"error","error":{"type":"...","message":"..."}}
                 let msg = parsed
                     .pointer("/error/message")
@@ -9234,6 +9596,7 @@ async fn forward_openai_compat_anthropic(
         let agent_clone = agent_id.to_owned();
         let session_clone = session_id.to_owned();
         let req_id_clone = req_id.to_owned();
+        let session_key_clone = session_key.map(str::to_owned);
         let status_code = status.as_u16();
 
         tokio::spawn(async move {
@@ -9346,6 +9709,8 @@ async fn forward_openai_compat_anthropic(
                 client_gone,
                 upstream_error,
                 true,
+                session_key_clone.as_deref(),
+                context_window,
             )
             .await;
         });
@@ -9407,6 +9772,8 @@ async fn forward_openai_compat_anthropic(
         &usage,
         request_start.elapsed().as_millis() as u64,
         true,
+        session_key,
+        context_window,
     )
     .await;
 
@@ -9578,6 +9945,7 @@ async fn openai_chat_handler(
                                     &agent_id,
                                     &session_id,
                                     &model,
+                                    affinity,
                                     is_streaming,
                                     json_mode,
                                     request_start,
@@ -10019,6 +10387,14 @@ async fn main() {
                 .unwrap_or(DEFAULT_BODY_READ_TIMEOUT_SECS),
         ),
         body_read_timeout_total: AtomicU64::new(0),
+        sessions: Mutex::new(HashMap::new()),
+        session_registry_max: config
+            .session_registry_max
+            .unwrap_or(DEFAULT_SESSION_REGISTRY_MAX),
+        session_registry_ttl_secs: config
+            .session_registry_ttl_secs
+            .unwrap_or(DEFAULT_SESSION_REGISTRY_TTL_SECS),
+        prompt_too_long: Mutex::new(HashMap::new()),
     });
 
     if state.auto_cache {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -334,6 +334,10 @@ fn test_state_base() -> AppState {
         body_shed_total: AtomicU64::new(0),
         body_read_timeout: Duration::from_secs(DEFAULT_BODY_READ_TIMEOUT_SECS),
         body_read_timeout_total: AtomicU64::new(0),
+        sessions: Mutex::new(HashMap::new()),
+        session_registry_max: DEFAULT_SESSION_REGISTRY_MAX,
+        session_registry_ttl_secs: DEFAULT_SESSION_REGISTRY_TTL_SECS,
+        prompt_too_long: Mutex::new(HashMap::new()),
     }
 }
 
@@ -14141,4 +14145,335 @@ fn upstream_client_builder_composes_with_and_without_read_timeout() {
     let _nonstreaming = upstream_client_builder()
         .build()
         .expect("non-streaming client builds");
+}
+
+// ── LAB-916: session registry + context-window visibility ───────────
+
+#[test]
+fn session_registry_populates_updates_and_caps() {
+    let state = Arc::new(AppState {
+        session_registry_max: 3,
+        ..test_state_base()
+    });
+    let rctx = ("cli", "agent-1", "sess-1");
+    for (i, key) in ["k1", "k2", "k3"].iter().enumerate() {
+        state.record_session(
+            key,
+            rctx,
+            "claude-sonnet-4-5",
+            "acct-a",
+            1000,
+            200_000,
+            100 + i as u64,
+        );
+    }
+    // Repeat request on a known key updates in place — no new entry.
+    state.record_session(
+        "k2",
+        rctx,
+        "claude-sonnet-4-5",
+        "acct-b",
+        5000,
+        200_000,
+        200,
+    );
+    {
+        let map = state.sessions.lock().unwrap();
+        assert_eq!(map.len(), 3);
+        let e = &map["k2"];
+        assert_eq!(e.requests, 2);
+        assert_eq!(
+            e.last_prompt_tokens, 5000,
+            "occupancy tracks the LAST response"
+        );
+        assert_eq!(e.endpoint, "acct-b", "re-pin updates the endpoint");
+        assert_eq!(e.client_id, "cli");
+        assert_eq!(e.session_id, "sess-1");
+    }
+    // A 4th distinct key at the cap evicts the oldest entry (k1, last_seen=100).
+    state.record_session("k4", rctx, "claude-sonnet-4-5", "acct-a", 1, 200_000, 300);
+    let map = state.sessions.lock().unwrap();
+    assert_eq!(map.len(), 3, "cap holds");
+    assert!(!map.contains_key("k1"), "oldest entry evicted");
+    assert!(map.contains_key("k4"));
+}
+
+#[test]
+fn session_registry_evicts_by_ttl() {
+    let state = test_state_with(vec![]); // defaults: max 1000, ttl 1800s
+    let rctx = ("cli", "-", "-");
+    state.record_session("old", rctx, "m", "a", 1, 200_000, 1_000);
+    // A NEW key arriving past the TTL horizon prunes expired entries.
+    state.record_session("new", rctx, "m", "a", 1, 200_000, 1_000 + 1801);
+    {
+        let map = state.sessions.lock().unwrap();
+        assert!(
+            !map.contains_key("old"),
+            "expired entry pruned on new-key insert"
+        );
+        assert!(map.contains_key("new"));
+    }
+    // The /_stats snapshot ALSO filters expired entries before any prune runs.
+    assert!(state.sessions_snapshot(1_000 + 1801 + 1801).is_empty());
+}
+
+#[test]
+fn session_registry_disabled_when_max_zero() {
+    let state = Arc::new(AppState {
+        session_registry_max: 0,
+        ..test_state_base()
+    });
+    state.record_session("k", ("c", "-", "-"), "m", "a", 1, 200_000, 1);
+    assert!(state.sessions.lock().unwrap().is_empty());
+}
+
+#[test]
+fn sessions_snapshot_sorts_by_pct_desc_and_caps_top_n() {
+    let state = test_state_with(vec![]);
+    let rctx = ("c", "-", "-");
+    state.record_session("low", rctx, "m", "a", 10_000, 200_000, 100);
+    state.record_session("high", rctx, "m", "a", 190_000, 200_000, 100);
+    state.record_session("mid", rctx, "m", "a", 100_000, 200_000, 100);
+    let pcts: Vec<f64> = state
+        .sessions_snapshot(100)
+        .iter()
+        .map(|s| s["context_window_pct"].as_f64().unwrap())
+        .collect();
+    assert_eq!(pcts, vec![95.0, 50.0, 5.0], "hottest sessions first");
+
+    let state = test_state_with(vec![]);
+    for i in 0..(SESSIONS_STATS_TOP_N + 10) {
+        state.record_session(&format!("k{i}"), rctx, "m", "a", i as u64, 200_000, 100);
+    }
+    assert_eq!(state.sessions_snapshot(100).len(), SESSIONS_STATS_TOP_N);
+}
+
+#[test]
+fn context_window_mapping() {
+    assert_eq!(context_window_for("claude-sonnet-4-5", false), 200_000);
+    assert_eq!(context_window_for("claude-sonnet-4-5", true), 1_000_000);
+    assert_eq!(
+        context_window_for("some-future-model", false),
+        200_000,
+        "unknown model family falls back to 200k"
+    );
+    assert_eq!(context_window_for("", false), 200_000);
+}
+
+#[test]
+fn request_1m_beta_detected_from_comma_joined_header() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_static("oauth-2025-04-20, context-1m-2025-08-07"),
+    );
+    assert!(request_has_1m_beta(&headers));
+    let mut plain = axum::http::HeaderMap::new();
+    plain.insert(
+        "anthropic-beta",
+        HeaderValue::from_static("oauth-2025-04-20"),
+    );
+    assert!(!request_has_1m_beta(&plain));
+    assert!(!request_has_1m_beta(&axum::http::HeaderMap::new()));
+}
+
+#[test]
+fn window_pct_reports_past_100() {
+    assert_eq!(window_pct(100_000, 200_000), 50.0);
+    assert_eq!(
+        window_pct(250_000, 200_000),
+        125.0,
+        "over-window sessions must report >100% — that IS the signal"
+    );
+    assert_eq!(window_pct(1, 0), 0.0);
+}
+
+#[test]
+fn prompt_too_long_shape_detection_and_parse() {
+    let body = serde_json::json!({
+        "type": "error",
+        "error": {
+            "type": "invalid_request_error",
+            "message": "prompt is too long: 213462 tokens > 200000 maximum"
+        }
+    });
+    let msg = prompt_too_long_message(&body).expect("matches the prompt-too-long shape");
+    assert_eq!(parse_prompt_too_long(msg), Some((213_462, 200_000)));
+
+    let other_400 = serde_json::json!({
+        "type": "error",
+        "error": {"type": "invalid_request_error", "message": "max_tokens: field required"}
+    });
+    assert!(prompt_too_long_message(&other_400).is_none());
+
+    let wrong_type = serde_json::json!({
+        "type": "error",
+        "error": {"type": "authentication_error", "message": "prompt is too long: 1 tokens > 0 maximum"}
+    });
+    assert!(
+        prompt_too_long_message(&wrong_type).is_none(),
+        "only invalid_request_error counts"
+    );
+    assert_eq!(parse_prompt_too_long("prompt is too long"), None);
+}
+
+#[test]
+fn prompt_too_long_counter_bounds_model_cardinality() {
+    let state = test_state_with(vec![]);
+    for i in 0..(MAX_PROMPT_TOO_LONG_MODELS + 5) {
+        state.note_prompt_too_long(
+            "req",
+            &format!("model-{i}"),
+            None,
+            "prompt is too long: 5 tokens > 1 maximum",
+        );
+    }
+    let counts = state.prompt_too_long.lock().unwrap();
+    assert_eq!(
+        counts.len(),
+        MAX_PROMPT_TOO_LONG_MODELS + 1,
+        "distinct models capped, overflow buckets into _other"
+    );
+    assert_eq!(counts.get("_other"), Some(&5));
+}
+
+/// Canned Anthropic context-window-overflow 400, byte-for-byte.
+const PROMPT_TOO_LONG_BODY: &[u8] = br#"{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 213462 tokens > 200000 maximum"}}"#;
+
+/// Raw-TCP upstream that answers every request with the canned 400.
+async fn spawn_prompt_too_long_upstream() -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut s, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 65536];
+            let _ = s.read(&mut buf).await;
+            let head = format!(
+                "HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                PROMPT_TOO_LONG_BODY.len()
+            );
+            let _ = s.write_all(head.as_bytes()).await;
+            let _ = s.write_all(PROMPT_TOO_LONG_BODY).await;
+            let _ = s.flush().await;
+        }
+    });
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn prompt_too_long_400_counted_logged_and_forwarded_unchanged() {
+    let url = spawn_prompt_too_long_upstream().await;
+    let state = test_state_with(vec![mk_endpoint_at("a", "sk-ant-api-aaa", &url)]);
+    let addr = serve(build_router(state.clone())).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-claude-code-session-id", "sess-92af31")
+        .body(r#"{"model":"claude-sonnet-4-5","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "the 400 must pass through — client errors are not retried"
+    );
+    let body = resp.bytes().await.unwrap();
+    assert_eq!(
+        &body[..],
+        PROMPT_TOO_LONG_BODY,
+        "error body forwarded unchanged"
+    );
+    assert_eq!(
+        state
+            .prompt_too_long
+            .lock()
+            .unwrap()
+            .get("claude-sonnet-4-5"),
+        Some(&1)
+    );
+
+    // And the counter reaches /metrics with the model label.
+    let metrics = reqwest::Client::new()
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        metrics.contains(r#"anthropic_prompt_too_long_total{model="claude-sonnet-4-5"} 1"#),
+        "metric missing from /metrics: {metrics}"
+    );
+}
+
+/// 200 upstream body carrying usage — populates the session registry.
+/// Prompt occupancy = 150k input + 20k cache_read + 10k cache_creation = 180k (90%).
+const ANTHROPIC_USAGE_BODY: &[u8] = br#"{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"model":"claude-sonnet-4-5","stop_reason":"end_turn","usage":{"input_tokens":150000,"output_tokens":10,"cache_creation_input_tokens":10000,"cache_read_input_tokens":20000}}"#;
+
+#[tokio::test]
+async fn stats_sessions_block_lists_and_redacts() {
+    let (url, _hits) = spawn_flaky_upstream(0, ANTHROPIC_USAGE_BODY).await;
+    let state = test_state_with(vec![mk_endpoint_at("acct-a", "sk-ant-api-aaa", &url)]);
+    let addr = serve(build_router(state.clone())).await;
+
+    let raw_session_id = "0b5e7c1e-secret-session-uuid";
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-client-id", "geo-pipeline")
+        .header("x-agent-id", "agent-77")
+        .header("x-claude-code-session-id", raw_session_id)
+        .body(r#"{"model":"claude-sonnet-4-5","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let stats: serde_json::Value = reqwest::Client::new()
+        .get(format!("http://{addr}/_stats"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let sessions = stats["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1);
+    let s = &sessions[0];
+    assert_eq!(s["client_id"], "geo-pipeline");
+    assert_eq!(s["model"], "claude-sonnet-4-5");
+    assert_eq!(s["endpoint"], "acct-a");
+    assert_eq!(
+        s["last_prompt_tokens"], 180_000,
+        "input + cache_read + cache_creation, NOT output"
+    );
+    assert_eq!(s["context_window"], 200_000);
+    assert_eq!(s["context_window_pct"], 90.0);
+    assert_eq!(s["requests"], 1);
+    assert_eq!(s["agent"], "agent-77");
+    assert_eq!(
+        s["session_prefix"], "0b5e7c1e",
+        "session id truncated to 8 chars"
+    );
+
+    let label = s["session"].as_str().unwrap();
+    assert_eq!(
+        label.len(),
+        16,
+        "label is a 16-hex-char hash of the affinity key"
+    );
+    assert!(label.chars().all(|c| c.is_ascii_hexdigit()));
+
+    // AC3 redaction: no raw client IP or raw session id in the block.
+    let text = serde_json::to_string(&stats["sessions"]).unwrap();
+    assert!(
+        !text.contains(raw_session_id),
+        "raw session id must not leak"
+    );
+    assert!(!text.contains("127.0.0.1"), "raw client IP must not leak");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -364,6 +364,16 @@ fn test_state_with_soft_limit(endpoints: Vec<Endpoint>, soft_limit: f64) -> Arc<
     state
 }
 
+/// `test_state_with(vec![])` with a session-registry cap override (0 = off).
+/// Registry unit tests don't route, so no endpoints are needed.
+fn test_state_with_session_max(max: usize) -> Arc<AppState> {
+    let mut state = test_state_with(vec![]);
+    Arc::get_mut(&mut state)
+        .expect("test fixture should be uniquely owned")
+        .session_registry_max = max;
+    state
+}
+
 /// Spawn a mock upstream that returns a canned response with rate-limit headers.
 async fn spawn_mock_upstream() -> (String, tokio::task::JoinHandle<()>) {
     let app = Router::new().fallback(any(mock_upstream_handler));
@@ -14151,10 +14161,7 @@ fn upstream_client_builder_composes_with_and_without_read_timeout() {
 
 #[test]
 fn session_registry_populates_updates_and_caps() {
-    let state = Arc::new(AppState {
-        session_registry_max: 3,
-        ..test_state_base()
-    });
+    let state = test_state_with_session_max(3);
     let rctx = ("cli", "agent-1", "sess-1");
     for (i, key) in ["k1", "k2", "k3"].iter().enumerate() {
         state.record_session(
@@ -14219,10 +14226,7 @@ fn session_registry_evicts_by_ttl() {
 
 #[test]
 fn session_registry_disabled_when_max_zero() {
-    let state = Arc::new(AppState {
-        session_registry_max: 0,
-        ..test_state_base()
-    });
+    let state = test_state_with_session_max(0);
     state.record_session("k", ("c", "-", "-"), "m", "a", 1, 200_000, 1);
     assert!(state.sessions.lock().unwrap().is_empty());
 }
@@ -14340,26 +14344,22 @@ fn prompt_too_long_counter_bounds_model_cardinality() {
 /// Canned Anthropic context-window-overflow 400, byte-for-byte.
 const PROMPT_TOO_LONG_BODY: &[u8] = br#"{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 213462 tokens > 200000 maximum"}}"#;
 
-/// Raw-TCP upstream that answers every request with the canned 400.
+/// Upstream that answers every request with the canned 400 — the shared
+/// canned-status helper with `bad_first = MAX` (never recovers). `bad_head`
+/// is a raw pre-formatted response, so the JSON body rides along in it; the
+/// content-length is computed here and the leak is one string per test run.
 async fn spawn_prompt_too_long_upstream() -> String {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        loop {
-            let (mut s, _) = listener.accept().await.unwrap();
-            let mut buf = [0u8; 65536];
-            let _ = s.read(&mut buf).await;
-            let head = format!(
-                "HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
-                PROMPT_TOO_LONG_BODY.len()
-            );
-            let _ = s.write_all(head.as_bytes()).await;
-            let _ = s.write_all(PROMPT_TOO_LONG_BODY).await;
-            let _ = s.flush().await;
-        }
-    });
-    format!("http://{addr}")
+    let raw: &'static str = Box::leak(
+        format!(
+            "HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            PROMPT_TOO_LONG_BODY.len(),
+            std::str::from_utf8(PROMPT_TOO_LONG_BODY).unwrap(),
+        )
+        .into_boxed_str(),
+    );
+    spawn_status_then_ok_upstream(usize::MAX, raw, ANTHROPIC_OK_BODY)
+        .await
+        .0
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #109 · Multica LAB-916

## What

Operator visibility for context-window exhaustion — the data behind Ray's "sessions > pins > token % / window" dashboard, on the surfaces that already exist. Three additive pieces, **zero routing change**:

1. **Session registry (AC1)** — bounded (`session_registry_max`, default 1000) + TTL-evicted (`session_registry_ttl_secs`, default 1800s) in-memory map keyed by the affinity routing key (the same key `pick_endpoint` pins on, so fan-out subagents sharing one coarse session-id appear as distinct entries — the overflow pattern this is meant to expose). Records client/agent/session ids, model, pinned endpoint, last prompt occupancy (`input + cache_read + cache_creation` from the last successful `Usage`), context window, request count, last-seen. Updated in `finalize_stream`/`finalize_non_stream` on both Anthropic-bound paths (native + openai-compat).
2. **Context-window table (AC2)** — 200k default, 1M when the request carries the `context-1m` beta (checked per request, comma-joined header values handled); unknown model families fall back to 200k with a bounded once-per-model warn.
3. **Prompt-too-long detection (AC4)** — upstream `400 invalid_request_error` matching "prompt is too long" increments `anthropic_prompt_too_long_total{model}` on `/metrics` (cardinality bounded via `_other`) and emits a structured WARN with the redacted session label + observed-vs-max tokens parsed from the error message. The 400 body is forwarded **byte-for-byte unchanged** (test-pinned).

**`/_stats` `sessions` block (AC3)** — behind the existing IP allowlist + `proxy_key` gate: hashed 16-hex session label (joins with the WARN logs), operator-masked `client_id`, 8-char truncated agent/session prefixes, model, endpoint, occupancy, window, `context_window_pct` (can exceed 100 — that's the signal), sorted hottest-first, top-50. Raw IPs and raw session ids never leave the process (test-asserted).

## Hot-path & security notes (AC7 + audit guardrail)

- Registry + counter use sync `std::sync::Mutex`, never held across `.await`; TTL prune and oldest-eviction run only on new-key inserts (steady-state = one map update).
- No change to routing math, headroom weighting, affinity selection, or retry behaviour — all 479 pre-existing bin tests pass unchanged.
- New `/_stats` fields sit behind the *existing* auth; redaction is test-asserted (no raw `session_id`/client IP substring in the block).
- Not persisted, per-replica, no Redis — visibility MVP per ticket scope.

## Tests (AC6)

10 new tests: registry populate/update/cap-evict, TTL evict (prune + snapshot filter), disabled-at-0, snapshot sort+top-N, window mapping, 1M-beta header parse, `window_pct` ≥100%, error-shape detection + token parse (incl. negative cases), counter cardinality bound, plus two integrations: canned 400 → counter + `/metrics` label + unchanged passthrough; end-to-end `/_stats` sessions block + redaction.

`cargo fmt --check` ✓ · `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` ✓ · `cargo test` 509 passed / 0 failed ✓

## Docs (AC5)

README: config reference rows, endpoints table, a "Session context-window visibility" section, and the example `/_stats` response now includes `sessions`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live session visibility to `/_stats`, including context-window usage, request counts, model, endpoint and last-seen details.
  * Added configurable session limits and expiry settings.
  * Added `prompt is too long` tracking by model in `/_stats` and `/metrics`.
  * Added support for larger context-window reporting, including 1M-token beta configurations.

* **Documentation**
  * Updated configuration and endpoint documentation with the new settings, statistics and response examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->