### PR TITLE
LAB-933: reinstate response_cache.api_url for the cachekit dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ backend = "redis"
 redis_url = "redis://10.0.0.5:6379/1"
 # backend = "cachekitio"
 # api_key = "ck_live_..."
+# api_url = "https://api.dev.cachekit.io"  # optional; default https://api.cachekit.io. HTTPS enforced, private/loopback IPs rejected at startup.
 
 # Hex-encoded 32-byte master key for client-side encryption (MANDATORY —
 # there is no plaintext mode). Generate: openssl rand -hex 32

--- a/config.toml.example
+++ b/config.toml.example
@@ -68,6 +68,7 @@ probe_interval_secs = 300
 # backend = "redis"                    # "redis" or "cachekitio"
 # redis_url = "redis://10.0.0.5:6379/1"
 # # api_key = "<from secret store>"    # for backend = "cachekitio"
+# # api_url = "https://api.dev.cachekit.io" # optional override (e.g. cachekit DEV env); default api.cachekit.io. HTTPS-only, private/loopback IPs rejected.
 # master_key = "<from secret store: openssl rand -hex 32>" # mandatory; 32+ bytes hex
 # # ttl_secs = 3600                    # default 1h
 # # op_timeout_ms = 250                # fail-open budget per cache op

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,12 +130,16 @@ struct ResponseCacheConfig {
     op_timeout_ms: Option<u64>,
     /// Connection URL for backend = "redis" (redis:// or rediss://).
     redis_url: Option<String>,
-    /// API key for backend = "cachekitio". The API URL is fixed at
-    /// cachekit's default (api.cachekit.io) — deliberately no override knob:
-    /// an operator egress-URL switch on a proxy with an open SSRF audit
-    /// finding is negative-value optionality until a real self-hosted
-    /// deployment exists.
+    /// API key for backend = "cachekitio".
     api_key: Option<String>,
+    /// API URL override for backend = "cachekitio". Default:
+    /// https://api.cachekit.io. This knob was cut in the LAB-933 review as
+    /// YAGNI and reinstated for a named need: the first rollout targets the
+    /// cachekit DEV environment, which lives on a different hostname.
+    /// Operator config, same trust as endpoints[].base_url; cachekit's own
+    /// validator still enforces HTTPS and rejects private/loopback IPs
+    /// (SSRF guard — pinned by a test).
+    api_url: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -1132,9 +1136,18 @@ impl ResponseCache {
                     .api_key
                     .as_deref()
                     .ok_or("response_cache.api_key is required for backend = \"cachekitio\"")?;
+                let mut builder =
+                    cachekit::backend::cachekitio::CachekitIO::builder().api_key(api_key);
+                if let Some(url) = &cfg.api_url {
+                    // allow_custom_host is required for hosts outside
+                    // cachekit's built-in allow-list (api.cachekit.io /
+                    // api.staging.cachekit.io) — e.g. the dev environment.
+                    // The validator still enforces HTTPS and blocks
+                    // private/loopback IPs regardless.
+                    builder = builder.api_url(url).allow_custom_host(true);
+                }
                 std::sync::Arc::new(
-                    cachekit::backend::cachekitio::CachekitIO::builder()
-                        .api_key(api_key)
+                    builder
                         .build()
                         .map_err(|e| format!("response_cache cachekitio backend: {e}"))?,
                 )

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15470,6 +15470,7 @@ async fn response_cache_redis_backend_fails_open_when_down() {
         op_timeout_ms: Some(200),
         redis_url: Some("redis://127.0.0.1:1".to_string()),
         api_key: None,
+        api_url: None,
     };
     let rc = tokio::time::timeout(Duration::from_secs(10), ResponseCache::from_config(&cfg))
         .await
@@ -15482,10 +15483,12 @@ async fn response_cache_redis_backend_fails_open_when_down() {
     assert!(rc.errors.load(Ordering::Relaxed) >= 1);
 }
 
-// AC11 (SaaS): CachekitIO backend constructs through the same config path
-// (fixed at cachekit's default HTTPS endpoint — there is deliberately no
-// api_url knob), and the SDK's SSRF guard holds: loopback/private hosts are
-// rejected even when a caller asks for a custom host (AC14 talking point).
+// AC11 (SaaS): CachekitIO backend constructs through the same config path,
+// with and without an api_url override (the override exists for the dev
+// environment, which is not on cachekit's built-in host allow-list), and the
+// SDK's SSRF guard holds through OUR config path: loopback/private hosts are
+// rejected at startup even though the override sets allow_custom_host
+// (AC14 talking point).
 #[tokio::test]
 async fn response_cache_cachekitio_backend_constructs_and_blocks_loopback() {
     let cfg = ResponseCacheConfig {
@@ -15496,18 +15499,35 @@ async fn response_cache_cachekitio_backend_constructs_and_blocks_loopback() {
         op_timeout_ms: Some(200),
         redis_url: None,
         api_key: Some("ck_test_dummy".to_string()),
+        api_url: None,
     };
     assert!(ResponseCache::from_config(&cfg).await.unwrap().is_some());
 
-    // The guard the config path relies on, exercised directly.
+    // Custom public host (the dev-environment shape) constructs.
+    let dev = ResponseCacheConfig {
+        api_url: Some("https://api.dev.cachekit.io".to_string()),
+        ..cfg.clone()
+    };
+    assert!(ResponseCache::from_config(&dev).await.unwrap().is_some());
+
+    // Loopback/private hosts fail startup loudly — through the config path.
+    let loopback = ResponseCacheConfig {
+        api_url: Some("https://127.0.0.1:9".to_string()),
+        ..cfg.clone()
+    };
     assert!(
-        cachekit::backend::cachekitio::CachekitIO::builder()
-            .api_key("ck_test_dummy")
-            .api_url("https://127.0.0.1:9")
-            .allow_custom_host(true)
-            .build()
-            .is_err(),
+        ResponseCache::from_config(&loopback).await.is_err(),
         "loopback api_url must be rejected by cachekit's SSRF guard"
+    );
+
+    // Plain HTTP fails too.
+    let http = ResponseCacheConfig {
+        api_url: Some("http://api.dev.cachekit.io".to_string()),
+        ..cfg
+    };
+    assert!(
+        ResponseCache::from_config(&http).await.is_err(),
+        "non-HTTPS api_url must be rejected"
     );
 }
 
@@ -15523,6 +15543,7 @@ async fn response_cache_config_validation() {
         op_timeout_ms: None,
         redis_url: None,
         api_key: None,
+        api_url: None,
     };
     assert!(
         ResponseCache::from_config(&base).await.is_err(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15520,6 +15520,16 @@ async fn response_cache_cachekitio_backend_constructs_and_blocks_loopback() {
         "loopback api_url must be rejected by cachekit's SSRF guard"
     );
 
+    // RFC1918 private hosts fail too — internal targets stay unreachable.
+    let private = ResponseCacheConfig {
+        api_url: Some("https://10.0.0.1:443".to_string()),
+        ..cfg.clone()
+    };
+    assert!(
+        ResponseCache::from_config(&private).await.is_err(),
+        "private-address api_url must be rejected by cachekit's SSRF guard"
+    );
+
     // Plain HTTP fails too.
     let http = ResponseCacheConfig {
         api_url: Some("http://api.dev.cachekit.io".to_string()),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR reinstates the `api_url` configuration option for the `cachekitio` response cache backend, enabling the response cache to target the cachekit DEV environment.

## Background

The `api_url` override knob was previously removed during the LAB-933 review as YAGNI (deliberately fixing the API URL to cachekit's default `api.cachekit.io`). This PR brings it back for a concrete need: the first rollout targets the cachekit DEV environment, which runs on a different hostname (`api.dev.cachekit.io`) that is not on cachekit's built-in host allow-list.

## Changes

- **`src/main.rs`**:
  - Added the optional `api_url` field to `ResponseCacheConfig`.
  - When `api_url` is set, the `CachekitIO` builder now applies it along with `allow_custom_host(true)`, which is required for hosts outside cachekit's built-in allow-list. The SDK's validator still enforces HTTPS and rejects private/loopback IPs regardless.

- **`src/tests.rs`**:
  - Updated existing test fixtures to include the new `api_url: None` field.
  - Expanded the `cachekitio` backend test to verify the SSRF/security guards hold **through the config path** (not just directly against the SDK):
    - A custom public host (dev-environment shape) constructs successfully.
    - Loopback/private hosts fail startup loudly even with `allow_custom_host` set.
    - Plain HTTP (non-HTTPS) URLs are rejected.

- **`README.md` / `config.toml.example`**: Documented the new optional `api_url` override, noting it defaults to `https://api.cachekit.io`, enforces HTTPS-only, and rejects private/loopback IPs at startup.

## Security Notes

The override is operator config, carrying the same trust level as `endpoints[].base_url`. Cachekit's own validator continues to enforce HTTPS and block private/loopback IPs (SSRF guard), now verified via a test that exercises the actual configuration path.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional response-cache API URL override for CachekitIO backends.
  - Custom endpoints must use HTTPS; private and loopback addresses are rejected during startup.

- **Documentation**
  - Documented the new `api_url` setting, its default endpoint, and security requirements.
  - Updated the sample configuration with the optional setting and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->