### PR TITLE
LAB-933: opt-in encrypted response cache on /v1/messages (cachekit-rs + SecureCache)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,43 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,22 +49,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anthropic-lb"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "axum",
+ "blake2",
  "bytes",
+ "cachekit-rs",
  "http-body-util",
  "hyper",
  "ipnet",
  "redis",
  "reqwest",
  "serde",
+ "serde_bytes",
  "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.8.23",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -47,6 +138,17 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -134,16 +236,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
+name = "cachekit-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee6235f73aefb0dc66b9cd0d333b9da928c8192e4234357a739fe756c2f8f23"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "cbindgen",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "hmac",
+ "lz4_flex",
+ "ring",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "thiserror",
+ "xxhash-rust",
+ "zeroize",
+]
+
+[[package]]
+name = "cachekit-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602e017ad7eb735ba12665f217ef7c887b697fb6a6d392486c8e84e2c4865524"
+dependencies = [
+ "async-trait",
+ "blake2",
+ "bytes",
+ "cachekit-core",
+ "fred",
+ "hex",
+ "moka",
+ "reqwest",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url",
+ "urlencoding",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.114",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
+]
 
 [[package]]
 name = "cc"
@@ -162,6 +367,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +439,12 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
 
 [[package]]
 name = "core-foundation"
@@ -202,6 +473,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,8 +568,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encoding_rs"
@@ -250,6 +615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,12 +654,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "fred"
+version = "9.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cdd5378252ea124b712e0ac55147d26ae3af575883b34b8423091a4c719606b"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytes-utils",
+ "crossbeam-queue",
+ "float-cmp",
+ "fred-macros",
+ "futures",
+ "log",
+ "parking_lot",
+ "rand 0.8.7",
+ "redis-protocol",
+ "semver",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "fred-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1458c6e22d36d61507034d5afecc64f105c1d39712b7ac6ec3b352c423f715cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -293,6 +721,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -308,7 +747,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -329,6 +768,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -341,14 +781,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -359,8 +811,32 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -387,6 +863,36 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -470,6 +976,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -505,7 +1012,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -626,6 +1133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +1156,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -697,6 +1219,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +1261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +1275,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -749,6 +1309,16 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -795,6 +1365,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,7 +1398,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -891,6 +1473,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,12 +1500,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -922,6 +1587,68 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "redis"
@@ -945,12 +1672,26 @@ dependencies = [
  "rustls-native-certs",
  "ryu",
  "sha1_smol",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "url",
  "xxhash-rust",
+]
+
+[[package]]
+name = "redis-protocol"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65deb7c9501fbb2b6f812a30d59c0253779480853545153a51d8e9e444ddc99f"
+dependencies = [
+ "bytes",
+ "bytes-utils",
+ "cookie-factory",
+ "crc16",
+ "log",
+ "nom",
 ]
 
 [[package]]
@@ -1004,6 +1745,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1011,6 +1754,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1020,6 +1764,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1035,6 +1780,31 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1056,6 +1826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1080,6 +1851,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1158,6 +1930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1943,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1184,7 +1972,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1222,6 +2010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +2035,17 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -1278,6 +2086,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -1293,6 +2111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +2127,17 @@ name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1326,7 +2161,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1351,6 +2186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +2202,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1383,6 +2244,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,7 +2270,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1407,7 +2283,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1461,9 +2337,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -1476,6 +2367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,10 +2383,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1494,6 +2403,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -1562,7 +2477,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1611,10 +2526,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -1635,10 +2572,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -1651,6 +2611,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1722,7 +2688,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1756,6 +2722,25 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1959,6 +2944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,8 +2986,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2016,7 +3027,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2025,6 +3036,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2056,7 +3081,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,16 @@ http-body-util = "0.1"
 ipnet = "2.11.0"
 tokio-stream = "0.1"
 redis = { version = "1.0.3", features = ["tokio-comp", "connection-manager", "tls-rustls", "tokio-rustls-comp"] }
+# LAB-933 response cache. NOTE: the crate is `cachekit-rs` (lib name `cachekit`,
+# github.com/cachekit-io/cachekit-rs) — the crate published as plain `cachekit`
+# on crates.io is an UNRELATED eviction-primitives library. Do not "fix" this.
+# Default features (cachekitio SaaS backend, encryption, L1) + the fred-backed
+# redis backend so both AC11 backends are selectable at runtime.
+cachekit-rs = { version = "0.5", features = ["redis"] }
+# Same versions cachekit-rs already pins — zero marginal dependency weight.
+blake2 = "0.10"
+serde_bytes = "0.11"
 
 [dev-dependencies]
 tempfile = "3.25.0"
+async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -514,6 +514,74 @@ When Redis is connected, `/_stats` includes a `cluster` section with replica cou
 
 ---
 
+## Response Cache (opt-in, encrypted)
+
+An **opt-in** response cache for non-streaming `POST /v1/messages`. When an
+allow-listed client replays a byte-identical request, the previous response is
+served from cache — **the upstream call is skipped entirely, so a hit burns
+zero 5h/7d rate-limit headroom and does not count against the client's daily
+token budget**. That is the point: eval reruns, pipeline replays, and retries
+after client-side timeouts stop costing quota.
+
+**Default-off.** Without a `[response_cache]` section — or with an empty
+`clients` list — behavior is byte-identical to a build without the feature.
+Clients not on the allow-list never touch the cache.
+
+```toml
+[response_cache]
+# Only these client IDs (x-client-id header / client_names mapping) use the cache.
+clients = ["geo-pipeline"]
+
+# Backend: "cachekitio" (cachekit.io SaaS) or "redis" (local Redis/Valkey).
+backend = "redis"
+redis_url = "redis://10.0.0.5:6379/1"
+# backend = "cachekitio"
+# api_key = "ck_live_..."
+
+# Hex-encoded 32-byte master key for client-side encryption (MANDATORY —
+# there is no plaintext mode). Generate: openssl rand -hex 32
+master_key = "…64 hex chars…"
+
+# Entry TTL. Default: 3600 (1 hour).
+# ttl_secs = 3600
+
+# Per-operation budget before the cache fails open. Default: 250.
+# op_timeout_ms = 250
+```
+
+**What is cached:** the full response body (status + content-type + JSON body)
+of **2xx, non-streaming** `/v1/messages` responses. Streaming (`"stream": true`)
+requests always bypass the cache. Error responses are never cached.
+
+**Where it lands, and what the backend can read:** entries are encrypted
+**client-side** (in the proxy process) with AES-256-GCM before touching any
+storage layer — the in-process L1, local Redis, or cachekit.io only ever hold
+**ciphertext**. Per-client keys are derived from `master_key` via HKDF with the
+client ID as tenant, so two clients sending identical prompts get separate,
+mutually-undecryptable entries. Cache keys are content digests (Blake2s-256 of
+model + canonical body + beta headers + client ID) — no prompt text appears in
+keys, logs, or metrics.
+
+**How a hit looks:** identical response body, plus an `x-alb-cache: hit`
+header. Upstream per-request headers (request IDs, rate-limit snapshots) are
+not replayed — they described the original exchange.
+
+**Fail-open:** a slow, dead, or misconfigured cache backend never blocks a
+request. Every cache operation is bounded by `op_timeout_ms`; on any error the
+request proceeds upstream exactly as if the cache did not exist. Hit / miss /
+store / error counters are exposed on `/metrics`
+(`anthropic_response_cache_*_total{surface="messages"}`).
+
+> [!WARNING]
+> **Non-determinism caveat — opting in is consent to replay.** Sampling
+> parameters (`temperature`, `top_p`, `top_k`) are part of the cache key but do
+> **not** disable caching: an opted-in client replaying an identical
+> `temperature > 0` request within the TTL gets the **same** answer back, not a
+> fresh sample. If your workload needs fresh samples per call, do not opt that
+> client in (or vary the request, e.g. a nonce field in metadata).
+
+---
+
 ## Deployment
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -551,7 +551,8 @@ master_key = "…64 hex chars…"
 
 **What is cached:** the full response body (status + content-type + JSON body)
 of **2xx, non-streaming** `/v1/messages` responses. Streaming (`"stream": true`)
-requests always bypass the cache. Error responses are never cached.
+requests always bypass the cache, as do non-JSON responses and bodies over
+1 MiB. Error responses are never cached.
 
 **Where it lands, and what the backend can read:** entries are encrypted
 **client-side** (in the proxy process) with AES-256-GCM before touching any
@@ -571,6 +572,17 @@ request. Every cache operation is bounded by `op_timeout_ms`; on any error the
 request proceeds upstream exactly as if the cache did not exist. Hit / miss /
 store / error counters are exposed on `/metrics`
 (`anthropic_response_cache_*_total{surface="messages"}`).
+
+> [!WARNING]
+> **Allow-listed clients must mutually trust each other.** Client identity is
+> the client-asserted `x-client-id` header — the proxy's identity model is
+> trust-based (see [Security](#security)). Per-client encryption keys are
+> derived from that asserted identity, so any authenticated caller who
+> *presents* an opted-in client's ID can read that client's cached responses
+> (prompt content included). This is a *read* capability on top of the
+> pre-existing impersonation surface (budget-burning). Only opt in clients
+> that already share a trust domain, and treat the allow-list as one
+> confidentiality boundary, not N.
 
 > [!WARNING]
 > **Non-determinism caveat — opting in is consent to replay.** Sampling

--- a/config.toml.example
+++ b/config.toml.example
@@ -59,12 +59,16 @@ probe_interval_secs = 300
 # SECURITY: x-client-id is client-asserted, so allow-listed clients must
 # mutually trust each other — presenting an opted-in client's ID reads its
 # cached responses. One trust domain per allow-list.
+# SECRETS: master_key / api_key are placeholders — NEVER commit real values.
+# Like proxy_key and endpoint tokens, the rendered config file IS the secret
+# vehicle: deployments template it from the secret store at pod start (see
+# README "Deployment"); this example file must only ever hold placeholders.
 # [response_cache]
 # clients = ["geo-pipeline"]           # allow-list of client IDs; empty = inert
 # backend = "redis"                    # "redis" or "cachekitio"
 # redis_url = "redis://10.0.0.5:6379/1"
-# # api_key = "ck_live_..."            # for backend = "cachekitio"
-# master_key = "<openssl rand -hex 32>" # mandatory; 32+ bytes hex
+# # api_key = "<from secret store>"    # for backend = "cachekitio"
+# master_key = "<from secret store: openssl rand -hex 32>" # mandatory; 32+ bytes hex
 # # ttl_secs = 3600                    # default 1h
 # # op_timeout_ms = 250                # fail-open budget per cache op
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -56,6 +56,9 @@ probe_interval_secs = 300
 # backend only ever holds ciphertext. Omit the section (or leave clients
 # empty) to disable entirely. NOTE: an opted-in client replaying an identical
 # temperature > 0 request gets the SAME answer back, by design.
+# SECURITY: x-client-id is client-asserted, so allow-listed clients must
+# mutually trust each other — presenting an opted-in client's ID reads its
+# cached responses. One trust domain per allow-list.
 # [response_cache]
 # clients = ["geo-pipeline"]           # allow-list of client IDs; empty = inert
 # backend = "redis"                    # "redis" or "cachekitio"

--- a/config.toml.example
+++ b/config.toml.example
@@ -50,6 +50,21 @@ probe_interval_secs = 300
 # Omit for single-instance deployments (local-only state).
 # redis_url = "redis://10.0.0.5:6379"
 
+# Opt-in encrypted response cache on non-streaming /v1/messages (see README
+# "Response Cache"). A hit skips the upstream call — zero rate-limit headroom
+# burned. Entries are AES-256-GCM encrypted in-process before storage; the
+# backend only ever holds ciphertext. Omit the section (or leave clients
+# empty) to disable entirely. NOTE: an opted-in client replaying an identical
+# temperature > 0 request gets the SAME answer back, by design.
+# [response_cache]
+# clients = ["geo-pipeline"]           # allow-list of client IDs; empty = inert
+# backend = "redis"                    # "redis" or "cachekitio"
+# redis_url = "redis://10.0.0.5:6379/1"
+# # api_key = "ck_live_..."            # for backend = "cachekitio"
+# master_key = "<openssl rand -hex 32>" # mandatory; 32+ bytes hex
+# # ttl_secs = 3600                    # default 1h
+# # op_timeout_ms = 250                # fail-open budget per cache op
+
 # "passthrough" = forward caller's auth headers as-is (for OpenClaw managed tokens)
 # Any other value = inject as the endpoint's own token
 # OAuth tokens (sk-ant-oat*) are injected as Authorization: Bearer

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,17 +128,14 @@ struct ResponseCacheConfig {
     /// Per-operation budget in ms before the cache fails open and the
     /// request proceeds upstream (AC10). Default: 250.
     op_timeout_ms: Option<u64>,
-    /// Per-client in-process L1 capacity, in entries (ciphertext-at-rest,
-    /// same zero-knowledge guarantee as the backend). Default: 256.
-    l1_capacity: Option<usize>,
     /// Connection URL for backend = "redis" (redis:// or rediss://).
     redis_url: Option<String>,
-    /// API key for backend = "cachekitio".
+    /// API key for backend = "cachekitio". The API URL is fixed at
+    /// cachekit's default (api.cachekit.io) — deliberately no override knob:
+    /// an operator egress-URL switch on a proxy with an open SSRF audit
+    /// finding is negative-value optionality until a real self-hosted
+    /// deployment exists.
     api_key: Option<String>,
-    /// API URL override for backend = "cachekitio". Setting a non-default
-    /// URL implies allow_custom_host; cachekit's validator still enforces
-    /// HTTPS and blocks private/loopback IPs (SSRF guard).
-    api_url: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -990,12 +987,17 @@ struct CachedResponse {
 /// writes ciphertext to both L1 and the backend).
 struct ResponseCache {
     clients: HashMap<String, cachekit::CacheKit>,
-    ttl: Duration,
     op_timeout: Duration,
     hits: AtomicU64,
     misses: AtomicU64,
     errors: AtomicU64,
     stores: AtomicU64,
+}
+
+/// First 16 hex chars of a cache-key digest — the ONLY form a cache key may
+/// take in any diagnostic output (AC5).
+fn key_digest_prefix(key: &str) -> &str {
+    &key[..key.len().min(16)]
 }
 
 /// Decode a hex master key, enforcing the 32-byte SecureCache minimum.
@@ -1019,21 +1021,25 @@ fn decode_hex_key(s: &str) -> Result<Vec<u8>, String> {
 }
 
 /// Derive the response-cache storage key (AC6): hex Blake2s-256 over
-/// (model ␟ canonical body JSON ␟ sorted anthropic-beta values ␟ client_id
-/// ␟ fp ␟ fps). The full-body digest is what carries correctness — two
-/// requests differing anywhere, including a nested structural position,
-/// serialize differently (`preserve_order` keeps the client's key order) and
-/// get different keys. The 48-bit SipHash content fingerprints are folded in
-/// to reuse the existing canonical machinery, but are deliberately not
-/// trusted alone: 48 bits over prompt content is collision territory, and a
-/// key collision here would serve someone the wrong completion. client_id in
-/// the material separates keys per client on top of the per-tenant
-/// encryption (AC7). The emitted key is a digest only — no prompt content
-/// ever appears in a storage key or diagnostic line (AC5).
+/// (model ␟ canonical body JSON ␟ sorted anthropic-beta values ␟
+/// anthropic-version ␟ URI query ␟ client_id ␟ fp ␟ fps). The full-body
+/// digest is what carries correctness — two requests differing anywhere,
+/// including a nested structural position, serialize differently
+/// (`preserve_order` keeps the client's key order) and get different keys.
+/// anthropic-version and the query string are keyed because they change the
+/// RESPONSE schema for an identical body (an SDK upgrade mid-TTL must miss,
+/// not replay the old shape). The 48-bit SipHash content fingerprints are
+/// folded in to reuse the existing canonical machinery (per AC6), but are
+/// deliberately not trusted alone: 48 bits over prompt content is collision
+/// territory, and a key collision here would serve someone the wrong
+/// completion. client_id in the material separates keys per client on top
+/// of the per-tenant encryption (AC7). The emitted key is a digest only —
+/// no prompt content ever appears in a storage key or diagnostic line (AC5).
 fn response_cache_key(
     model: &str,
     body: &serde_json::Value,
     headers: &hyper::HeaderMap,
+    query: Option<&str>,
     client_id: &str,
     fp: &str,
     fps: &str,
@@ -1045,9 +1051,22 @@ fn response_cache_key(
         .filter_map(|v| v.to_str().ok())
         .collect();
     betas.sort_unstable();
+    let version = headers
+        .get("anthropic-version")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
     let canonical = serde_json::to_string(body).unwrap_or_default();
     let mut h = Blake2s256::new();
-    for part in [model, &canonical, &betas.join(","), client_id, fp, fps] {
+    for part in [
+        model,
+        &canonical,
+        &betas.join(","),
+        version,
+        query.unwrap_or(""),
+        client_id,
+        fp,
+        fps,
+    ] {
         h.update(part.as_bytes());
         h.update([0x1f]);
     }
@@ -1065,7 +1084,13 @@ impl ResponseCache {
     const NAMESPACE: &'static str = "alb-resp";
     const DEFAULT_TTL_SECS: u64 = 3600;
     const DEFAULT_OP_TIMEOUT_MS: u64 = 250;
-    const DEFAULT_L1_CAPACITY: usize = 256;
+    /// Per-client in-process L1 entries (ciphertext at rest). Together with
+    /// `MAX_BODY_BYTES` this bounds worst-case L1 memory per client.
+    const L1_CAPACITY: usize = 64;
+    /// Bodies larger than this are not cached (the entry would also bump
+    /// into cachekit's 5 MiB payload ceiling once encrypted + encoded).
+    /// Bounds both backend value growth and worst-case L1 memory.
+    const MAX_BODY_BYTES: usize = 1024 * 1024;
 
     /// Build from config. `Ok(None)` when the allow-list is empty (inert,
     /// AC2). Config errors — bad key, missing backend params — are `Err`:
@@ -1087,14 +1112,17 @@ impl ResponseCache {
                     .url(url)
                     .build()
                     .map_err(|e| format!("response_cache redis backend: {e}"))?;
-                // fred's connection task detaches when the handle drops. A
-                // failed initial connect is NOT fatal: ops fail open until
-                // connectivity returns. (cachekit-rs 0.5.0 exposes no
-                // auto-reconnect on this builder — flagged upstream.)
+                // fred's connection task detaches when the handle drops.
+                // KNOWN LIMITATION (cachekit-rs 0.5.0, flagged upstream):
+                // auto-reconnect is pub(crate) and unreachable from this
+                // builder, so after a failed initial connect OR any later
+                // Redis outage the client does NOT recover — every cache op
+                // errors (fail-open, bounded by op_timeout per op) until the
+                // process restarts. Watch anthropic_response_cache_errors_total.
                 match b.connect().await {
                     Ok(_handle) => info!("response cache redis backend connected"),
                     Err(e) => {
-                        warn!(error = %e, "response cache redis connect failed — cache will fail open")
+                        warn!(error = %e, "response cache redis connect failed — cache disabled until restart (fail-open)")
                     }
                 }
                 std::sync::Arc::new(b)
@@ -1104,16 +1132,9 @@ impl ResponseCache {
                     .api_key
                     .as_deref()
                     .ok_or("response_cache.api_key is required for backend = \"cachekitio\"")?;
-                let mut builder =
-                    cachekit::backend::cachekitio::CachekitIO::builder().api_key(api_key);
-                if let Some(url) = &cfg.api_url {
-                    // Operator-supplied override (same trust level as
-                    // endpoints[].base_url). cachekit's validator still
-                    // enforces HTTPS and rejects private/loopback IPs.
-                    builder = builder.api_url(url).allow_custom_host(true);
-                }
                 std::sync::Arc::new(
-                    builder
+                    cachekit::backend::cachekitio::CachekitIO::builder()
+                        .api_key(api_key)
                         .build()
                         .map_err(|e| format!("response_cache cachekitio backend: {e}"))?,
                 )
@@ -1130,7 +1151,6 @@ impl ResponseCache {
             &master_key,
             Duration::from_secs(cfg.ttl_secs.unwrap_or(Self::DEFAULT_TTL_SECS)),
             Duration::from_millis(cfg.op_timeout_ms.unwrap_or(Self::DEFAULT_OP_TIMEOUT_MS)),
-            cfg.l1_capacity.unwrap_or(Self::DEFAULT_L1_CAPACITY),
         )
         .map(Some)
     }
@@ -1144,7 +1164,6 @@ impl ResponseCache {
         master_key: &[u8],
         ttl: Duration,
         op_timeout: Duration,
-        l1_capacity: usize,
     ) -> Result<Self, String> {
         let mut map = HashMap::new();
         for client_id in clients {
@@ -1154,11 +1173,13 @@ impl ResponseCache {
                         .into(),
                 );
             }
+            // The builder's default_ttl is the SINGLE source of entry
+            // lifetime — writes use plain `set()` so the two can't drift.
             let ck = cachekit::CacheKit::builder()
                 .backend(backend.clone())
                 .default_ttl(ttl)
                 .namespace(Self::NAMESPACE)
-                .l1_capacity(l1_capacity)
+                .l1_capacity(Self::L1_CAPACITY)
                 .encryption_from_bytes(master_key, client_id)
                 .map_err(|e| format!("response_cache encryption init for \"{client_id}\": {e}"))?
                 .build()
@@ -1167,18 +1188,12 @@ impl ResponseCache {
         }
         Ok(Self {
             clients: map,
-            ttl,
             op_timeout,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
             errors: AtomicU64::new(0),
             stores: AtomicU64::new(0),
         })
-    }
-
-    /// Whether this client_id may use the cache (AC2).
-    fn is_opted_in(&self, client_id: &str) -> bool {
-        self.clients.contains_key(client_id)
     }
 
     /// Read an entry. Every failure mode — no encryption handle, backend
@@ -1199,13 +1214,13 @@ impl ResponseCache {
             }
             Ok(Err(e)) => {
                 self.errors.fetch_add(1, Ordering::Relaxed);
-                warn!(key_digest = &key[..key.len().min(16)], error = %e, "response cache read failed — proceeding upstream");
+                warn!(key_digest = key_digest_prefix(key), error = %e, "response cache read failed — proceeding upstream");
                 None
             }
             Err(_) => {
                 self.errors.fetch_add(1, Ordering::Relaxed);
                 warn!(
-                    key_digest = &key[..key.len().min(16)],
+                    key_digest = key_digest_prefix(key),
                     timeout_ms = self.op_timeout.as_millis() as u64,
                     "response cache read timed out — proceeding upstream"
                 );
@@ -1220,19 +1235,19 @@ impl ResponseCache {
         let Some(cache) = self.clients.get(client_id) else {
             return;
         };
-        let op = async { cache.secure()?.set_with_ttl(key, entry, self.ttl).await };
+        let op = async { cache.secure()?.set(key, entry).await };
         match tokio::time::timeout(self.op_timeout, op).await {
             Ok(Ok(())) => {
                 self.stores.fetch_add(1, Ordering::Relaxed);
             }
             Ok(Err(e)) => {
                 self.errors.fetch_add(1, Ordering::Relaxed);
-                warn!(key_digest = &key[..key.len().min(16)], error = %e, "response cache write failed — skipped");
+                warn!(key_digest = key_digest_prefix(key), error = %e, "response cache write failed — skipped");
             }
             Err(_) => {
                 self.errors.fetch_add(1, Ordering::Relaxed);
                 warn!(
-                    key_digest = &key[..key.len().min(16)],
+                    key_digest = key_digest_prefix(key),
                     timeout_ms = self.op_timeout.as_millis() as u64,
                     "response cache write timed out — skipped"
                 );
@@ -1242,15 +1257,28 @@ impl ResponseCache {
 }
 
 /// Build the client-facing response for a cache hit. Only ever called for
-/// entries written from 2xx responses (AC3).
+/// entries written from 2xx responses (AC3). The entry came through AEAD
+/// decryption, so an invalid stored status means OUR bug — surface a loud
+/// 500, never a fabricated 200.
 fn cached_hit_response(entry: CachedResponse) -> Response {
+    let Ok(status) = StatusCode::from_u16(entry.status) else {
+        error!(
+            status = entry.status,
+            "cached entry carries an invalid status code — refusing to serve"
+        );
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "cached response rebuild error",
+        )
+            .into_response();
+    };
     let content_type = if entry.content_type.is_empty() {
         "application/json"
     } else {
         entry.content_type.as_str()
     };
     Response::builder()
-        .status(StatusCode::from_u16(entry.status).unwrap_or(StatusCode::OK))
+        .status(status)
         .header("content-type", content_type)
         .header("x-alb-cache", "hit")
         .body(Body::from(entry.body))
@@ -5908,7 +5936,16 @@ fn upstream_client_builder() -> reqwest::ClientBuilder {
 fn request_wants_stream(body: &[u8]) -> bool {
     serde_json::from_slice::<serde_json::Value>(body)
         .ok()
-        .and_then(|v| v.get("stream").and_then(|s| s.as_bool()))
+        .map(|v| body_wants_stream(&v))
+        .unwrap_or(false)
+}
+
+/// The streaming predicate on an already-parsed body. Single definition
+/// shared by `request_wants_stream` and the response-cache gate so the two
+/// can never disagree on what "streaming" means.
+fn body_wants_stream(body: &serde_json::Value) -> bool {
+    body.get("stream")
+        .and_then(|s| s.as_bool())
         .unwrap_or(false)
 }
 
@@ -6349,6 +6386,24 @@ async fn maybe_cache_store(
     if !resp.status().is_success() {
         return resp;
     }
+    // Only JSON bodies are cacheable. The request was non-streaming, so the
+    // forward path buffered the body — but that is an invariant of TODAY's
+    // upstreams, not a law: an upstream answering a `stream:false` request
+    // with `text/event-stream` must pass through untouched (never collected,
+    // never cached as a bogus non-streaming entry).
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+    if !content_type.starts_with("application/json") {
+        debug!(
+            req_id,
+            content_type, "response cache: non-JSON content-type — not cached"
+        );
+        return resp;
+    }
     let (parts, body) = resp.into_parts();
     let bytes = match http_body_util::BodyExt::collect(body).await {
         Ok(collected) => collected.to_bytes(),
@@ -6363,12 +6418,16 @@ async fn maybe_cache_store(
                 .into_response();
         }
     };
-    let content_type = parts
-        .headers
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/json")
-        .to_string();
+    if bytes.len() > ResponseCache::MAX_BODY_BYTES {
+        // Deliberate policy skip, not a failure: bounds backend value growth
+        // and worst-case L1 memory (L1_CAPACITY × MAX_BODY_BYTES per client).
+        debug!(
+            req_id,
+            body_bytes = bytes.len(),
+            "response cache: body exceeds size cap — not cached"
+        );
+        return Response::from_parts(parts, Body::from(bytes));
+    }
     rc.store(
         client_id,
         key,
@@ -6473,19 +6532,18 @@ async fn proxy_handler(
             // path, and non-streaming (AC8; same predicate as
             // `request_wants_stream`, evaluated on the parsed body).
             let cache_key = match &state.response_cache {
+                // The per-client map doubles as the opt-in allow-list (AC2).
                 Some(rc)
-                    if rc.is_opted_in(&client_id)
+                    if rc.clients.contains_key(&client_id)
                         && parts.method == hyper::Method::POST
                         && parts.uri.path() == "/v1/messages"
-                        && !parsed
-                            .get("stream")
-                            .and_then(|s| s.as_bool())
-                            .unwrap_or(false) =>
+                        && !body_wants_stream(&parsed) =>
                 {
                     Some(response_cache_key(
                         &model,
                         &parsed,
                         &parts.headers,
+                        parts.uri.query(),
                         &client_id,
                         &fp,
                         &fps,
@@ -6605,7 +6663,7 @@ async fn proxy_handler(
                 info!(
                     req_id,
                     client_id = %client_id,
-                    key_digest = &key[..key.len().min(16)],
+                    key_digest = key_digest_prefix(key),
                     "response cache hit"
                 );
                 return cached_hit_response(entry);
@@ -11165,7 +11223,7 @@ async fn main() {
                 info!(
                     clients = rc.clients.len(),
                     backend = %cfg.backend,
-                    ttl_secs = rc.ttl.as_secs(),
+                    ttl_secs = cfg.ttl_secs.unwrap_or(ResponseCache::DEFAULT_TTL_SECS),
                     "response cache enabled"
                 );
                 Some(rc)

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,46 @@ struct Config {
     /// Seconds after a session's last request before its registry entry is
     /// evicted. Default: 1800 (30 min).
     session_registry_ttl_secs: Option<u64>,
+    /// Opt-in encrypted response cache on `/v1/messages` (LAB-933).
+    /// Absent, or present with an empty `clients` list = feature entirely inert.
+    response_cache: Option<ResponseCacheConfig>,
+}
+
+/// `[response_cache]` — opt-in, client-side-encrypted response cache on
+/// non-streaming `/v1/messages` (LAB-933). Cached bodies contain prompt
+/// content, so SecureCache (AES-256-GCM, encrypted before any layer — L1
+/// included) is mandatory: there is no plaintext-storage configuration.
+#[derive(Deserialize, Clone)]
+struct ResponseCacheConfig {
+    /// Client IDs allowed to read/write the cache. Empty = inert (AC2).
+    /// May not contain "-" (the unknown-client sentinel) — that would opt in
+    /// every unidentified caller.
+    #[serde(default)]
+    clients: Vec<String>,
+    /// Cache backend: "cachekitio" (SaaS, rides the existing reqwest/rustls
+    /// stack) or "redis" (local Redis/Valkey via cachekit's fred client).
+    backend: String,
+    /// Hex-encoded master key for client-side encryption; must decode to at
+    /// least 32 bytes. Per-client keys are derived from it via HKDF-SHA256
+    /// with the client_id as tenant, so clients are cryptographically
+    /// isolated from each other (AC7), not just key-string separated.
+    master_key: String,
+    /// Entry TTL in seconds. Default: 3600 (1 h).
+    ttl_secs: Option<u64>,
+    /// Per-operation budget in ms before the cache fails open and the
+    /// request proceeds upstream (AC10). Default: 250.
+    op_timeout_ms: Option<u64>,
+    /// Per-client in-process L1 capacity, in entries (ciphertext-at-rest,
+    /// same zero-knowledge guarantee as the backend). Default: 256.
+    l1_capacity: Option<usize>,
+    /// Connection URL for backend = "redis" (redis:// or rediss://).
+    redis_url: Option<String>,
+    /// API key for backend = "cachekitio".
+    api_key: Option<String>,
+    /// API URL override for backend = "cachekitio". Setting a non-default
+    /// URL implies allow_custom_host; cachekit's validator still enforces
+    /// HTTPS and blocks private/loopback IPs (SSRF guard).
+    api_url: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -616,6 +656,10 @@ struct AppState {
     /// mutex, never held across `.await`; bounded by UNSUPPORTED_MODEL_MAX
     /// + TTL eviction. Per-replica: a fresh replica re-learns in one attempt.
     unsupported_models: Mutex<HashMap<(usize, String), Instant>>,
+    /// Opt-in encrypted response cache on non-streaming /v1/messages
+    /// (LAB-933). None = feature off — the no-config case is byte-identical
+    /// to pre-cache behaviour (AC1).
+    response_cache: Option<ResponseCache>,
 }
 
 /// RAII reservation against `AppState::inflight_body_bytes`. Holding it keeps the
@@ -912,6 +956,311 @@ fn content_fingerprints(body: &serde_json::Value) -> (String, String) {
         format!("{:012x}", fp & 0xFFFF_FFFF_FFFF),
         format!("{:012x}", fps & 0xFFFF_FFFF_FFFF),
     )
+}
+
+// ── Response cache (LAB-933) ────────────────────────────────────────
+//
+// Opt-in, client-side-encrypted response cache on non-streaming
+// /v1/messages. The prize is headroom, not latency: a hit skips the
+// upstream call entirely, so replayed traffic (eval reruns, pipeline
+// replays, post-timeout retries) burns zero 5h/7d rate-limit budget.
+// Everything below fails OPEN — a sick cache degrades to a miss/skipped
+// write and the request proceeds upstream exactly as today.
+
+/// A cached /v1/messages response: status + content-type + body, nothing
+/// else. Upstream per-request headers (request ids, rate-limit snapshots,
+/// x-budget-status) describe the ORIGINAL exchange and are deliberately not
+/// replayed; a hit instead carries `x-alb-cache: hit`.
+#[derive(Serialize, Deserialize)]
+struct CachedResponse {
+    status: u16,
+    content_type: String,
+    #[serde(with = "serde_bytes")]
+    body: Vec<u8>,
+}
+
+/// Runtime handle for the response cache: one shared backend, one
+/// `cachekit::CacheKit` per allow-listed client with `tenant_id =
+/// client_id`. HKDF-SHA256 then derives a distinct AES-256-GCM key per
+/// client, so cross-client isolation (AC7) is cryptographic — even a key
+/// collision could not decrypt another client's entry. The map doubles as
+/// the opt-in allow-list: no entry, no cache (AC2). All values are
+/// encrypted before any storage layer sees them, in-process L1 included
+/// (verified against cachekit-rs 0.5.0 `SecureCache::set_with_ttl`, which
+/// writes ciphertext to both L1 and the backend).
+struct ResponseCache {
+    clients: HashMap<String, cachekit::CacheKit>,
+    ttl: Duration,
+    op_timeout: Duration,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    errors: AtomicU64,
+    stores: AtomicU64,
+}
+
+/// Decode a hex master key, enforcing the 32-byte SecureCache minimum.
+fn decode_hex_key(s: &str) -> Result<Vec<u8>, String> {
+    let s = s.trim();
+    if !s.is_ascii() || !s.len().is_multiple_of(2) {
+        return Err("response_cache.master_key must be an even-length hex string".into());
+    }
+    let bytes = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+        .collect::<Result<Vec<u8>, _>>()
+        .map_err(|_| "response_cache.master_key contains non-hex characters".to_string())?;
+    if bytes.len() < 32 {
+        return Err(format!(
+            "response_cache.master_key must decode to at least 32 bytes, got {}",
+            bytes.len()
+        ));
+    }
+    Ok(bytes)
+}
+
+/// Derive the response-cache storage key (AC6): hex Blake2s-256 over
+/// (model ␟ canonical body JSON ␟ sorted anthropic-beta values ␟ client_id
+/// ␟ fp ␟ fps). The full-body digest is what carries correctness — two
+/// requests differing anywhere, including a nested structural position,
+/// serialize differently (`preserve_order` keeps the client's key order) and
+/// get different keys. The 48-bit SipHash content fingerprints are folded in
+/// to reuse the existing canonical machinery, but are deliberately not
+/// trusted alone: 48 bits over prompt content is collision territory, and a
+/// key collision here would serve someone the wrong completion. client_id in
+/// the material separates keys per client on top of the per-tenant
+/// encryption (AC7). The emitted key is a digest only — no prompt content
+/// ever appears in a storage key or diagnostic line (AC5).
+fn response_cache_key(
+    model: &str,
+    body: &serde_json::Value,
+    headers: &hyper::HeaderMap,
+    client_id: &str,
+    fp: &str,
+    fps: &str,
+) -> String {
+    use blake2::{Blake2s256, Digest};
+    let mut betas: Vec<&str> = headers
+        .get_all("anthropic-beta")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+    betas.sort_unstable();
+    let canonical = serde_json::to_string(body).unwrap_or_default();
+    let mut h = Blake2s256::new();
+    for part in [model, &canonical, &betas.join(","), client_id, fp, fps] {
+        h.update(part.as_bytes());
+        h.update([0x1f]);
+    }
+    let digest = h.finalize();
+    let mut out = String::with_capacity(64);
+    for b in digest {
+        use std::fmt::Write;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+impl ResponseCache {
+    /// Storage-key namespace: entries land as `alb-resp:<digest>`.
+    const NAMESPACE: &'static str = "alb-resp";
+    const DEFAULT_TTL_SECS: u64 = 3600;
+    const DEFAULT_OP_TIMEOUT_MS: u64 = 250;
+    const DEFAULT_L1_CAPACITY: usize = 256;
+
+    /// Build from config. `Ok(None)` when the allow-list is empty (inert,
+    /// AC2). Config errors — bad key, missing backend params — are `Err`:
+    /// startup fails loudly rather than running with a silently-disabled
+    /// cache. Backend REACHABILITY is not required at startup: connection
+    /// failures are logged and every later operation fails open (AC10).
+    async fn from_config(cfg: &ResponseCacheConfig) -> Result<Option<Self>, String> {
+        if cfg.clients.is_empty() {
+            return Ok(None);
+        }
+        let master_key = decode_hex_key(&cfg.master_key)?;
+        let backend: cachekit::SharedBackend = match cfg.backend.as_str() {
+            "redis" => {
+                let url = cfg
+                    .redis_url
+                    .as_deref()
+                    .ok_or("response_cache.redis_url is required for backend = \"redis\"")?;
+                let b = cachekit::backend::redis::RedisBackend::builder()
+                    .url(url)
+                    .build()
+                    .map_err(|e| format!("response_cache redis backend: {e}"))?;
+                // fred's connection task detaches when the handle drops. A
+                // failed initial connect is NOT fatal: ops fail open until
+                // connectivity returns. (cachekit-rs 0.5.0 exposes no
+                // auto-reconnect on this builder — flagged upstream.)
+                match b.connect().await {
+                    Ok(_handle) => info!("response cache redis backend connected"),
+                    Err(e) => {
+                        warn!(error = %e, "response cache redis connect failed — cache will fail open")
+                    }
+                }
+                std::sync::Arc::new(b)
+            }
+            "cachekitio" => {
+                let api_key = cfg
+                    .api_key
+                    .as_deref()
+                    .ok_or("response_cache.api_key is required for backend = \"cachekitio\"")?;
+                let mut builder =
+                    cachekit::backend::cachekitio::CachekitIO::builder().api_key(api_key);
+                if let Some(url) = &cfg.api_url {
+                    // Operator-supplied override (same trust level as
+                    // endpoints[].base_url). cachekit's validator still
+                    // enforces HTTPS and rejects private/loopback IPs.
+                    builder = builder.api_url(url).allow_custom_host(true);
+                }
+                std::sync::Arc::new(
+                    builder
+                        .build()
+                        .map_err(|e| format!("response_cache cachekitio backend: {e}"))?,
+                )
+            }
+            other => {
+                return Err(format!(
+                    "response_cache.backend must be \"cachekitio\" or \"redis\", got \"{other}\""
+                ))
+            }
+        };
+        Self::from_parts(
+            backend,
+            &cfg.clients,
+            &master_key,
+            Duration::from_secs(cfg.ttl_secs.unwrap_or(Self::DEFAULT_TTL_SECS)),
+            Duration::from_millis(cfg.op_timeout_ms.unwrap_or(Self::DEFAULT_OP_TIMEOUT_MS)),
+            cfg.l1_capacity.unwrap_or(Self::DEFAULT_L1_CAPACITY),
+        )
+        .map(Some)
+    }
+
+    /// Assemble per-client caches over a shared backend. Split out from
+    /// `from_config` so tests can inject mock backends through the same
+    /// construction path production uses.
+    fn from_parts(
+        backend: cachekit::SharedBackend,
+        clients: &[String],
+        master_key: &[u8],
+        ttl: Duration,
+        op_timeout: Duration,
+        l1_capacity: usize,
+    ) -> Result<Self, String> {
+        let mut map = HashMap::new();
+        for client_id in clients {
+            if client_id == "-" {
+                return Err(
+                    "response_cache.clients cannot contain \"-\" (the unknown-client sentinel — it would opt in every unidentified caller)"
+                        .into(),
+                );
+            }
+            let ck = cachekit::CacheKit::builder()
+                .backend(backend.clone())
+                .default_ttl(ttl)
+                .namespace(Self::NAMESPACE)
+                .l1_capacity(l1_capacity)
+                .encryption_from_bytes(master_key, client_id)
+                .map_err(|e| format!("response_cache encryption init for \"{client_id}\": {e}"))?
+                .build()
+                .map_err(|e| format!("response_cache init for \"{client_id}\": {e}"))?;
+            map.insert(client_id.clone(), ck);
+        }
+        Ok(Self {
+            clients: map,
+            ttl,
+            op_timeout,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            errors: AtomicU64::new(0),
+            stores: AtomicU64::new(0),
+        })
+    }
+
+    /// Whether this client_id may use the cache (AC2).
+    fn is_opted_in(&self, client_id: &str) -> bool {
+        self.clients.contains_key(client_id)
+    }
+
+    /// Read an entry. Every failure mode — no encryption handle, backend
+    /// error, decrypt error, timeout — degrades to `None` and the request
+    /// proceeds upstream (AC10). Diagnostics carry the key digest only,
+    /// never content (AC5).
+    async fn lookup(&self, client_id: &str, key: &str) -> Option<CachedResponse> {
+        let cache = self.clients.get(client_id)?;
+        let op = async { cache.secure()?.get::<CachedResponse>(key).await };
+        match tokio::time::timeout(self.op_timeout, op).await {
+            Ok(Ok(Some(entry))) => {
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                Some(entry)
+            }
+            Ok(Ok(None)) => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+            Ok(Err(e)) => {
+                self.errors.fetch_add(1, Ordering::Relaxed);
+                warn!(key_digest = &key[..key.len().min(16)], error = %e, "response cache read failed — proceeding upstream");
+                None
+            }
+            Err(_) => {
+                self.errors.fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    key_digest = &key[..key.len().min(16)],
+                    timeout_ms = self.op_timeout.as_millis() as u64,
+                    "response cache read timed out — proceeding upstream"
+                );
+                None
+            }
+        }
+    }
+
+    /// Write an entry. Failures are counted and logged (digest only) but
+    /// never affect the client response (AC10).
+    async fn store(&self, client_id: &str, key: &str, entry: &CachedResponse) {
+        let Some(cache) = self.clients.get(client_id) else {
+            return;
+        };
+        let op = async { cache.secure()?.set_with_ttl(key, entry, self.ttl).await };
+        match tokio::time::timeout(self.op_timeout, op).await {
+            Ok(Ok(())) => {
+                self.stores.fetch_add(1, Ordering::Relaxed);
+            }
+            Ok(Err(e)) => {
+                self.errors.fetch_add(1, Ordering::Relaxed);
+                warn!(key_digest = &key[..key.len().min(16)], error = %e, "response cache write failed — skipped");
+            }
+            Err(_) => {
+                self.errors.fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    key_digest = &key[..key.len().min(16)],
+                    timeout_ms = self.op_timeout.as_millis() as u64,
+                    "response cache write timed out — skipped"
+                );
+            }
+        }
+    }
+}
+
+/// Build the client-facing response for a cache hit. Only ever called for
+/// entries written from 2xx responses (AC3).
+fn cached_hit_response(entry: CachedResponse) -> Response {
+    let content_type = if entry.content_type.is_empty() {
+        "application/json"
+    } else {
+        entry.content_type.as_str()
+    };
+    Response::builder()
+        .status(StatusCode::from_u16(entry.status).unwrap_or(StatusCode::OK))
+        .header("content-type", content_type)
+        .header("x-alb-cache", "hit")
+        .body(Body::from(entry.body))
+        .unwrap_or_else(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "cached response rebuild error",
+            )
+                .into_response()
+        })
 }
 
 /// Parsed IP allow entry — either a single IP or a CIDR range.
@@ -5981,6 +6330,58 @@ async fn forward_anthropic(
     }
 }
 
+/// LAB-933 write path. Pass-through unless a cache key was derived for this
+/// request (opted-in client, non-streaming /v1/messages — AC1/AC2/AC8) AND
+/// the response is 2xx (AC3: 4xx/5xx are never written). The body is already
+/// fully buffered for non-streaming requests, so `collect()` is a cheap
+/// re-assembly, not a wait. A cache-write failure fails open (AC10): the
+/// client response is returned unchanged either way.
+async fn maybe_cache_store(
+    state: &AppState,
+    cache_key: Option<&str>,
+    client_id: &str,
+    req_id: &str,
+    resp: Response,
+) -> Response {
+    let (Some(rc), Some(key)) = (&state.response_cache, cache_key) else {
+        return resp;
+    };
+    if !resp.status().is_success() {
+        return resp;
+    }
+    let (parts, body) = resp.into_parts();
+    let bytes = match http_body_util::BodyExt::collect(body).await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            // The buffered body failed to re-assemble — nothing valid to
+            // return OR cache. Surface it; never fabricate a success.
+            error!(req_id, error = %e, "response body collect failed during cache store");
+            return (
+                StatusCode::BAD_GATEWAY,
+                "response body collect failed during cache store",
+            )
+                .into_response();
+        }
+    };
+    let content_type = parts
+        .headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+    rc.store(
+        client_id,
+        key,
+        &CachedResponse {
+            status: parts.status.as_u16(),
+            content_type,
+            body: bytes.to_vec(),
+        },
+    )
+    .await;
+    Response::from_parts(parts, Body::from(bytes))
+}
+
 async fn proxy_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::ConnectInfo(client_addr): axum::extract::ConnectInfo<SocketAddr>,
@@ -6046,7 +6447,7 @@ async fn proxy_handler(
     };
 
     // Parse body once for model extraction and optional cache injection
-    let (body_bytes, oauth_body_bytes, model, fp) =
+    let (body_bytes, oauth_body_bytes, model, fp, cache_key) =
         if let Ok(mut parsed) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
             let model = parsed
                 .get("model")
@@ -6064,6 +6465,34 @@ async fn proxy_handler(
             // double as the affinity discriminator; bps is computed POST-injection
             // (below) to reflect the breakpoints actually forwarded upstream.
             let (fp, fps) = content_fingerprints(&parsed);
+
+            // LAB-933: derive the response-cache key on the PRE-injection
+            // body — the request exactly as the client sent it — so the
+            // deterministic auto-cache/OAuth mutations below never affect
+            // cache identity. Gated here on opt-in (AC2), the /v1/messages
+            // path, and non-streaming (AC8; same predicate as
+            // `request_wants_stream`, evaluated on the parsed body).
+            let cache_key = match &state.response_cache {
+                Some(rc)
+                    if rc.is_opted_in(&client_id)
+                        && parts.method == hyper::Method::POST
+                        && parts.uri.path() == "/v1/messages"
+                        && !parsed
+                            .get("stream")
+                            .and_then(|s| s.as_bool())
+                            .unwrap_or(false) =>
+                {
+                    Some(response_cache_key(
+                        &model,
+                        &parsed,
+                        &parts.headers,
+                        &client_id,
+                        &fp,
+                        &fps,
+                    ))
+                }
+                _ => None,
+            };
 
             // Debug: dump cache_control structures found in request body
             if tracing::enabled!(tracing::Level::DEBUG) {
@@ -6137,10 +6566,11 @@ async fn proxy_handler(
                 bytes::Bytes::from(oauth_bytes),
                 model,
                 Some(fp),
+                cache_key,
             )
         } else {
             let clone = body_bytes.clone();
-            (body_bytes, clone, String::new(), None)
+            (body_bytes, clone, String::new(), None, None)
         };
 
     // Build the affinity key now that fp is known. fp is the finest routing
@@ -6162,6 +6592,25 @@ async fn proxy_handler(
     // splitting the gate for a few microseconds on an almost-never code path.
     if let Err(resp) = state.pre_request_gate(&client_id, &model).await {
         return resp;
+    }
+
+    // LAB-933: serve an opted-in replay from the encrypted response cache.
+    // Placed AFTER the gate so budget/emergency policy still applies to
+    // opted-in clients; a hit then never touches an upstream — no rate-limit
+    // headroom burned, no budget decrement, no usage recorded (AC9). Only
+    // the hit counter and a digest-only log line observe it (AC5).
+    if let Some(key) = cache_key.as_deref() {
+        if let Some(rc) = &state.response_cache {
+            if let Some(entry) = rc.lookup(&client_id, key).await {
+                info!(
+                    req_id,
+                    client_id = %client_id,
+                    key_digest = &key[..key.len().min(16)],
+                    "response cache hit"
+                );
+                return cached_hit_response(entry);
+            }
+        }
     }
 
     let n = state.endpoints.len();
@@ -6251,7 +6700,19 @@ async fn proxy_handler(
                 &mut saw_transient,
                 &mut model_unsupported_resp,
             ) {
-                RetryStep::Return(resp) => return resp,
+                // LAB-933: the single success seam — every proxied response
+                // (Anthropic or translated OpenAI) exits proxy_handler here,
+                // so the cache write lives in exactly one place.
+                RetryStep::Return(resp) => {
+                    return maybe_cache_store(
+                        &state,
+                        cache_key.as_deref(),
+                        &client_id,
+                        &req_id,
+                        resp,
+                    )
+                    .await
+                }
                 RetryStep::NextAttempt => continue,
                 RetryStep::EndRound => break,
             }
@@ -8321,6 +8782,43 @@ async fn metrics_handler(
         &[],
         state.body_read_timeout_total.load(Ordering::Relaxed),
     );
+
+    // LAB-933 response cache counters (AC12). Emitted only when the cache is
+    // configured; the `surface` label leaves room for the LAB-929
+    // count_tokens cache to join the same series without a rename.
+    if let Some(rc) = &state.response_cache {
+        let series: [(&str, &AtomicU64, &str); 4] = [
+            (
+                "anthropic_response_cache_hits_total",
+                &rc.hits,
+                "Requests served from the response cache (no upstream call, no headroom burned)",
+            ),
+            (
+                "anthropic_response_cache_misses_total",
+                &rc.misses,
+                "Opted-in cacheable requests that proceeded upstream on a cache miss",
+            ),
+            (
+                "anthropic_response_cache_stores_total",
+                &rc.stores,
+                "2xx responses written to the response cache",
+            ),
+            (
+                "anthropic_response_cache_errors_total",
+                &rc.errors,
+                "Response cache operations that failed or timed out (request failed open)",
+            ),
+        ];
+        for (name, counter, help) in series {
+            prom_header(&mut buf, name, "counter", help);
+            prom_counter(
+                &mut buf,
+                name,
+                &[("surface", "messages")],
+                counter.load(Ordering::Relaxed),
+            );
+        }
+    }
 
     (
         StatusCode::OK,
@@ -10658,6 +11156,29 @@ async fn main() {
         None
     };
 
+    // LAB-933: opt-in encrypted response cache. Invalid CONFIG fails startup
+    // — an operator who configured a cache must not silently run without
+    // one. An unreachable BACKEND does not: operations fail open per-request.
+    let response_cache = match config.response_cache {
+        Some(ref cfg) => match ResponseCache::from_config(cfg).await {
+            Ok(Some(rc)) => {
+                info!(
+                    clients = rc.clients.len(),
+                    backend = %cfg.backend,
+                    ttl_secs = rc.ttl.as_secs(),
+                    "response cache enabled"
+                );
+                Some(rc)
+            }
+            Ok(None) => {
+                info!("response_cache configured with an empty client allow-list — inert");
+                None
+            }
+            Err(msg) => panic!("response_cache config error: {msg}"),
+        },
+        None => None,
+    };
+
     let state = Arc::new(AppState {
         // Liveness knobs are load-bearing against Anthropic's Cloudflare edge:
         // h2 PING (while_idle) evicts half-closed pooled streams before they're
@@ -10733,6 +11254,7 @@ async fn main() {
             .unwrap_or(DEFAULT_SESSION_REGISTRY_TTL_SECS),
         prompt_too_long: Mutex::new(HashMap::new()),
         unsupported_models: Mutex::new(HashMap::new()),
+        response_cache,
     });
 
     if state.auto_cache {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -339,6 +339,7 @@ fn test_state_base() -> AppState {
         session_registry_ttl_secs: DEFAULT_SESSION_REGISTRY_TTL_SECS,
         prompt_too_long: Mutex::new(HashMap::new()),
         unsupported_models: Mutex::new(HashMap::new()),
+        response_cache: None,
     }
 }
 
@@ -14853,4 +14854,740 @@ async fn stats_sessions_block_lists_and_redacts() {
         "raw session id must not leak"
     );
     assert!(!text.contains("127.0.0.1"), "raw client IP must not leak");
+}
+
+// ── LAB-933: opt-in encrypted response cache on /v1/messages ────────
+
+/// In-memory `cachekit::backend::Backend` that records every byte handed to
+/// it, so tests can assert on EXACTLY what the storage layer sees (AC4:
+/// ciphertext only, digest keys only).
+#[derive(Default)]
+struct RecordingBackend {
+    store: std::sync::Mutex<HashMap<String, Vec<u8>>>,
+    writes: std::sync::Mutex<Vec<(String, Vec<u8>)>>,
+}
+
+#[async_trait::async_trait]
+impl cachekit::backend::Backend for RecordingBackend {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, cachekit::BackendError> {
+        Ok(self.store.lock().unwrap().get(key).cloned())
+    }
+    async fn set(
+        &self,
+        key: &str,
+        value: Vec<u8>,
+        _ttl: Option<Duration>,
+    ) -> Result<(), cachekit::BackendError> {
+        self.writes
+            .lock()
+            .unwrap()
+            .push((key.to_string(), value.clone()));
+        self.store.lock().unwrap().insert(key.to_string(), value);
+        Ok(())
+    }
+    async fn delete(&self, key: &str) -> Result<bool, cachekit::BackendError> {
+        Ok(self.store.lock().unwrap().remove(key).is_some())
+    }
+    async fn exists(&self, key: &str) -> Result<bool, cachekit::BackendError> {
+        Ok(self.store.lock().unwrap().contains_key(key))
+    }
+    async fn health(&self) -> Result<cachekit::backend::HealthStatus, cachekit::BackendError> {
+        Ok(cachekit::backend::HealthStatus {
+            is_healthy: true,
+            latency_ms: 0.0,
+            backend_type: "recording".into(),
+            details: HashMap::new(),
+        })
+    }
+}
+
+/// Backend where every operation fails — the "Redis is down" shape (AC10).
+struct ErroringBackend;
+
+#[async_trait::async_trait]
+impl cachekit::backend::Backend for ErroringBackend {
+    async fn get(&self, _key: &str) -> Result<Option<Vec<u8>>, cachekit::BackendError> {
+        Err(cachekit::BackendError::transient("backend down"))
+    }
+    async fn set(
+        &self,
+        _key: &str,
+        _value: Vec<u8>,
+        _ttl: Option<Duration>,
+    ) -> Result<(), cachekit::BackendError> {
+        Err(cachekit::BackendError::transient("backend down"))
+    }
+    async fn delete(&self, _key: &str) -> Result<bool, cachekit::BackendError> {
+        Err(cachekit::BackendError::transient("backend down"))
+    }
+    async fn exists(&self, _key: &str) -> Result<bool, cachekit::BackendError> {
+        Err(cachekit::BackendError::transient("backend down"))
+    }
+    async fn health(&self) -> Result<cachekit::backend::HealthStatus, cachekit::BackendError> {
+        Err(cachekit::BackendError::transient("backend down"))
+    }
+}
+
+/// Backend where every operation hangs well past any op timeout (AC10).
+struct SlowBackend;
+
+#[async_trait::async_trait]
+impl cachekit::backend::Backend for SlowBackend {
+    async fn get(&self, _key: &str) -> Result<Option<Vec<u8>>, cachekit::BackendError> {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        Ok(None)
+    }
+    async fn set(
+        &self,
+        _key: &str,
+        _value: Vec<u8>,
+        _ttl: Option<Duration>,
+    ) -> Result<(), cachekit::BackendError> {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        Ok(())
+    }
+    async fn delete(&self, _key: &str) -> Result<bool, cachekit::BackendError> {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        Ok(false)
+    }
+    async fn exists(&self, _key: &str) -> Result<bool, cachekit::BackendError> {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        Ok(false)
+    }
+    async fn health(&self) -> Result<cachekit::backend::HealthStatus, cachekit::BackendError> {
+        Err(cachekit::BackendError::timeout("slow"))
+    }
+}
+
+const TEST_MASTER_KEY: [u8; 32] = [7u8; 32];
+
+fn test_response_cache(
+    backend: cachekit::SharedBackend,
+    clients: &[&str],
+    op_timeout_ms: u64,
+) -> ResponseCache {
+    ResponseCache::from_parts(
+        backend,
+        &clients.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        &TEST_MASTER_KEY,
+        Duration::from_secs(3600),
+        Duration::from_millis(op_timeout_ms),
+        64,
+    )
+    .unwrap()
+}
+
+/// Full app against a counting upstream, with the response cache installed
+/// for `clients`. Returns (addr, upstream_hits, state).
+async fn serve_cache_app(
+    backend: cachekit::SharedBackend,
+    clients: &[&str],
+) -> (
+    SocketAddr,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    Arc<AppState>,
+) {
+    let (url, hits) = spawn_flaky_upstream(0, ANTHROPIC_OK_BODY).await;
+    let rc = test_response_cache(backend, clients, 500);
+    let state = Arc::new(AppState {
+        endpoints: vec![mk_endpoint_at("acct-a", "sk-ant-api-test-aaa", &url)],
+        response_cache: Some(rc),
+        ..test_state_base()
+    });
+    let addr = serve(build_router(state.clone())).await;
+    (addr, hits, state)
+}
+
+const CACHE_TEST_BODY: &str =
+    r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#;
+
+async fn post_messages(addr: SocketAddr, client_id: &str, body: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-client-id", client_id)
+        .body(body.to_string())
+        .send()
+        .await
+        .unwrap()
+}
+
+// AC6: the key is a full-body canonical digest — same raw text in a
+// different structural position must produce a different key.
+#[test]
+fn response_cache_key_differs_on_nested_structure() {
+    let headers = hyper::HeaderMap::new();
+    let a: serde_json::Value = serde_json::from_str(
+        r#"{"messages":[{"role":"user","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}]}"#,
+    )
+    .unwrap();
+    let b: serde_json::Value = serde_json::from_str(
+        r#"{"messages":[{"role":"user","content":[{"type":"text","text":"ab"}]}]}"#,
+    )
+    .unwrap();
+    let (fpa, fpsa) = content_fingerprints(&a);
+    let (fpb, fpsb) = content_fingerprints(&b);
+    let ka = response_cache_key("m", &a, &headers, "c", &fpa, &fpsa);
+    let kb = response_cache_key("m", &b, &headers, "c", &fpb, &fpsb);
+    assert_ne!(ka, kb, "structural difference must change the key");
+
+    // Model and beta headers are key material too.
+    let ka2 = response_cache_key("m2", &a, &headers, "c", &fpa, &fpsa);
+    assert_ne!(ka, ka2, "model must change the key");
+    let mut beta_headers = hyper::HeaderMap::new();
+    beta_headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_static("context-1m-2025"),
+    );
+    let ka3 = response_cache_key("m", &a, &beta_headers, "c", &fpa, &fpsa);
+    assert_ne!(ka, ka3, "anthropic-beta must change the key");
+
+    // Key format: hex digest only, never content (AC5).
+    assert_eq!(ka.len(), 64);
+    assert!(ka.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+// AC7 (unit half): identical bodies, different clients → different keys.
+#[test]
+fn response_cache_key_isolates_clients() {
+    let headers = hyper::HeaderMap::new();
+    let body: serde_json::Value = serde_json::from_str(CACHE_TEST_BODY).unwrap();
+    let (fp, fps) = content_fingerprints(&body);
+    let ka = response_cache_key("test", &body, &headers, "client-a", &fp, &fps);
+    let kb = response_cache_key("test", &body, &headers, "client-b", &fp, &fps);
+    assert_ne!(ka, kb);
+}
+
+#[test]
+fn response_cache_master_key_validation() {
+    assert!(decode_hex_key(&"ab".repeat(32)).is_ok());
+    assert!(decode_hex_key("deadbeef").is_err(), "short key must fail");
+    assert!(
+        decode_hex_key(&"a".repeat(63)).is_err(),
+        "odd length must fail"
+    );
+    assert!(
+        decode_hex_key(&"zz".repeat(32)).is_err(),
+        "non-hex must fail"
+    );
+    assert!(decode_hex_key("").is_err());
+}
+
+#[test]
+fn response_cache_rejects_unknown_client_sentinel() {
+    let backend: cachekit::SharedBackend = std::sync::Arc::new(RecordingBackend::default());
+    let err = ResponseCache::from_parts(
+        backend,
+        &["-".to_string()],
+        &TEST_MASTER_KEY,
+        Duration::from_secs(60),
+        Duration::from_millis(100),
+        64,
+    )
+    .err()
+    .expect("\"-\" must be rejected");
+    assert!(err.contains("sentinel"), "got: {err}");
+}
+
+// AC1: with no cache configured, repeat requests hit the upstream every time
+// and no cache artifacts appear on the response.
+#[tokio::test]
+async fn response_cache_absent_config_is_inert() {
+    let (url, hits) = spawn_flaky_upstream(0, ANTHROPIC_OK_BODY).await;
+    let state = test_state_with(vec![mk_endpoint_at("a", "sk-ant-api-aaa", &url)]);
+    let addr = serve(build_router(state)).await;
+    for _ in 0..2 {
+        let resp = post_messages(addr, "someone", CACHE_TEST_BODY).await;
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert!(resp.headers().get("x-alb-cache").is_none());
+    }
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "both requests must reach upstream"
+    );
+}
+
+// AC2: a client NOT on the allow-list never reads or writes the cache even
+// when the cache is configured for someone else.
+#[tokio::test]
+async fn response_cache_ignores_non_opted_client() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, hits, state) = serve_cache_app(backend.clone(), &["opted-in"]).await;
+    for _ in 0..2 {
+        let resp = post_messages(addr, "not-opted-in", CACHE_TEST_BODY).await;
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert!(resp.headers().get("x-alb-cache").is_none());
+    }
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+    assert!(
+        backend.writes.lock().unwrap().is_empty(),
+        "no cache writes for non-opted client"
+    );
+    let rc = state.response_cache.as_ref().unwrap();
+    assert_eq!(rc.hits.load(Ordering::Relaxed), 0);
+    assert_eq!(rc.misses.load(Ordering::Relaxed), 0);
+}
+
+// AC9 + AC3 write side: an opted-in replay is served from cache — exactly one
+// upstream call, no second budget/usage recording, hit counted, marker header.
+#[tokio::test]
+async fn response_cache_hit_replays_without_upstream_or_budget() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, hits, state) = serve_cache_app(backend.clone(), &["geo"]).await;
+
+    let first = post_messages(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+    assert!(first.headers().get("x-alb-cache").is_none());
+    let first_body = first.bytes().await.unwrap();
+
+    let budget_after_first = state.budget_usage.lock().unwrap().clone();
+    let usage_after_first = state.client_usage.lock().unwrap().clone();
+    let upstream_requests_after_first = state.endpoints[0].requests.load(Ordering::Relaxed);
+
+    let second = post_messages(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(second.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        second
+            .headers()
+            .get("x-alb-cache")
+            .map(|v| v.to_str().unwrap()),
+        Some("hit")
+    );
+    let second_body = second.bytes().await.unwrap();
+    assert_eq!(first_body, second_body, "replay must be the original body");
+
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "second request must not reach upstream"
+    );
+    assert_eq!(
+        *state.budget_usage.lock().unwrap(),
+        budget_after_first,
+        "a cache hit must not decrement the daily budget"
+    );
+    assert_eq!(
+        *state.client_usage.lock().unwrap(),
+        usage_after_first,
+        "a cache hit must not record token usage"
+    );
+    assert_eq!(
+        state.endpoints[0].requests.load(Ordering::Relaxed),
+        upstream_requests_after_first,
+        "a cache hit must not consume endpoint headroom accounting"
+    );
+
+    let rc = state.response_cache.as_ref().unwrap();
+    assert_eq!(rc.hits.load(Ordering::Relaxed), 1);
+    assert_eq!(rc.misses.load(Ordering::Relaxed), 1);
+    assert_eq!(rc.stores.load(Ordering::Relaxed), 1);
+}
+
+// AC7 (integration half): a second opted-in client with a byte-identical
+// body must MISS — entries are never shared across clients.
+#[tokio::test]
+async fn response_cache_cross_client_read_misses() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, hits, _state) = serve_cache_app(backend.clone(), &["client-a", "client-b"]).await;
+
+    let r = post_messages(addr, "client-a", CACHE_TEST_BODY).await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    let r = post_messages(addr, "client-b", CACHE_TEST_BODY).await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    assert!(
+        r.headers().get("x-alb-cache").is_none(),
+        "cross-client must not hit"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "client-b must reach upstream"
+    );
+
+    // Each client still hits their OWN entry.
+    let r = post_messages(addr, "client-b", CACHE_TEST_BODY).await;
+    assert_eq!(
+        r.headers().get("x-alb-cache").map(|v| v.to_str().unwrap()),
+        Some("hit")
+    );
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+}
+
+// AC8: streaming requests bypass the cache entirely, even for opted-in clients.
+#[tokio::test]
+async fn response_cache_streaming_bypasses() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, hits, state) = serve_cache_app(backend.clone(), &["geo"]).await;
+    let streaming_body = r#"{"model":"test","max_tokens":1,"stream":true,"messages":[{"role":"user","content":"hi"}]}"#;
+    for _ in 0..2 {
+        let resp = post_messages(addr, "geo", streaming_body).await;
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert!(resp.headers().get("x-alb-cache").is_none());
+    }
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+    assert!(backend.writes.lock().unwrap().is_empty());
+    let rc = state.response_cache.as_ref().unwrap();
+    assert_eq!(
+        rc.misses.load(Ordering::Relaxed) + rc.hits.load(Ordering::Relaxed),
+        0
+    );
+}
+
+// AC3: non-2xx responses are never written to the cache.
+#[tokio::test]
+async fn response_cache_never_stores_non_2xx() {
+    // Upstream that always 500s.
+    let (url, _hits) = {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut s, _) = listener.accept().await.unwrap();
+                let mut buf = [0u8; 4096];
+                let _ = s.read(&mut buf).await;
+                let body = br#"{"type":"error","error":{"type":"api_error","message":"boom"}}"#;
+                let head = format!(
+                    "HTTP/1.1 500 Internal Server Error\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = s.write_all(head.as_bytes()).await;
+                let _ = s.write_all(body).await;
+            }
+        });
+        (format!("http://{addr}"), ())
+    };
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let rc = test_response_cache(backend.clone(), &["geo"], 500);
+    let state = Arc::new(AppState {
+        endpoints: vec![mk_endpoint_at("acct-a", "sk-ant-api-test-aaa", &url)],
+        response_cache: Some(rc),
+        ..test_state_base()
+    });
+    let addr = serve(build_router(state.clone())).await;
+    let resp = post_messages(addr, "geo", CACHE_TEST_BODY).await;
+    // The LB rotates/retries on upstream 5xx, so a permanently-500ing pool
+    // surfaces as an exhaustion status — the invariant under test is only
+    // that NOTHING non-2xx is ever written to the cache.
+    assert!(!resp.status().is_success());
+    assert!(
+        backend.writes.lock().unwrap().is_empty(),
+        "5xx must never be written to the cache"
+    );
+    assert_eq!(
+        state
+            .response_cache
+            .as_ref()
+            .unwrap()
+            .stores
+            .load(Ordering::Relaxed),
+        0
+    );
+}
+
+// AC4: nothing handed to the backend may contain the prompt or completion
+// plaintext; keys are digests; a wrong-key read fails closed (returns
+// nothing) rather than returning plaintext.
+#[tokio::test]
+async fn response_cache_backend_sees_only_ciphertext() {
+    let marker = b"XKCD-CORRECT-HORSE-BATTERY-STAPLE";
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let rc = test_response_cache(backend.clone(), &["geo"], 500);
+    let entry = CachedResponse {
+        status: 200,
+        content_type: "application/json".into(),
+        body: format!(
+            r#"{{"content":[{{"type":"text","text":"{}"}}]}}"#,
+            String::from_utf8_lossy(marker)
+        )
+        .into_bytes(),
+    };
+    let key = "a".repeat(64);
+    rc.store("geo", &key, &entry).await;
+    assert_eq!(rc.stores.load(Ordering::Relaxed), 1, "store must succeed");
+
+    let writes = backend.writes.lock().unwrap().clone();
+    assert!(!writes.is_empty());
+    for (k, v) in &writes {
+        assert!(
+            !v.windows(marker.len()).any(|w| w == marker),
+            "plaintext marker leaked into backend value"
+        );
+        assert!(
+            !k.as_bytes().windows(marker.len()).any(|w| w == marker),
+            "plaintext marker leaked into backend key"
+        );
+    }
+
+    // Right key decrypts.
+    let got = rc
+        .lookup("geo", &key)
+        .await
+        .expect("right-key read must hit");
+    assert_eq!(got.body, entry.body);
+
+    // Wrong master key over the SAME stored bytes: must fail closed.
+    let rc_wrong = ResponseCache::from_parts(
+        backend.clone(),
+        &["geo".to_string()],
+        &[9u8; 32],
+        Duration::from_secs(3600),
+        Duration::from_millis(500),
+        64,
+    )
+    .unwrap();
+    assert!(
+        rc_wrong.lookup("geo", &key).await.is_none(),
+        "wrong-key read must not return plaintext"
+    );
+    assert_eq!(
+        rc_wrong.errors.load(Ordering::Relaxed),
+        1,
+        "wrong-key read counts as error"
+    );
+
+    // Cross-tenant decrypt must also fail: same master key, different
+    // client_id (tenant) — HKDF gives it a different derived key. Reads go
+    // through client-b's cache handle but target client-a's stored bytes.
+    let rc_other = ResponseCache::from_parts(
+        backend.clone(),
+        &["other-client".to_string()],
+        &TEST_MASTER_KEY,
+        Duration::from_secs(3600),
+        Duration::from_millis(500),
+        64,
+    )
+    .unwrap();
+    assert!(
+        rc_other.lookup("other-client", &key).await.is_none(),
+        "cross-tenant read must not decrypt"
+    );
+}
+
+// AC10: a dead backend degrades to normal proxying, never an error response.
+#[tokio::test]
+async fn response_cache_fails_open_on_backend_error() {
+    let backend = std::sync::Arc::new(ErroringBackend);
+    let (addr, hits, state) = serve_cache_app(backend, &["geo"]).await;
+    for _ in 0..2 {
+        let resp = post_messages(addr, "geo", CACHE_TEST_BODY).await;
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::OK,
+            "must fail open to upstream"
+        );
+        assert!(resp.headers().get("x-alb-cache").is_none());
+    }
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+    let rc = state.response_cache.as_ref().unwrap();
+    assert!(
+        rc.errors.load(Ordering::Relaxed) >= 2,
+        "read+write errors must be counted"
+    );
+}
+
+// AC10: a HUNG backend is bounded by op_timeout — the request still
+// completes promptly with a normal proxied response.
+#[tokio::test]
+async fn response_cache_fails_open_on_slow_backend() {
+    let backend = std::sync::Arc::new(SlowBackend);
+    let (url, hits) = spawn_flaky_upstream(0, ANTHROPIC_OK_BODY).await;
+    let rc = test_response_cache(backend, &["geo"], 50);
+    let state = Arc::new(AppState {
+        endpoints: vec![mk_endpoint_at("acct-a", "sk-ant-api-test-aaa", &url)],
+        response_cache: Some(rc),
+        ..test_state_base()
+    });
+    let addr = serve(build_router(state.clone())).await;
+    let started = std::time::Instant::now();
+    let resp = post_messages(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "hung backend must be bounded by op_timeout, took {:?}",
+        started.elapsed()
+    );
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+    assert!(
+        state
+            .response_cache
+            .as_ref()
+            .unwrap()
+            .errors
+            .load(Ordering::Relaxed)
+            >= 2
+    );
+}
+
+// AC12: hit/miss/store/error counters are exposed on /metrics.
+#[tokio::test]
+async fn response_cache_metrics_exposed() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, _hits, _state) = serve_cache_app(backend, &["geo"]).await;
+    post_messages(addr, "geo", CACHE_TEST_BODY).await; // miss + store
+    post_messages(addr, "geo", CACHE_TEST_BODY).await; // hit
+    let text = reqwest::Client::new()
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        text.contains(r#"anthropic_response_cache_hits_total{surface="messages"} 1"#),
+        "{text}"
+    );
+    assert!(text.contains(r#"anthropic_response_cache_misses_total{surface="messages"} 1"#));
+    assert!(text.contains(r#"anthropic_response_cache_stores_total{surface="messages"} 1"#));
+    assert!(text.contains(r#"anthropic_response_cache_errors_total{surface="messages"} 0"#));
+}
+
+// Metrics stay silent when the cache is not configured (no phantom series).
+#[tokio::test]
+async fn response_cache_metrics_absent_without_config() {
+    let (url, _hits) = spawn_flaky_upstream(0, ANTHROPIC_OK_BODY).await;
+    let state = test_state_with(vec![mk_endpoint_at("a", "sk-ant-api-aaa", &url)]);
+    let addr = serve(build_router(state)).await;
+    let text = reqwest::Client::new()
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(!text.contains("anthropic_response_cache"));
+}
+
+// AC11 (redis): the real fred-backed RedisBackend against a dead port —
+// construction succeeds (connectivity is a runtime concern), operations
+// fail open within the timeout budget.
+#[tokio::test]
+async fn response_cache_redis_backend_fails_open_when_down() {
+    let cfg = ResponseCacheConfig {
+        clients: vec!["geo".to_string()],
+        backend: "redis".to_string(),
+        master_key: "ab".repeat(32),
+        ttl_secs: Some(60),
+        op_timeout_ms: Some(200),
+        l1_capacity: None,
+        redis_url: Some("redis://127.0.0.1:1".to_string()),
+        api_key: None,
+        api_url: None,
+    };
+    let rc = tokio::time::timeout(Duration::from_secs(10), ResponseCache::from_config(&cfg))
+        .await
+        .expect("from_config must not hang on a dead redis")
+        .expect("dead redis must not be a config error")
+        .expect("allow-list is non-empty");
+    let started = std::time::Instant::now();
+    assert!(rc.lookup("geo", &"a".repeat(64)).await.is_none());
+    assert!(started.elapsed() < Duration::from_secs(5));
+    assert!(rc.errors.load(Ordering::Relaxed) >= 1);
+}
+
+// AC11 (SaaS): CachekitIO backend constructs through the same config path,
+// and its SSRF guard holds — loopback api_url is rejected even though the
+// operator asked for a custom host (no new exfil surface, AC14 talking point).
+#[tokio::test]
+async fn response_cache_cachekitio_backend_constructs_and_blocks_loopback() {
+    let cfg = ResponseCacheConfig {
+        clients: vec!["geo".to_string()],
+        backend: "cachekitio".to_string(),
+        master_key: "ab".repeat(32),
+        ttl_secs: Some(60),
+        op_timeout_ms: Some(200),
+        l1_capacity: None,
+        redis_url: None,
+        api_key: Some("ck_test_dummy".to_string()),
+        api_url: None,
+    };
+    assert!(ResponseCache::from_config(&cfg).await.unwrap().is_some());
+
+    let loopback = ResponseCacheConfig {
+        api_url: Some("https://127.0.0.1:9".to_string()),
+        ..cfg.clone()
+    };
+    assert!(
+        ResponseCache::from_config(&loopback).await.is_err(),
+        "loopback api_url must be rejected by the SSRF guard"
+    );
+}
+
+// Config-shape checks: unknown backend and missing per-backend params fail
+// startup loudly; an empty allow-list is inert (AC2).
+#[tokio::test]
+async fn response_cache_config_validation() {
+    let base = ResponseCacheConfig {
+        clients: vec!["geo".to_string()],
+        backend: "redis".to_string(),
+        master_key: "ab".repeat(32),
+        ttl_secs: None,
+        op_timeout_ms: None,
+        l1_capacity: None,
+        redis_url: None,
+        api_key: None,
+        api_url: None,
+    };
+    assert!(
+        ResponseCache::from_config(&base).await.is_err(),
+        "backend=redis without redis_url must fail"
+    );
+    let bad_backend = ResponseCacheConfig {
+        backend: "memcached".to_string(),
+        ..base.clone()
+    };
+    assert!(ResponseCache::from_config(&bad_backend).await.is_err());
+    let no_key = ResponseCacheConfig {
+        backend: "cachekitio".to_string(),
+        ..base.clone()
+    };
+    assert!(
+        ResponseCache::from_config(&no_key).await.is_err(),
+        "backend=cachekitio without api_key must fail"
+    );
+    let inert = ResponseCacheConfig {
+        clients: vec![],
+        ..base
+    };
+    assert!(ResponseCache::from_config(&inert).await.unwrap().is_none());
+}
+
+// AC11 (SaaS, live): full round-trip against the real api.cachekit.io.
+// Requires CACHEKIT_API_KEY with write access; deliberately #[ignore]d so CI
+// stays hermetic — run locally with `cargo test -- --ignored` to exercise.
+#[tokio::test]
+#[ignore = "requires CACHEKIT_API_KEY and network access to api.cachekit.io"]
+async fn response_cache_cachekitio_live_round_trip() {
+    let api_key = match std::env::var("CACHEKIT_API_KEY") {
+        Ok(k) if !k.is_empty() => k,
+        _ => panic!("set CACHEKIT_API_KEY to run this test"),
+    };
+    let backend = cachekit::backend::cachekitio::CachekitIO::builder()
+        .api_key(api_key)
+        .build()
+        .unwrap();
+    let rc = test_response_cache(std::sync::Arc::new(backend), &["live-test"], 5_000);
+    let key = response_cache_key(
+        "live",
+        &serde_json::from_str::<serde_json::Value>(CACHE_TEST_BODY).unwrap(),
+        &hyper::HeaderMap::new(),
+        "live-test",
+        "fp",
+        "fps",
+    );
+    let entry = CachedResponse {
+        status: 200,
+        content_type: "application/json".into(),
+        body: b"{\"live\":true}".to_vec(),
+    };
+    rc.store("live-test", &key, &entry).await;
+    assert_eq!(rc.stores.load(Ordering::Relaxed), 1, "live store failed");
+    let got = rc
+        .lookup("live-test", &key)
+        .await
+        .expect("live read-back failed");
+    assert_eq!(got.body, entry.body);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14972,7 +14972,6 @@ fn test_response_cache(
         &TEST_MASTER_KEY,
         Duration::from_secs(3600),
         Duration::from_millis(op_timeout_ms),
-        64,
     )
     .unwrap()
 }
@@ -15027,19 +15026,19 @@ fn response_cache_key_differs_on_nested_structure() {
     .unwrap();
     let (fpa, fpsa) = content_fingerprints(&a);
     let (fpb, fpsb) = content_fingerprints(&b);
-    let ka = response_cache_key("m", &a, &headers, "c", &fpa, &fpsa);
-    let kb = response_cache_key("m", &b, &headers, "c", &fpb, &fpsb);
+    let ka = response_cache_key("m", &a, &headers, None, "c", &fpa, &fpsa);
+    let kb = response_cache_key("m", &b, &headers, None, "c", &fpb, &fpsb);
     assert_ne!(ka, kb, "structural difference must change the key");
 
     // Model and beta headers are key material too.
-    let ka2 = response_cache_key("m2", &a, &headers, "c", &fpa, &fpsa);
+    let ka2 = response_cache_key("m2", &a, &headers, None, "c", &fpa, &fpsa);
     assert_ne!(ka, ka2, "model must change the key");
     let mut beta_headers = hyper::HeaderMap::new();
     beta_headers.insert(
         "anthropic-beta",
         HeaderValue::from_static("context-1m-2025"),
     );
-    let ka3 = response_cache_key("m", &a, &beta_headers, "c", &fpa, &fpsa);
+    let ka3 = response_cache_key("m", &a, &beta_headers, None, "c", &fpa, &fpsa);
     assert_ne!(ka, ka3, "anthropic-beta must change the key");
 
     // Key format: hex digest only, never content (AC5).
@@ -15053,8 +15052,8 @@ fn response_cache_key_isolates_clients() {
     let headers = hyper::HeaderMap::new();
     let body: serde_json::Value = serde_json::from_str(CACHE_TEST_BODY).unwrap();
     let (fp, fps) = content_fingerprints(&body);
-    let ka = response_cache_key("test", &body, &headers, "client-a", &fp, &fps);
-    let kb = response_cache_key("test", &body, &headers, "client-b", &fp, &fps);
+    let ka = response_cache_key("test", &body, &headers, None, "client-a", &fp, &fps);
+    let kb = response_cache_key("test", &body, &headers, None, "client-b", &fp, &fps);
     assert_ne!(ka, kb);
 }
 
@@ -15082,7 +15081,6 @@ fn response_cache_rejects_unknown_client_sentinel() {
         &TEST_MASTER_KEY,
         Duration::from_secs(60),
         Duration::from_millis(100),
-        64,
     )
     .err()
     .expect("\"-\" must be rejected");
@@ -15334,7 +15332,6 @@ async fn response_cache_backend_sees_only_ciphertext() {
         &[9u8; 32],
         Duration::from_secs(3600),
         Duration::from_millis(500),
-        64,
     )
     .unwrap();
     assert!(
@@ -15356,7 +15353,6 @@ async fn response_cache_backend_sees_only_ciphertext() {
         &TEST_MASTER_KEY,
         Duration::from_secs(3600),
         Duration::from_millis(500),
-        64,
     )
     .unwrap();
     assert!(
@@ -15472,10 +15468,8 @@ async fn response_cache_redis_backend_fails_open_when_down() {
         master_key: "ab".repeat(32),
         ttl_secs: Some(60),
         op_timeout_ms: Some(200),
-        l1_capacity: None,
         redis_url: Some("redis://127.0.0.1:1".to_string()),
         api_key: None,
-        api_url: None,
     };
     let rc = tokio::time::timeout(Duration::from_secs(10), ResponseCache::from_config(&cfg))
         .await
@@ -15488,9 +15482,10 @@ async fn response_cache_redis_backend_fails_open_when_down() {
     assert!(rc.errors.load(Ordering::Relaxed) >= 1);
 }
 
-// AC11 (SaaS): CachekitIO backend constructs through the same config path,
-// and its SSRF guard holds — loopback api_url is rejected even though the
-// operator asked for a custom host (no new exfil surface, AC14 talking point).
+// AC11 (SaaS): CachekitIO backend constructs through the same config path
+// (fixed at cachekit's default HTTPS endpoint — there is deliberately no
+// api_url knob), and the SDK's SSRF guard holds: loopback/private hosts are
+// rejected even when a caller asks for a custom host (AC14 talking point).
 #[tokio::test]
 async fn response_cache_cachekitio_backend_constructs_and_blocks_loopback() {
     let cfg = ResponseCacheConfig {
@@ -15499,20 +15494,20 @@ async fn response_cache_cachekitio_backend_constructs_and_blocks_loopback() {
         master_key: "ab".repeat(32),
         ttl_secs: Some(60),
         op_timeout_ms: Some(200),
-        l1_capacity: None,
         redis_url: None,
         api_key: Some("ck_test_dummy".to_string()),
-        api_url: None,
     };
     assert!(ResponseCache::from_config(&cfg).await.unwrap().is_some());
 
-    let loopback = ResponseCacheConfig {
-        api_url: Some("https://127.0.0.1:9".to_string()),
-        ..cfg.clone()
-    };
+    // The guard the config path relies on, exercised directly.
     assert!(
-        ResponseCache::from_config(&loopback).await.is_err(),
-        "loopback api_url must be rejected by the SSRF guard"
+        cachekit::backend::cachekitio::CachekitIO::builder()
+            .api_key("ck_test_dummy")
+            .api_url("https://127.0.0.1:9")
+            .allow_custom_host(true)
+            .build()
+            .is_err(),
+        "loopback api_url must be rejected by cachekit's SSRF guard"
     );
 }
 
@@ -15526,10 +15521,8 @@ async fn response_cache_config_validation() {
         master_key: "ab".repeat(32),
         ttl_secs: None,
         op_timeout_ms: None,
-        l1_capacity: None,
         redis_url: None,
         api_key: None,
-        api_url: None,
     };
     assert!(
         ResponseCache::from_config(&base).await.is_err(),
@@ -15574,6 +15567,7 @@ async fn response_cache_cachekitio_live_round_trip() {
         "live",
         &serde_json::from_str::<serde_json::Value>(CACHE_TEST_BODY).unwrap(),
         &hyper::HeaderMap::new(),
+        None,
         "live-test",
         "fp",
         "fps",
@@ -15590,4 +15584,146 @@ async fn response_cache_cachekitio_live_round_trip() {
         .await
         .expect("live read-back failed");
     assert_eq!(got.body, entry.body);
+}
+
+// Panel fix (bug-hunter MAJ): anthropic-version and the URI query string are
+// key material — an SDK upgrade mid-TTL must miss, not replay the old shape.
+#[test]
+fn response_cache_key_varies_on_version_and_query() {
+    let body: serde_json::Value = serde_json::from_str(CACHE_TEST_BODY).unwrap();
+    let (fp, fps) = content_fingerprints(&body);
+    let plain = hyper::HeaderMap::new();
+    let mut versioned = hyper::HeaderMap::new();
+    versioned.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+    let base = response_cache_key("m", &body, &plain, None, "c", &fp, &fps);
+    assert_ne!(
+        base,
+        response_cache_key("m", &body, &versioned, None, "c", &fp, &fps),
+        "anthropic-version must change the key"
+    );
+    assert_ne!(
+        base,
+        response_cache_key("m", &body, &plain, Some("beta=true"), "c", &fp, &fps),
+        "URI query must change the key"
+    );
+}
+
+// Panel fix (craftsman MAJ): an upstream answering a stream:false request
+// with text/event-stream must pass through untouched — never collected,
+// never cached as a bogus non-streaming entry.
+#[tokio::test]
+async fn response_cache_skips_non_json_content_type() {
+    let sse_body: &[u8] = b"event: message_start\ndata: {}\n\n";
+    let (url, hits) = {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let hits = Arc::new(AtomicUsize::new(0));
+        let h = hits.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut s, _) = listener.accept().await.unwrap();
+                h.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 4096];
+                let _ = s.read(&mut buf).await;
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    sse_body.len()
+                );
+                let _ = s.write_all(head.as_bytes()).await;
+                let _ = s.write_all(sse_body).await;
+            }
+        });
+        (format!("http://{addr}"), hits)
+    };
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let rc = test_response_cache(backend.clone(), &["geo"], 500);
+    let state = Arc::new(AppState {
+        endpoints: vec![mk_endpoint_at("acct-a", "sk-ant-api-test-aaa", &url)],
+        response_cache: Some(rc),
+        ..test_state_base()
+    });
+    let addr = serve(build_router(state.clone())).await;
+    for _ in 0..2 {
+        let resp = post_messages(addr, "geo", CACHE_TEST_BODY).await;
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert!(resp.headers().get("x-alb-cache").is_none());
+        assert_eq!(resp.bytes().await.unwrap().as_ref(), sse_body);
+    }
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "SSE responses must never be served from cache"
+    );
+    assert!(
+        backend.writes.lock().unwrap().is_empty(),
+        "non-JSON content-type must never be written to the cache"
+    );
+    assert_eq!(
+        state
+            .response_cache
+            .as_ref()
+            .unwrap()
+            .stores
+            .load(Ordering::Relaxed),
+        0
+    );
+}
+
+// Panel fix (bug-hunter MAJ): bodies over MAX_BODY_BYTES are not stored —
+// bounds backend value growth and worst-case L1 memory. The response itself
+// is returned intact.
+#[tokio::test]
+async fn response_cache_skips_oversized_bodies() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let rc = test_response_cache(backend.clone(), &["geo"], 500);
+    let state = Arc::new(AppState {
+        response_cache: Some(rc),
+        ..test_state_base()
+    });
+    let big = vec![b'x'; ResponseCache::MAX_BODY_BYTES + 1];
+    let resp = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(big.clone()))
+        .unwrap();
+    let out = maybe_cache_store(&state, Some(&"a".repeat(64)), "geo", "rid", resp).await;
+    assert_eq!(out.status(), StatusCode::OK);
+    let out_bytes = axum::body::to_bytes(out.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        out_bytes.len(),
+        big.len(),
+        "oversized body must be returned intact"
+    );
+    assert!(backend.writes.lock().unwrap().is_empty());
+    assert_eq!(
+        state
+            .response_cache
+            .as_ref()
+            .unwrap()
+            .stores
+            .load(Ordering::Relaxed),
+        0
+    );
+
+    // At the cap boundary it IS stored.
+    let ok_body = vec![b'y'; 1024];
+    let resp = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(ok_body))
+        .unwrap();
+    let _ = maybe_cache_store(&state, Some(&"b".repeat(64)), "geo", "rid", resp).await;
+    assert_eq!(
+        state
+            .response_cache
+            .as_ref()
+            .unwrap()
+            .stores
+            .load(Ordering::Relaxed),
+        1
+    );
 }


### PR DESCRIPTION
Closes LAB-933.

An **opt-in** response cache on non-streaming `POST /v1/messages`, built on `cachekit-rs` 0.5.0. A hit skips the upstream call entirely — **zero 5h/7d rate-limit headroom burned, no daily-budget decrement** — which is the whole point: eval reruns, geo-pipeline replays, and post-timeout retries stop costing quota.

## Design

- **Default-off, allow-list gated (AC1/AC2).** No `[response_cache]` config, or an empty `clients` list ⇒ byte-identical behaviour to today, verified by regression tests. `"-"` (the unknown-client sentinel) is rejected at startup so unidentified callers can never be opted in.
- **Zero-knowledge storage (AC4).** `SecureCache` is mandatory — there is no plaintext configuration. Values are AES-256-GCM encrypted in-process before any layer sees them; cachekit-rs 0.5.0 writes ciphertext to the in-process L1 too (verified in its source: `SecureCache::set_with_ttl`, client.rs:413-448). Tests assert no plaintext substring of a distinctive prompt reaches anything handed to the backend, and that wrong-key and cross-tenant reads fail closed.
- **Per-client isolation is cryptographic (AC7).** One `CacheKit` per allow-listed client over a shared backend, with `tenant_id = client_id` → HKDF-SHA256 derives a distinct key per client. On top, `client_id` is part of the cache-key digest. Cross-client reads miss *and* couldn't decrypt.
- **Key correctness (AC6).** Key = Blake2s-256 over `(model ␟ canonical body JSON ␟ sorted anthropic-beta ␟ anthropic-version ␟ URI query ␟ client_id ␟ fp ␟ fps)`, computed on the **pre-injection** body (as the client sent it). The existing 48-bit SipHash fingerprints are folded in per the AC, but the full-body digest carries correctness — 48 bits over prompt content is collision territory, and a collision here would serve someone the wrong completion. `anthropic-version` and the query string are keyed because they change the response *schema* for an identical body.
- **Scope guards (AC3/AC8).** Only 2xx responses are written (4xx/5xx never written, never served). Streaming requests bypass entirely — same predicate as `request_wants_stream()`, evaluated pre-injection. `/v1/messages/count_tokens` doesn't match the path gate (that's LAB-929).
- **A hit consumes nothing (AC9).** The lookup sits *after* `pre_request_gate` (budget/emergency policy still applies) and *before* the retry loop — a hit returns without touching `pick_endpoint`, usage recording, or budget accounting. Test pins upstream hit-count, `budget_usage`, `client_usage`, and endpoint request counters across a hit.
- **Fail-open (AC10).** Every cache op is bounded by `op_timeout_ms` (default 250 ms) via `tokio::time::timeout`; any error or timeout degrades to a miss / skipped write. Tests cover an always-erroring backend, a hung backend, and the real fred-backed Redis backend against a dead port.
- **Both backends (AC11).** `backend = "cachekitio"` (SaaS — rides the existing reqwest/rustls stack) or `backend = "redis"` (local Redis/Valkey via cachekit's fred client). The write path lives at the retry loop's single exit seam, so responses served by Anthropic endpoints and translated OpenAI fallbacks are cached uniformly.
- **Metrics (AC12).** `anthropic_response_cache_{hits,misses,stores,errors}_total{surface="messages"}` — the `surface` label is where LAB-929's count_tokens cache slots in without a rename.
- **Docs (AC13).** README section covering what's cached, where it lands, ciphertext-only storage, opt-in mechanics, TTL, and the non-determinism caveat (replaying a `temperature > 0` request returns the *same* answer, by design — opting in is consent). `config.toml.example` updated.

## Testing (AC11 caveats stated plainly)

18 new tests (505 total, clippy `-Dwarnings` clean, fmt clean). Most cache logic is exercised through cachekit's public `Backend` trait with an in-memory recording backend — the seam the SDK itself provides. Backend-specific coverage:

- **Redis:** real `RedisBackend` construction + fail-open ops against a dead port. A live-Redis integration baseline is LAB-931's remit; not duplicated here.
- **CachekitIO:** construction through the production config path, plus a test pinning that the SSRF guard rejects loopback `api_url` even with a custom host. A **full live round-trip exists but is `#[ignore]`d** (`response_cache_cachekitio_live_round_trip`, needs `CACHEKIT_API_KEY`) because cachekit's URL validator blocks loopback/private IPs even in allow-custom-host mode — there is no way to point the real SaaS backend at a local mock. That gap is written up in the dogfooding findings (AC15).

## Security review (AC14) — run, findings applied

`security-specialist` review completed pre-merge, plus a full expert panel (bug-hunter, code-craftsman, catchphrase) per the workspace gate. **All four AC14 areas HOLD**: per-client key isolation (HKDF per tenant; wrong-key and cross-tenant reads fail AEAD — tested), ciphertext-only storage (L1 included; no plaintext-storage config path exists), digest-only diagnostics (no `Debug` on config structs, so `master_key`/`api_key` can't leak via formatting), and **no new interaction with the 2026-06-02 SSRF/token-exfil surface** (no client-controlled outbound URL; cachekit's CachekitIO client has redirects disabled and blocks private/loopback hosts even in allow-custom-host mode — pinned by a test).

Findings applied in `40776da`: `anthropic-version` + query string added to key material (wrong-response-shape class); response content-type gate (SSE answers to `stream:false` requests pass through uncollected); 1 MiB store cap; mutual-trust caveat documented (below); Redis no-reconnect comment corrected; cut list (config knobs `l1_capacity`/`api_url` deleted, TTL single-sourced, digest-prefix helper, shared streaming predicate, invalid-status fails loud).

**Accepted-risk finding (documented, escalated):** client identity is the client-asserted `x-client-id` header — the LB's identity model is explicitly trust-based, pre-existing this change. The cache adds a cross-tenant *read* capability on top of the existing impersonation surface (budget-burning): any authenticated caller presenting an opted-in client's ID can read that client's cached responses. Mitigation in this PR is documentation (README + config example: allow-listed clients form ONE trust domain). Hardening identity to authenticated principals (per-client keys / verified IP binding) is a separate decision — flagged to Ray on LAB-933.

**Panel findings rejected, with reasons:** async cache-write spawn (write is bounded at `op_timeout_ms` worst-case, opted-in misses only, ~1 ms healthy; spawning makes write ordering nondeterministic and tests flaky — revisit on p99 evidence); dropping fp/fps from key material (AC6 mandates reusing the fingerprint machinery; zero cost, deterministic).

## Dogfooding write-back (AC15)

Findings filed upstream: https://github.com/cachekit-io/cachekit-rs/issues/51 — CachekitIO has no CI test seam (SSRF validator blocks loopback even for tests, transport not pluggable), RedisBackend auto-reconnect unreachable outside presets (and presets can't do per-tenant encryption), no op-timeout control on either backend, msgpack `Vec<u8>` int-array tax without `serde_bytes`, plus doc nits. Also: what worked — the L1-ciphertext guarantee is verifiable in source, per-tenant HKDF made client isolation nearly free, `Ok(None)`-on-miss keeps fail-open trivial.

## Deployment notes

- Requires config change + pod restart to enable (init-container config delivery).
- `master_key`: `openssl rand -hex 32`, delivered via the secret store like other config secrets.
- cachekit-rs 0.5.0's Redis backend has **no auto-reconnect** outside its presets (upstream finding #2): a Redis restart leaves the cache failing open until pod restart. Survivable by design (fail-open), but pick `cachekitio` if that bothers you — it's also the lighter dependency path.


## Supply-chain evidence (Kody round 1)

- **Publisher verified first-party:** `cachekit-rs` on crates.io is owned by [`27Bslash6` (Ray Walker)](https://crates.io/crates/cachekit-rs), repository `github.com/cachekit-io/cachekit-rs` — our own org's crate. The naming-collision warning in `Cargo.toml` guards against the *unrelated* plain `cachekit` crate; this dependency is not it, and typosquat risk is nil for a crate we publish ourselves.
- **RustSec audit clean:** `cargo audit` exits 0 with **0 advisories across 313 locked crates** as of `d453cb7`. Three pre-existing advisories (RUSTSEC-2026-0098/0099/0104, all `rustls-webpki 0.103.10` via `reqwest`/`redis`/`quinn` — present on `main`, not introduced here) were cleared in this PR by a patch-level `cargo update -p rustls-webpki` → 0.103.13. Full test suite green after the bump.
- New direct deps beyond `cachekit-rs`: `blake2 0.10` (RustCrypto) and `serde_bytes 0.11` (serde-rs) — both already pinned at identical versions inside cachekit-rs's own tree, so they add no new resolution.
