### PR TITLE
LAB-941: route away from accounts that reject the requested model

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2209,7 +2209,10 @@ impl AppState {
             return;
         };
         map.retain(|_, expiry| *expiry > now);
-        if map.len() >= UNSUPPORTED_MODEL_MAX {
+        // Capacity gates NEW pairs only — refreshing an existing pair's TTL
+        // doesn't grow the map and must not starve under sustained rejections.
+        let key = (endpoint_idx, model.to_string());
+        if !map.contains_key(&key) && map.len() >= UNSUPPORTED_MODEL_MAX {
             return;
         }
         warn!(
@@ -2218,10 +2221,7 @@ impl AppState {
             cooldown_secs = UNSUPPORTED_MODEL_TTL.as_secs(),
             "model unsupported on account, routing away"
         );
-        map.insert(
-            (endpoint_idx, model.to_string()),
-            now + UNSUPPORTED_MODEL_TTL,
-        );
+        map.insert(key, now + UNSUPPORTED_MODEL_TTL);
     }
 
     /// Endpoint indices currently marked unsupported for `model`. One lock +
@@ -2240,6 +2240,33 @@ impl AppState {
                 .collect(),
             Err(_) => Vec::new(),
         }
+    }
+
+    /// True when EVERY endpoint whose config allows `model` carries a live
+    /// unsupported-model entry — the pool cannot serve the model at all,
+    /// regardless of capacity. Used at exhaustion: on a warm negative cache
+    /// the candidate pool empties before any forward attempt runs, so there
+    /// is no stashed upstream 404 — this check lets the handler synthesize
+    /// one instead of degrading to a retryable 429 (LAB-941 follow-up).
+    /// Endpoints excluded by their config `models` allowlist never serve the
+    /// model and don't count; false when no endpoint could ever serve it
+    /// (config-only exclusion keeps its pre-existing 429 semantics).
+    fn model_unsupported_everywhere(&self, model: &str) -> bool {
+        if model.is_empty() {
+            return false;
+        }
+        let unsupported = self.unsupported_endpoints_for(model);
+        let mut eligible = 0usize;
+        for (i, ep) in self.endpoints.iter().enumerate() {
+            if !ep.serves_model(model) {
+                continue;
+            }
+            eligible += 1;
+            if !unsupported.contains(&i) {
+                return false;
+            }
+        }
+        eligible > 0
     }
 
     async fn routing_candidates(&self, model: &str, skip: &[EndpointIdx]) -> Vec<RoutingCandidate> {
@@ -5410,6 +5437,38 @@ fn exhaustion_response(last_saw_transient: bool, last_saw_529: bool) -> Response
     (StatusCode::TOO_MANY_REQUESTS, "exhausted all endpoints").into_response()
 }
 
+/// Synthesized model-unsupported 404 for the warm negative-cache path: every
+/// eligible endpoint is already cached as rejecting `model`, so the pool
+/// empties before any forward attempt runs and there is no upstream response
+/// to stash. Mirrors Anthropic's canonical not-found envelope (`"model: <id>"`
+/// is the wire format accounts actually return); `openai_shape` emits the
+/// OpenAI error shape for the compat handler instead. Cannot echo cached
+/// upstream bytes: the cache stores no bodies, and a body cached from one
+/// protocol would be wrong for the other handler's clients (LAB-941).
+fn model_unsupported_response(model: &str, openai_shape: bool) -> Response {
+    let body = if openai_shape {
+        serde_json::json!({
+            "error": {
+                "message": format!("model: {model}"),
+                "type": "not_found_error",
+                "param": null,
+                "code": "model_not_found"
+            }
+        })
+    } else {
+        serde_json::json!({
+            "type": "error",
+            "error": { "type": "not_found_error", "message": format!("model: {model}") }
+        })
+    };
+    (
+        StatusCode::NOT_FOUND,
+        [("content-type", "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
 /// 400 in Anthropic's error envelope when an Anthropic request can't be
 /// faithfully translated for an OpenAI-compat fallback endpoint (e.g. an
 /// image source type the translator doesn't support). The caller's request
@@ -6172,6 +6231,14 @@ async fn proxy_handler(
     if !last_saw_529 && !last_saw_transient {
         if let Some(resp) = model_unsupported_resp {
             return resp;
+        }
+        // Warm-cache path: every eligible endpoint was filtered by the
+        // negative cache BEFORE any forward ran, so nothing was stashed.
+        // Synthesize the same truthful 404 the first request returned —
+        // a 429 here would invite retries of a permanently-failing model.
+        if state.model_unsupported_everywhere(&model) {
+            warn!(model, "model unsupported on all eligible endpoints");
+            return model_unsupported_response(&model, false);
         }
     }
     exhaustion_response(last_saw_transient, last_saw_529)
@@ -10170,10 +10237,15 @@ async fn openai_chat_handler(
         }
     }
 
-    // Same model-rejection exhaustion rule as `proxy_handler` (LAB-941).
+    // Same model-rejection exhaustion rule as `proxy_handler` (LAB-941),
+    // in the OpenAI error shape this handler's clients parse.
     if !last_saw_529 && !last_saw_transient {
         if let Some(resp) = model_unsupported_resp {
             return resp;
+        }
+        if state.model_unsupported_everywhere(&model) {
+            warn!(model, "model unsupported on all eligible endpoints");
+            return model_unsupported_response(&model, true);
         }
     }
     exhaustion_response(last_saw_transient, last_saw_529)

--- a/src/main.rs
+++ b/src/main.rs
@@ -608,6 +608,14 @@ struct AppState {
     /// Upstream "prompt is too long" 400s by model (LAB-916). Exposed as
     /// `anthropic_prompt_too_long_total`; bounded via `_other` overflow.
     prompt_too_long: Mutex<HashMap<String, u64>>,
+    /// (endpoint idx, model) pairs an upstream rejected as unsupported — a
+    /// gateway without the model, or a plan without access (LAB-941).
+    /// `routing_candidates` skips these until the entry expires; because
+    /// session affinity is a stateless hash over the candidate list, the
+    /// filter also re-buckets pinned sessions away from the endpoint. Sync
+    /// mutex, never held across `.await`; bounded by UNSUPPORTED_MODEL_MAX
+    /// + TTL eviction. Per-replica: a fresh replica re-learns in one attempt.
+    unsupported_models: Mutex<HashMap<(usize, String), Instant>>,
 }
 
 /// RAII reservation against `AppState::inflight_body_bytes`. Holding it keeps the
@@ -1584,6 +1592,20 @@ const TRANSPORT_FAILURE_THRESHOLD: u32 = 3;
 /// ponytail: constant, add a config knob if operators ever need to tune it.
 const TRANSPORT_UNHEALTHY_COOLDOWN: Duration = Duration::from_secs(30);
 
+/// How long a learned "(endpoint, model) unsupported" verdict keeps that
+/// endpoint out of the model's routing pool (LAB-941). An account's model set
+/// changes only on plan/gateway updates, so a long hold is safe; the TTL is
+/// the self-heal path when it does change (no restart needed). The cost of an
+/// expiry is one wasted upstream attempt to re-learn the rejection.
+/// ponytail: constant, add a config knob if operators ever need to tune it.
+const UNSUPPORTED_MODEL_TTL: Duration = Duration::from_secs(900);
+
+/// Bound on distinct learned (endpoint, model) rejections. Model names are
+/// client-supplied, so without a cap a client spraying junk model names could
+/// grow the map without limit. When full, new learns are dropped (that only
+/// costs the pre-LAB-941 behaviour) and TTL expiry drains the map.
+const UNSUPPORTED_MODEL_MAX: usize = 256;
+
 /// Sentinel value written to `alb:hard:{account}` when a replica has observed
 /// recovery from a hard rate limit. Other replicas interpret this as an
 /// instruction to proactively clear their local `hard_limited_until`, which
@@ -2176,15 +2198,68 @@ impl AppState {
         &self.endpoints[ep].name
     }
 
+    /// Record that `endpoint_idx` cannot serve `model` — the upstream itself
+    /// said so (LAB-941). Routing skips the pair for UNSUPPORTED_MODEL_TTL.
+    fn note_model_unsupported(&self, endpoint_name: &str, endpoint_idx: usize, model: &str) {
+        if model.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        let Ok(mut map) = self.unsupported_models.lock() else {
+            return;
+        };
+        map.retain(|_, expiry| *expiry > now);
+        if map.len() >= UNSUPPORTED_MODEL_MAX {
+            return;
+        }
+        warn!(
+            account = endpoint_name,
+            model,
+            cooldown_secs = UNSUPPORTED_MODEL_TTL.as_secs(),
+            "model unsupported on account, routing away"
+        );
+        map.insert(
+            (endpoint_idx, model.to_string()),
+            now + UNSUPPORTED_MODEL_TTL,
+        );
+    }
+
+    /// Endpoint indices currently marked unsupported for `model`. One lock +
+    /// full scan per pick — the map is capped at UNSUPPORTED_MODEL_MAX and
+    /// empty in the common case.
+    fn unsupported_endpoints_for(&self, model: &str) -> Vec<usize> {
+        if model.is_empty() {
+            return Vec::new();
+        }
+        let now = Instant::now();
+        match self.unsupported_models.lock() {
+            Ok(map) => map
+                .iter()
+                .filter(|((_, m), expiry)| m == model && **expiry > now)
+                .map(|((idx, _), _)| *idx)
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     async fn routing_candidates(&self, model: &str, skip: &[EndpointIdx]) -> Vec<RoutingCandidate> {
         let now = Instant::now();
         let now_epoch = Self::now_epoch();
+        let unsupported = self.unsupported_endpoints_for(model);
         let mut candidates: Vec<RoutingCandidate> = Vec::new();
         for (i, ep) in self.endpoints.iter().enumerate() {
             if skip.contains(&i) {
                 continue;
             }
             if !ep.serves_model(model) {
+                continue;
+            }
+            if unsupported.contains(&i) {
+                trace!(
+                    endpoint = ep.name,
+                    model,
+                    "pick: skipping, model unsupported on endpoint"
+                );
                 continue;
             }
             match ep.protocol {
@@ -5071,13 +5146,49 @@ fn debug_dump_cache_control(body: &serde_json::Value, req_id: &str) {
 ///     (ETIMEDOUT/reset/closed/DNS) — the loop treats these with round-gated
 ///     rotation (retry the affinity/cache-warm endpoint in place on round 0,
 ///     rotate only on later rounds) and a transient-aware exhaustion status.
+///   - `RetryModelUnsupported(resp)`: the endpoint rejected the request's
+///     MODEL, not the request itself (LAB-941). The forward path has already
+///     negative-cached the (endpoint, model) pair; the loop rotates like a
+///     429 while stashing the upstream's error response, so a model no OTHER
+///     endpoint can serve still surfaces the real error — a nonexistent-model
+///     404 must not morph into a synthetic 429 that invites retries.
 enum ForwardOutcome {
     Done(Response),
+    RetryModelUnsupported(Response),
     Retry {
         saw_529: bool,
         push_skip: bool,
         transient: bool,
     },
+}
+
+/// True when an upstream error body says this ACCOUNT cannot serve the
+/// requested model — distinct from a malformed request (LAB-941). Matched
+/// conservatively against observed wire formats:
+///   - Anthropic: 404 `{"type":"error","error":{"type":"not_found_error",
+///     "message":"model: <id>"}}` — also what subscription accounts return
+///     for models outside their plan.
+///   - LiteLLM-style gateways: 400 `{"error":{"message":"... Invalid model
+///     name passed in model=<id> ..."}}` (observed live from insight-gateway,
+///     2026-07-27).
+///   - OpenAI: `{"error":{"code":"model_not_found", ...}}`.
+fn is_model_unsupported_error(status: StatusCode, body: &serde_json::Value) -> bool {
+    if status != StatusCode::NOT_FOUND && status != StatusCode::BAD_REQUEST {
+        return false;
+    }
+    let Some(err) = body.get("error") else {
+        return false;
+    };
+    let msg = err.get("message").and_then(|v| v.as_str()).unwrap_or("");
+    if err.get("type").and_then(|v| v.as_str()) == Some("not_found_error")
+        && msg.starts_with("model:")
+    {
+        return true;
+    }
+    if err.get("code").and_then(|v| v.as_str()) == Some("model_not_found") {
+        return true;
+    }
+    msg.to_ascii_lowercase().contains("invalid model name")
 }
 
 /// Surface the real cause of a `reqwest::Error`. The Display form only shows
@@ -5211,9 +5322,18 @@ fn apply_round_outcome(
     skip: &mut Vec<EndpointIdx>,
     saw_529: &mut bool,
     saw_transient: &mut bool,
+    model_unsupported_resp: &mut Option<Response>,
 ) -> RetryStep {
     match outcome {
         ForwardOutcome::Done(resp) => RetryStep::Return(resp),
+        // Model rejected by this endpoint: rotate immediately (another
+        // account may serve it) but keep the upstream's error in hand for
+        // the case where none does (LAB-941).
+        ForwardOutcome::RetryModelUnsupported(resp) => {
+            *model_unsupported_resp = Some(resp);
+            skip.push(picked_idx);
+            RetryStep::NextAttempt
+        }
         ForwardOutcome::Retry {
             saw_529: s,
             push_skip,
@@ -5721,6 +5841,19 @@ async fn forward_anthropic(
                     state.note_prompt_too_long(req_id, model, session_key, msg);
                 }
             }
+            // Model unsupported on THIS account (e.g. outside its plan):
+            // negative-cache the pair and rotate — another account may serve
+            // it. Forwarding the 404 as-is wedges affinity-pinned clients
+            // into a permanent retry loop against this account (LAB-941).
+            if is_model_unsupported_error(status, &parsed) {
+                state.note_model_unsupported(endpoint_name, endpoint_idx, model);
+                let response = builder
+                    .body(Body::from(resp_body_bytes))
+                    .unwrap_or_else(|_| {
+                        (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
+                    });
+                return ForwardOutcome::RetryModelUnsupported(response);
+            }
         }
         finalize_non_stream(
             state,
@@ -5935,6 +6068,9 @@ async fn proxy_handler(
     let n = state.endpoints.len();
     let mut last_saw_529 = false;
     let mut last_saw_transient = false;
+    // Upstream error from the most recent model-unsupported rejection —
+    // returned verbatim if the pool exhausts on nothing but rejections.
+    let mut model_unsupported_resp: Option<Response> = None;
     for retry_round in 0..=MAX_529_RETRIES {
         if retry_round > 0 {
             let delay = round_backoff_delay(retry_round, last_saw_529);
@@ -6014,6 +6150,7 @@ async fn proxy_handler(
                 &mut skip,
                 &mut saw_529,
                 &mut saw_transient,
+                &mut model_unsupported_resp,
             ) {
                 RetryStep::Return(resp) => return resp,
                 RetryStep::NextAttempt => continue,
@@ -6027,6 +6164,16 @@ async fn proxy_handler(
         }
     }
 
+    // A pool exhausted purely by model rejections (no 529/transient in the
+    // final round) returns the upstream's own error — truthful when the model
+    // exists nowhere. Overload/transient exhaustion keeps its retryable
+    // status; the negative cache already routes follow-up requests away from
+    // the rejecting endpoints (LAB-941).
+    if !last_saw_529 && !last_saw_transient {
+        if let Some(resp) = model_unsupported_resp {
+            return resp;
+        }
+    }
     exhaustion_response(last_saw_transient, last_saw_529)
 }
 
@@ -6193,36 +6340,46 @@ async fn try_fallback_upstream(
             body = %err_body,
             "fallback: unified endpoint returned error"
         );
-        if translate {
+        // Gateway rejected the MODEL (e.g. LiteLLM "Invalid model name"):
+        // negative-cache the pair and rotate instead of handing the client a
+        // misleading "your request is invalid" 400 — the model is fine, this
+        // endpoint just doesn't serve it (LAB-941, observed 2026-07-27 when a
+        // 529 storm drained the Anthropic pool into insight-gateway).
+        let model_unsupported = serde_json::from_str::<serde_json::Value>(&err_body)
+            .map(|v| is_model_unsupported_error(status, &v))
+            .unwrap_or(false);
+        let response = if translate {
             // Return error in Anthropic format
-            return ForwardOutcome::Done(
-                Response::builder()
-                    .status(status)
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        serde_json::json!({
-                            "type": "error",
-                            "error": {
-                                "type": "api_error",
-                                "message": err_body,
-                            }
-                        })
-                        .to_string(),
-                    ))
-                    .unwrap_or_else(|_| {
-                        (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
-                    }),
-            );
-        }
-        return ForwardOutcome::Done(
+            Response::builder()
+                .status(status)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "type": "error",
+                        "error": {
+                            "type": "api_error",
+                            "message": err_body,
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
+                })
+        } else {
             Response::builder()
                 .status(status)
                 .header("content-type", "application/json")
                 .body(Body::from(err_body))
                 .unwrap_or_else(|_| {
                     (StatusCode::INTERNAL_SERVER_ERROR, "fallback error").into_response()
-                }),
-        );
+                })
+        };
+        if model_unsupported {
+            state.note_model_unsupported(&ep.name, endpoint_idx, model);
+            return ForwardOutcome::RetryModelUnsupported(response);
+        }
+        return ForwardOutcome::Done(response);
     }
 
     // Streaming response
@@ -9533,6 +9690,7 @@ async fn forward_openai_compat_anthropic(
 
         // Translate Anthropic error to OpenAI error format so clients
         // (LiteLLM, etc.) can parse the actual error message.
+        let mut model_unsupported = false;
         let openai_error =
             if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&error_body) {
                 // Count + trace context-window overflows here too (LAB-916) —
@@ -9542,6 +9700,8 @@ async fn forward_openai_compat_anthropic(
                         state.note_prompt_too_long(req_id, model, session_key, msg);
                     }
                 }
+                // Same model-rejection detection as the native path (LAB-941).
+                model_unsupported = is_model_unsupported_error(status, &parsed);
                 // Anthropic: {"type":"error","error":{"type":"...","message":"..."}}
                 let msg = parsed
                     .pointer("/error/message")
@@ -9581,6 +9741,10 @@ async fn forward_openai_compat_anthropic(
             .unwrap_or_else(|_| {
                 (StatusCode::INTERNAL_SERVER_ERROR, "response build error").into_response()
             });
+        if model_unsupported {
+            state.note_model_unsupported(endpoint_name, endpoint_idx, model);
+            return ForwardOutcome::RetryModelUnsupported(response);
+        }
         return ForwardOutcome::Done(response);
     }
 
@@ -9907,6 +10071,9 @@ async fn openai_chat_handler(
     let n = state.endpoints.len();
     let mut last_saw_529 = false;
     let mut last_saw_transient = false;
+    // Upstream error from the most recent model-unsupported rejection —
+    // returned verbatim if the pool exhausts on nothing but rejections.
+    let mut model_unsupported_resp: Option<Response> = None;
     for retry_round in 0..=MAX_529_RETRIES {
         if retry_round > 0 {
             let delay = round_backoff_delay(retry_round, last_saw_529);
@@ -9989,6 +10156,7 @@ async fn openai_chat_handler(
                 &mut skip,
                 &mut saw_529,
                 &mut saw_transient,
+                &mut model_unsupported_resp,
             ) {
                 RetryStep::Return(resp) => return resp,
                 RetryStep::NextAttempt => continue,
@@ -10002,6 +10170,12 @@ async fn openai_chat_handler(
         }
     }
 
+    // Same model-rejection exhaustion rule as `proxy_handler` (LAB-941).
+    if !last_saw_529 && !last_saw_transient {
+        if let Some(resp) = model_unsupported_resp {
+            return resp;
+        }
+    }
     exhaustion_response(last_saw_transient, last_saw_529)
 }
 
@@ -10395,6 +10569,7 @@ async fn main() {
             .session_registry_ttl_secs
             .unwrap_or(DEFAULT_SESSION_REGISTRY_TTL_SECS),
         prompt_too_long: Mutex::new(HashMap::new()),
+        unsupported_models: Mutex::new(HashMap::new()),
     });
 
     if state.auto_cache {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5447,10 +5447,13 @@ fn exhaustion_response(last_saw_transient: bool, last_saw_529: bool) -> Response
 /// protocol would be wrong for the other handler's clients (LAB-941).
 fn model_unsupported_response(model: &str, openai_shape: bool) -> Response {
     let body = if openai_shape {
+        // OpenAI's canonical model-not-found envelope: type is
+        // invalid_request_error (an OpenAI type — not Anthropic's
+        // not_found_error), with the specific cause in `code`.
         serde_json::json!({
             "error": {
                 "message": format!("model: {model}"),
-                "type": "not_found_error",
+                "type": "invalid_request_error",
                 "param": null,
                 "code": "model_not_found"
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4881,6 +4881,65 @@ async fn model_unsupported_everywhere_returns_upstream_404_not_429() {
     );
 }
 
+/// Same all-reject scenario through `/v1/chat/completions`: the warm-cache
+/// synthesized 404 must carry the OpenAI error shape — `type` is
+/// `invalid_request_error` (an OpenAI type, not Anthropic's
+/// `not_found_error`) with the specific cause in `code = model_not_found`.
+#[tokio::test]
+async fn model_unsupported_everywhere_openai_handler_returns_openai_shaped_404() {
+    use std::sync::atomic::Ordering;
+    let (url, hits) = spawn_status_then_ok_upstream(usize::MAX, HEAD_404_MODEL, b"{}").await;
+    let state = test_state_with(vec![mk_endpoint_at("only", "sk-ant-api-o", &url)]);
+    let addr = serve(build_router(state)).await;
+
+    let client = reqwest::Client::new();
+    // Cold pass populates the cache from the upstream rejection.
+    let resp = client
+        .post(format!("http://{addr}/v1/chat/completions"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-nope-1","messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    // Warm pass: pool empties via the cache, response is synthesized.
+    let resp = client
+        .post(format!("http://{addr}/v1/chat/completions"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-nope-1","messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "warm cache through the OpenAI handler must return 404, not 429"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body.pointer("/error/type").and_then(|v| v.as_str()),
+        Some("invalid_request_error"),
+        "synthesized OpenAI envelope must use an OpenAI error type, got: {body}"
+    );
+    assert_eq!(
+        body.pointer("/error/code").and_then(|v| v.as_str()),
+        Some("model_not_found"),
+        "synthesized OpenAI envelope must carry code=model_not_found, got: {body}"
+    );
+    assert!(
+        body.pointer("/error/message")
+            .and_then(|v| v.as_str())
+            .is_some_and(|m| m.contains("claude-nope-1")),
+        "message must name the rejected model, got: {body}"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "the warm-cache request must not touch the upstream at all"
+    );
+}
+
 /// LAB-941 incident shape (observed live 2026-07-27): an OpenAI-protocol
 /// gateway without the requested model returns 400 "Invalid model name"; the
 /// LB must rotate to an account that serves it and route the NEXT request

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -338,6 +338,7 @@ fn test_state_base() -> AppState {
         session_registry_max: DEFAULT_SESSION_REGISTRY_MAX,
         session_registry_ttl_secs: DEFAULT_SESSION_REGISTRY_TTL_SECS,
         prompt_too_long: Mutex::new(HashMap::new()),
+        unsupported_models: Mutex::new(HashMap::new()),
     }
 }
 
@@ -4651,6 +4652,235 @@ async fn openai_529_triggers_bebo_backoff_retry() {
         hits.load(Ordering::SeqCst),
         2,
         "exactly one 529 then one successful retry"
+    );
+}
+
+// ── LAB-941: model-unsupported detection + negative-cache routing ────
+
+/// Raw 404 with Anthropic's model-not-found envelope (`connection: close`, so
+/// the body is EOF-delimited — no content-length needed).
+const HEAD_404_MODEL: &str = "HTTP/1.1 404 Not Found\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model: claude-nope-1\"}}";
+
+/// Wire-format detection: only genuine "this account can't serve the model"
+/// errors match; other 4xx (prompt too long, bad path) must not.
+#[test]
+fn model_unsupported_error_detection() {
+    let anthropic_404 = serde_json::json!({
+        "type": "error",
+        "error": {"type": "not_found_error", "message": "model: claude-nope-1"}
+    });
+    assert!(is_model_unsupported_error(
+        StatusCode::NOT_FOUND,
+        &anthropic_404
+    ));
+    assert!(
+        !is_model_unsupported_error(StatusCode::INTERNAL_SERVER_ERROR, &anthropic_404),
+        "status gate: a 5xx is never a model rejection"
+    );
+
+    let path_404 = serde_json::json!({
+        "type": "error",
+        "error": {"type": "not_found_error", "message": "Not Found"}
+    });
+    assert!(
+        !is_model_unsupported_error(StatusCode::NOT_FOUND, &path_404),
+        "URL-path 404 lacks the 'model:' prefix and must not match"
+    );
+
+    // LiteLLM-style gateway body, observed live from insight-gateway 2026-07-27.
+    let litellm_400 = serde_json::json!({
+        "error": {
+            "message": "/chat/completions: Invalid model name passed in model=claude-opus-5. Call `/v1/models` to view available models for your key.",
+            "type": "None", "param": "None", "code": "400"
+        }
+    });
+    assert!(is_model_unsupported_error(
+        StatusCode::BAD_REQUEST,
+        &litellm_400
+    ));
+
+    let openai_code = serde_json::json!({
+        "error": {"message": "The model `x` does not exist", "type": "invalid_request_error", "code": "model_not_found"}
+    });
+    assert!(is_model_unsupported_error(
+        StatusCode::NOT_FOUND,
+        &openai_code
+    ));
+
+    let too_long = serde_json::json!({
+        "type": "error",
+        "error": {"type": "invalid_request_error", "message": "prompt is too long: 210000 tokens > 200000 maximum"}
+    });
+    assert!(
+        !is_model_unsupported_error(StatusCode::BAD_REQUEST, &too_long),
+        "prompt-too-long 400 must not be treated as a model rejection"
+    );
+}
+
+/// The negative cache removes the (endpoint, model) pair from routing — for
+/// that model only, affinity or not — and an expired entry restores it.
+#[tokio::test]
+async fn model_unsupported_filters_routing_until_expiry() {
+    let acct_a = mk_endpoint("a", "sk-ant-api-a");
+    let acct_b = mk_endpoint("b", "sk-ant-api-b");
+    let state = test_state_with(vec![acct_a, acct_b]);
+
+    state.note_model_unsupported("a", 0, "claude-fable-5");
+
+    for _ in 0..8 {
+        assert_eq!(
+            state.pick_endpoint(None, "claude-fable-5", &[]).await,
+            Some(1),
+            "noted model must never route to the rejecting endpoint"
+        );
+    }
+    // Session affinity re-buckets too: the sticky hash only sees candidates.
+    assert_eq!(
+        state
+            .pick_endpoint(Some("client:sess:1"), "claude-fable-5", &[])
+            .await,
+        Some(1),
+        "an affinity-pinned session must migrate off the rejecting endpoint"
+    );
+    assert!(
+        state
+            .pick_endpoint(None, "claude-sonnet-5", &[])
+            .await
+            .is_some(),
+        "other models on the same endpoint are unaffected"
+    );
+
+    // Force-expire the entry: the endpoint must rejoin the model's pool.
+    {
+        let mut map = state.unsupported_models.lock().unwrap();
+        map.insert((0, "claude-fable-5".to_string()), Instant::now());
+    }
+    let candidates = state.routing_candidates("claude-fable-5", &[]).await;
+    assert_eq!(candidates.len(), 2, "expired entry must not filter routing");
+}
+
+/// The learn map is bounded: past UNSUPPORTED_MODEL_MAX distinct pairs, new
+/// learns are dropped — model strings are client-supplied input.
+#[test]
+fn model_unsupported_map_is_bounded() {
+    let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-a")]);
+    for i in 0..(UNSUPPORTED_MODEL_MAX + 50) {
+        state.note_model_unsupported("a", 0, &format!("model-{i}"));
+    }
+    assert_eq!(
+        state.unsupported_models.lock().unwrap().len(),
+        UNSUPPORTED_MODEL_MAX
+    );
+}
+
+/// LAB-941 native path: an account 404-rejecting the model rotates to the
+/// next account within the request, and the negative cache makes the NEXT
+/// request skip the rejecting account outright instead of re-pinning it via
+/// session affinity.
+#[tokio::test]
+async fn model_unsupported_rotates_and_next_request_skips_account() {
+    use std::sync::atomic::Ordering;
+    let (reject_url, reject_hits) =
+        spawn_status_then_ok_upstream(usize::MAX, HEAD_404_MODEL, b"{}").await;
+    let (ok_url, _h) = spawn_mock_upstream().await;
+
+    let reject = mk_endpoint_at("reject", "sk-ant-api-r", &reject_url);
+    let mut healthy = mk_endpoint_at("healthy", "sk-ant-api-h", &ok_url);
+    // Priority forces routing to try `reject` first — deterministic without
+    // depending on affinity hashing.
+    healthy.priority = 1;
+    let state = test_state_with(vec![reject, healthy]);
+    let addr = serve(build_router(state)).await;
+
+    let client = reqwest::Client::new();
+    for _ in 0..2 {
+        let resp = client
+            .post(format!("http://{addr}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"model":"claude-nope-1","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::OK,
+            "both requests must succeed via the account that serves the model"
+        );
+    }
+    assert_eq!(
+        reject_hits.load(Ordering::SeqCst),
+        1,
+        "the second request must skip the rejecting account, not retry it"
+    );
+}
+
+/// When NO account serves the model (nonexistent model), the upstream's own
+/// 404 must surface — not a synthetic 429 that invites the client to retry a
+/// permanently-failing request.
+#[tokio::test]
+async fn model_unsupported_everywhere_returns_upstream_404_not_429() {
+    let (url, _hits) = spawn_status_then_ok_upstream(usize::MAX, HEAD_404_MODEL, b"{}").await;
+    let state = test_state_with(vec![mk_endpoint_at("only", "sk-ant-api-o", &url)]);
+    let addr = serve(build_router(state)).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"claude-nope-1","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "pool exhausted purely by model rejections must return the real 404"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("not_found_error"),
+        "upstream error body must pass through, got: {body}"
+    );
+}
+
+/// LAB-941 incident shape (observed live 2026-07-27): an OpenAI-protocol
+/// gateway without the requested model returns 400 "Invalid model name"; the
+/// LB must rotate to an account that serves it and route the NEXT request
+/// away from the gateway, instead of handing clients the misleading 400.
+#[tokio::test]
+async fn gateway_invalid_model_rotates_to_serving_account() {
+    use std::sync::atomic::Ordering;
+    const HEAD_400_LITELLM: &str = "HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{\"error\":{\"message\":\"/chat/completions: Invalid model name passed in model=claude-opus-5. Call `/v1/models` to view available models for your key.\",\"type\":\"None\",\"param\":\"None\",\"code\":\"400\"}}";
+    let (gw_url, gw_hits) =
+        spawn_status_then_ok_upstream(usize::MAX, HEAD_400_LITELLM, OPENAI_OK_BODY).await;
+    let (ok_url, _h) = spawn_mock_upstream().await;
+
+    let mut gw = make_endpoint("gw", Protocol::OpenAI);
+    gw.base_url = gw_url;
+    let mut healthy = mk_endpoint_at("healthy", "sk-ant-api-h", &ok_url);
+    // Gateway tried first, deterministically.
+    healthy.priority = 1;
+    let state = test_state_with(vec![gw, healthy]);
+    let addr = serve(build_router(state)).await;
+
+    let client = reqwest::Client::new();
+    for _ in 0..2 {
+        let resp = client
+            .post(format!("http://{addr}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"model":"claude-opus-5","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::OK,
+            "requests must succeed via the Anthropic account, not fail on the gateway 400"
+        );
+    }
+    assert_eq!(
+        gw_hits.load(Ordering::SeqCst),
+        1,
+        "the second request must skip the gateway for this model"
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4760,7 +4760,8 @@ async fn model_unsupported_filters_routing_until_expiry() {
 }
 
 /// The learn map is bounded: past UNSUPPORTED_MODEL_MAX distinct pairs, new
-/// learns are dropped — model strings are client-supplied input.
+/// learns are dropped — model strings are client-supplied input. An EXISTING
+/// pair must still refresh its TTL at capacity (refresh doesn't grow the map).
 #[test]
 fn model_unsupported_map_is_bounded() {
     let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-a")]);
@@ -4771,6 +4772,30 @@ fn model_unsupported_map_is_bounded() {
         state.unsupported_models.lock().unwrap().len(),
         UNSUPPORTED_MODEL_MAX
     );
+
+    // Shorten one live entry's TTL, then re-note it with the map still full:
+    // the refresh must land (expiry back to ~full TTL), not be dropped.
+    let key = (0usize, "model-0".to_string());
+    {
+        let mut map = state.unsupported_models.lock().unwrap();
+        map.insert(key.clone(), Instant::now() + Duration::from_secs(1));
+    }
+    state.note_model_unsupported("a", 0, "model-0");
+    {
+        let map = state.unsupported_models.lock().unwrap();
+        assert_eq!(
+            map.len(),
+            UNSUPPORTED_MODEL_MAX,
+            "refresh must not grow the map"
+        );
+        let expiry = map
+            .get(&key)
+            .expect("existing pair must survive a refresh at capacity");
+        assert!(
+            *expiry > Instant::now() + Duration::from_secs(60),
+            "TTL must be refreshed for an existing pair even at capacity"
+        );
+    }
 }
 
 /// LAB-941 native path: an account 404-rejecting the model rotates to the
@@ -4816,29 +4841,43 @@ async fn model_unsupported_rotates_and_next_request_skips_account() {
 
 /// When NO account serves the model (nonexistent model), the upstream's own
 /// 404 must surface — not a synthetic 429 that invites the client to retry a
-/// permanently-failing request.
+/// permanently-failing request. A SECOND request then hits the warm negative
+/// cache (the pool empties before any forward runs, nothing is stashed) and
+/// must still get a 404, synthesized, without touching the upstream again.
 #[tokio::test]
 async fn model_unsupported_everywhere_returns_upstream_404_not_429() {
-    let (url, _hits) = spawn_status_then_ok_upstream(usize::MAX, HEAD_404_MODEL, b"{}").await;
+    use std::sync::atomic::Ordering;
+    let (url, hits) = spawn_status_then_ok_upstream(usize::MAX, HEAD_404_MODEL, b"{}").await;
     let state = test_state_with(vec![mk_endpoint_at("only", "sk-ant-api-o", &url)]);
     let addr = serve(build_router(state)).await;
 
-    let resp = reqwest::Client::new()
-        .post(format!("http://{addr}/v1/messages"))
-        .header("content-type", "application/json")
-        .body(r#"{"model":"claude-nope-1","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
-        .send()
-        .await
-        .unwrap();
+    let client = reqwest::Client::new();
+    for pass in [
+        "cold cache (real upstream 404)",
+        "warm cache (synthesized 404)",
+    ] {
+        let resp = client
+            .post(format!("http://{addr}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"model":"claude-nope-1","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::NOT_FOUND,
+            "{pass}: model unsupported everywhere must return 404, not 429"
+        );
+        let body = resp.text().await.unwrap();
+        assert!(
+            body.contains("not_found_error") && body.contains("claude-nope-1"),
+            "{pass}: error body must carry the model rejection, got: {body}"
+        );
+    }
     assert_eq!(
-        resp.status(),
-        reqwest::StatusCode::NOT_FOUND,
-        "pool exhausted purely by model rejections must return the real 404"
-    );
-    let body = resp.text().await.unwrap();
-    assert!(
-        body.contains("not_found_error"),
-        "upstream error body must pass through, got: {body}"
+        hits.load(Ordering::SeqCst),
+        1,
+        "the warm-cache request must not touch the upstream at all"
     );
 }
 


### PR DESCRIPTION
## Problem (LAB-941)

A thread wedged into a permanent retry loop when the LB kept sending its requests to an account that does not support the requested model. Observed live 2026-07-27 08:21–08:32:

1. Client requests `claude-opus-5` → every Anthropic account returns **529** (overload storm) → pool exhausts.
2. The retry loop falls through to `insight-gateway` (OpenAI-protocol fallback), which doesn't serve opus-5 → `400 "Invalid model name passed in model=claude-opus-5"`.
3. That 400 is forwarded blind to the client (4xx = never retried), the client retries, and the stateless affinity hash re-pins the same path — repeatedly, for 10+ minutes.

The LB never learned that the endpoint can't serve the model, and a valid-model request surfaced as a misleading "your request is invalid" 400.

## Fix

Three additive parts, no change to healthy-path routing:

- **Negative cache** — a new bounded `unsupported_models` map records `(endpoint, model)` pairs the upstream itself rejected (Anthropic 404 `not_found_error` `"model: …"`, LiteLLM `"Invalid model name"`, OpenAI `model_not_found` — matched conservatively in `is_model_unsupported_error`). `routing_candidates` skips live pairs for 15 min (TTL self-heals plan/gateway changes; cap 256 guards client-supplied model strings). Since session affinity is a stateless hash **over the candidate list**, filtering the pair automatically re-buckets pinned sessions — this is the "break session affinity" the issue asks for.
- **In-flight rotation** — a model rejection now returns `ForwardOutcome::RetryModelUnsupported` from all three forward paths, so the *current* request rotates to the next account instead of failing.
- **Truthful exhaustion** — if the pool exhausts *purely* on model rejections (model exists nowhere), the client gets the upstream's real 404 back, not a synthetic 429 that would invite doomed retries. Overload/transient exhaustion keeps its existing retryable semantics.

## Testing

- 6 new tests: wire-format detection (incl. the exact live gateway body), routing filter + affinity migration + TTL expiry, map bound, native-path rotate-and-skip, all-reject 404 passthrough, and the exact incident shape (gateway 400 → rotate to serving account, next request skips gateway).
- Full suite: 515 passed, 0 failed. `cargo fmt --check` and `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` clean.

## Notes for review

- Security posture unchanged: no new endpoints, no auth changes; the stashed rejection response reuses each path's existing error-response construction.
- Ops mitigation available independently of this PR: set `models = [...]` on `insight-gateway` in the deploy config so config-level filtering (`serves_model`) excludes it up front; this PR makes the LB robust when that list drifts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an upstream endpoint does not support the requested model.
  * Requests now retry through other available endpoints and avoid previously rejected endpoint/model pairs for a short time.
  * Preserved upstream “model unsupported” errors when no suitable endpoint is available, preventing repeated retry loops.
  * Added negative-caching to reduce repeated routing to recently rejecting endpoints.

* **Tests**
  * Added coverage for model support detection, endpoint rotation, cache expiry, capacity limits, and OpenAI-compatible error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->