### PR TITLE
LAB-957: emit live session-size distribution on /metrics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4431,19 +4431,24 @@ impl AppState {
     fn session_tokens_histogram(&self, now: u64) -> ([u64; SESSION_TOKENS_BUCKETS.len() + 1], u64) {
         let mut cumulative = [0u64; SESSION_TOKENS_BUCKETS.len() + 1];
         let mut sum = 0u64;
-        if let Ok(map) = self.sessions.lock() {
-            for e in map.values() {
-                if now.saturating_sub(e.last_seen) > self.session_registry_ttl_secs {
-                    continue;
-                }
-                sum += e.last_prompt_tokens;
-                for (i, le) in SESSION_TOKENS_BUCKETS.iter().enumerate() {
-                    if e.last_prompt_tokens <= *le {
-                        cumulative[i] += 1;
+        match self.sessions.lock() {
+            Ok(map) => {
+                for e in map.values() {
+                    if now.saturating_sub(e.last_seen) > self.session_registry_ttl_secs {
+                        continue;
                     }
+                    sum += e.last_prompt_tokens;
+                    for (i, le) in SESSION_TOKENS_BUCKETS.iter().enumerate() {
+                        if e.last_prompt_tokens <= *le {
+                            cumulative[i] += 1;
+                        }
+                    }
+                    cumulative[SESSION_TOKENS_BUCKETS.len()] += 1; // +Inf
                 }
-                cumulative[SESSION_TOKENS_BUCKETS.len()] += 1; // +Inf
             }
+            // All-zero output with no trace would read as "no sessions";
+            // a poisoned registry lock deserves a diagnostic.
+            Err(_) => warn!("session_tokens_histogram: sessions registry lock poisoned"),
         }
         (cumulative, sum)
     }
@@ -8222,9 +8227,9 @@ async fn metrics_handler(
     // histogram_quantile() working, and sum across replicas.
     prom_header(
         &mut buf,
-        "anthropic_session_tokens",
+        "anthropic_session_tokens_bucket",
         "gauge",
-        "Live sessions by last-prompt token size (snapshot gauge histogram; instant values, do not rate())",
+        "Live sessions with last-prompt tokens <= le (cumulative snapshot; instant values, do not rate())",
     );
     for (i, le) in SESSION_TOKENS_BUCKETS.iter().enumerate() {
         prom_gauge(
@@ -8240,11 +8245,23 @@ async fn metrics_handler(
         &[("le", "+Inf")],
         session_buckets[SESSION_TOKENS_BUCKETS.len()] as f64,
     );
+    prom_header(
+        &mut buf,
+        "anthropic_session_tokens_sum",
+        "gauge",
+        "Sum of last-prompt tokens across live sessions",
+    );
     prom_gauge(
         &mut buf,
         "anthropic_session_tokens_sum",
         &[],
         session_tokens_sum as f64,
+    );
+    prom_header(
+        &mut buf,
+        "anthropic_session_tokens_count",
+        "gauge",
+        "Number of live sessions",
     );
     prom_gauge(
         &mut buf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4186,6 +4186,13 @@ const SESSIONS_STATS_TOP_N: usize = 50;
 /// string is client-controlled; overflow buckets into `_other`).
 const MAX_PROMPT_TOO_LONG_MODELS: usize = 32;
 
+/// `le` boundaries (tokens) for the live session-size distribution on
+/// `/metrics`. Dense around the 200k window edge — that's where sessions
+/// start 400ing — sparse elsewhere; `+Inf` is implicit.
+const SESSION_TOKENS_BUCKETS: [u64; 10] = [
+    10_000, 25_000, 50_000, 100_000, 150_000, 175_000, 200_000, 300_000, 500_000, 1_000_000,
+];
+
 /// Default model context window (tokens). Every current Claude model ships
 /// with a 200k window unless the 1M beta is active on the request.
 const DEFAULT_CONTEXT_WINDOW: u64 = 200_000;
@@ -4414,6 +4421,31 @@ impl AppState {
         rows.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
         rows.truncate(SESSIONS_STATS_TOP_N);
         rows.into_iter().map(|(_, v)| v).collect()
+    }
+
+    /// Snapshot the live session registry as a cumulative `le` histogram over
+    /// `last_prompt_tokens` (LAB-957): per-boundary cumulative counts with a
+    /// trailing `+Inf`, plus the token sum. Fixed cardinality regardless of
+    /// session count — per-session Prometheus labels stay ruled out. Counts
+    /// sum cleanly across replicas (each pod holds a disjoint registry).
+    fn session_tokens_histogram(&self, now: u64) -> ([u64; SESSION_TOKENS_BUCKETS.len() + 1], u64) {
+        let mut cumulative = [0u64; SESSION_TOKENS_BUCKETS.len() + 1];
+        let mut sum = 0u64;
+        if let Ok(map) = self.sessions.lock() {
+            for e in map.values() {
+                if now.saturating_sub(e.last_seen) > self.session_registry_ttl_secs {
+                    continue;
+                }
+                sum += e.last_prompt_tokens;
+                for (i, le) in SESSION_TOKENS_BUCKETS.iter().enumerate() {
+                    if e.last_prompt_tokens <= *le {
+                        cumulative[i] += 1;
+                    }
+                }
+                cumulative[SESSION_TOKENS_BUCKETS.len()] += 1; // +Inf
+            }
+        }
+        (cumulative, sum)
     }
 }
 
@@ -7370,6 +7402,7 @@ async fn metrics_handler(
         .ok()
         .map(|g| g.iter().map(|(k, v)| (k.clone(), *v)).collect())
         .unwrap_or_default();
+    let (session_buckets, session_tokens_sum) = state.session_tokens_histogram(now_epoch);
 
     // ── Phase 2: Serialize (sync — no locks held) ──────────────────
 
@@ -8181,6 +8214,44 @@ async fn metrics_handler(
             *n,
         );
     }
+
+    // Live session-size distribution (LAB-957). A snapshot of the session
+    // registry, not an observation stream: values rise AND fall as sessions
+    // grow and expire, so this is declared `gauge` — chart instant values,
+    // never rate(). Cumulative `le` buckets keep Grafana heatmaps and
+    // histogram_quantile() working, and sum across replicas.
+    prom_header(
+        &mut buf,
+        "anthropic_session_tokens",
+        "gauge",
+        "Live sessions by last-prompt token size (snapshot gauge histogram; instant values, do not rate())",
+    );
+    for (i, le) in SESSION_TOKENS_BUCKETS.iter().enumerate() {
+        prom_gauge(
+            &mut buf,
+            "anthropic_session_tokens_bucket",
+            &[("le", &le.to_string())],
+            session_buckets[i] as f64,
+        );
+    }
+    prom_gauge(
+        &mut buf,
+        "anthropic_session_tokens_bucket",
+        &[("le", "+Inf")],
+        session_buckets[SESSION_TOKENS_BUCKETS.len()] as f64,
+    );
+    prom_gauge(
+        &mut buf,
+        "anthropic_session_tokens_sum",
+        &[],
+        session_tokens_sum as f64,
+    );
+    prom_gauge(
+        &mut buf,
+        "anthropic_session_tokens_count",
+        &[],
+        session_buckets[SESSION_TOKENS_BUCKETS.len()] as f64,
+    );
 
     // In-flight request-body memory admission (P1-01): current reserved bytes,
     // the configured ceiling, and the load-shed counter — together these let an

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14560,6 +14560,55 @@ fn session_registry_disabled_when_max_zero() {
 }
 
 #[test]
+fn session_tokens_histogram_cumulative_buckets_and_ttl() {
+    let state = test_state_with(vec![]);
+    let rctx = ("c", "-", "-");
+    // One session per interesting band: below the first boundary, exactly ON
+    // a boundary (le is inclusive), in the 200k danger zone, and over-window.
+    state.record_session("tiny", rctx, "m", "a", 9_000, 200_000, 100);
+    state.record_session("edge", rctx, "m", "a", 175_000, 200_000, 100);
+    state.record_session("hot", rctx, "m", "a", 190_000, 200_000, 100);
+    state.record_session("over", rctx, "m", "a", 324_667, 200_000, 100);
+    // Expired entry must not count.
+    state.record_session("stale", rctx, "m", "a", 50_000, 200_000, 100);
+    state
+        .sessions
+        .lock()
+        .unwrap()
+        .get_mut("stale")
+        .unwrap()
+        .last_seen = 0;
+
+    // now=1900: live entries are exactly at the TTL horizon (1800s, inclusive);
+    // stale (last_seen=0, age 1900) is past it.
+    let (cum, sum) = state.session_tokens_histogram(1_900);
+    let le = |bound: u64| {
+        cum[SESSION_TOKENS_BUCKETS
+            .iter()
+            .position(|b| *b == bound)
+            .unwrap()]
+    };
+    assert_eq!(le(10_000), 1, "tiny only");
+    assert_eq!(
+        le(150_000),
+        1,
+        "nothing between 10k and 150k (stale expired)"
+    );
+    assert_eq!(le(175_000), 2, "boundary value is inclusive");
+    assert_eq!(le(200_000), 3);
+    assert_eq!(le(300_000), 3, "over-window session past 300k");
+    assert_eq!(le(1_000_000), 4);
+    assert_eq!(cum[SESSION_TOKENS_BUCKETS.len()], 4, "+Inf == live count");
+    assert_eq!(sum, 9_000 + 175_000 + 190_000 + 324_667);
+
+    // Empty registry: all zeros, not an error.
+    let empty = test_state_with(vec![]);
+    let (cum, sum) = empty.session_tokens_histogram(100);
+    assert!(cum.iter().all(|c| *c == 0));
+    assert_eq!(sum, 0);
+}
+
+#[test]
 fn sessions_snapshot_sorts_by_pct_desc_and_caps_top_n() {
     let state = test_state_with(vec![]);
     let rctx = ("c", "-", "-");


### PR DESCRIPTION
Ray wants Grafana visibility into the size of in-flight sessions — what session token lengths look like (LAB-957).

The LAB-916 session registry already tracks `last_prompt_tokens` per live session, but only surfaces it via `/_stats` JSON, which the monitoring stack can't ingest (per-session Prometheus labels were ruled out as a cardinality anti-pattern in LAB-916, and that decision stands).

## What this adds

A **snapshot gauge histogram** over the live session registry on `/metrics`:

```
anthropic_session_tokens_bucket{le="10000"|"25000"|"50000"|"100000"|"150000"|"175000"|"200000"|"300000"|"500000"|"1000000"|"+Inf"}
anthropic_session_tokens_sum
anthropic_session_tokens_count
```

- TTL-filtered with the same horizon as `/_stats` (`session_registry_ttl_secs`, default 1800s) — "in flight" means seen in the last 30 minutes.
- **Fixed cardinality**: 13 series regardless of session count. Buckets are dense around the 200k context-window edge (150k/175k/200k/300k) — that's where sessions start 400ing with `prompt is too long`.
- Declared `gauge`, not `histogram`: this is a snapshot of current state (values rise and fall), not an observation stream — chart instant values, never `rate()`. Cumulative `le` buckets keep Grafana heatmaps and `histogram_quantile()` working.
- Buckets **sum cleanly across replicas** (each pod holds a disjoint in-process registry): the fleet-wide distribution is `sum by (le) (anthropic_session_tokens_bucket)`.

## Verification

- New test `session_tokens_histogram_cumulative_buckets_and_ttl`: boundary inclusivity, cumulative counts, TTL expiry, empty registry.
- Full suite green: 487 + 18 + 12 tests, `cargo fmt --check`, `RUSTFLAGS=-Dwarnings cargo clippy --all-targets`.

Grafana panels consuming this land separately in `27b-io/lab` (dashboard + per-pod scrape fix — the current static scrape hits the service VIP and samples a random replica per scrape).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for monitoring session context-window token usage.
  * Metrics include cumulative token-size buckets, total token count, and session count.
  * Expired sessions are automatically excluded from reported measurements.

* **Tests**
  * Added coverage for bucket boundaries, token totals, expired sessions, and empty session registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->