### PR TITLE
LAB-1191: close the four open token-exfil audit findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Routing consequences (`constraining_7d_claims`):
 | `endpoints[].fable_included` | bool? | true | Plan includes Fable's 50%-of-weekly band. Set false for Pro / standard Team accounts: Fable requests demote the endpoint by `overage_penalty`; non-Fable routing unaffected |
 | `endpoints[].allow_nonstandard_host` | bool? | false | Allow an `anthropic` endpoint whose `base_url` host isn't `api.anthropic.com` (otherwise startup fails — token exfil guard, LAB-1191) |
 | `expose_upstream_ratelimit_headers` | bool? | false | Reflect upstream `anthropic-ratelimit-*` headers to callers (reveals pooled account capacity — trusted networks only, LAB-1191) |
-| `allowed_client_betas` | string[]? | built-in list | Client `anthropic-beta` flags forwarded on OAuth endpoints (`*` suffix wildcard); unlisted flags dropped + logged + counted in `anthropic_beta_flag_dropped_total` (LAB-1191) |
+| `allowed_client_betas` | string[]? | built-in list | Client `anthropic-beta` flags forwarded on OAuth endpoints (`*` suffix wildcard); a configured list REPLACES the default (copy defaults alongside additions); unlisted flags dropped + logged + counted in `anthropic_beta_flag_dropped_total` (LAB-1191) |
 
 
 **Key headers parsed:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,9 @@ Routing consequences (`constraining_7d_claims`):
 | `endpoints[].models` | string[]? | [] (all) | Model allowlist (supports `*` suffix wildcards) |
 | `endpoints[].priority` | u32? | 0 | Priority tier (0 = highest). Lower tiers tried first |
 | `endpoints[].fable_included` | bool? | true | Plan includes Fable's 50%-of-weekly band. Set false for Pro / standard Team accounts: Fable requests demote the endpoint by `overage_penalty`; non-Fable routing unaffected |
+| `endpoints[].allow_nonstandard_host` | bool? | false | Allow an `anthropic` endpoint whose `base_url` host isn't `api.anthropic.com` (otherwise startup fails — token exfil guard, LAB-1191) |
+| `expose_upstream_ratelimit_headers` | bool? | false | Reflect upstream `anthropic-ratelimit-*` headers to callers (reveals pooled account capacity — trusted networks only, LAB-1191) |
+| `allowed_client_betas` | string[]? | built-in list | Client `anthropic-beta` flags forwarded on OAuth endpoints (`*` suffix wildcard); unlisted flags dropped + logged + counted in `anthropic_beta_flag_dropped_total` (LAB-1191) |
 
 
 **Key headers parsed:**

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ token = "sk-ant-api03-..."
 | `strategy` | `String` | `dynamic-capacity-v1` | Routing strategy (see note below) |
 | `emergency_threshold` | `f64` | `0.88` | Utilization threshold for emergency brake |
 | `redis_url` | `String?` | `None` | Redis/Valkey URL for distributed state |
+| `expose_upstream_ratelimit_headers` | `bool` | `false` | Reflect upstream `anthropic-ratelimit-*` headers to callers — they reveal the pooled capacity of every account, so enable on trusted networks only |
+| `allowed_client_betas` | `[String]?` | built-in list | Client `anthropic-beta` flags forwarded upstream on OAuth endpoints (`*` suffix wildcard); unlisted flags are dropped, logged, and counted (`anthropic_beta_flag_dropped_total`) so a caller can't activate arbitrary beta features against the operator's accounts |
 | `endpoints[].name` | `String` | — | Display name for the endpoint |
 | `endpoints[].protocol` | `String` | `"anthropic"` | `"anthropic"` (default) or `"openai"` |
 | `endpoints[].base_url` | `String?` | `https://api.anthropic.com` | Base URL; required and must be `https://` for `openai` |
@@ -167,6 +169,7 @@ token = "sk-ant-api03-..."
 | `endpoints[].models` | `[String]` | `[]` | Model allowlist (empty = all) |
 | `endpoints[].priority` | `u32` | `0` | Priority tier (lower tried first) |
 | `endpoints[].fable_included` | `bool` | `true` | Plan includes Fable band; set `false` for Pro / standard Team |
+| `endpoints[].allow_nonstandard_host` | `bool` | `false` | Allow an `anthropic` endpoint whose `base_url` host isn't `api.anthropic.com` — without it startup fails, because the endpoint token would be sent to that host |
 | `session_registry_max` | `usize` | `1000` | Max live-session entries tracked for `/_stats` `sessions` (0 = disabled) |
 | `session_registry_ttl_secs` | `u64` | `1800` | Seconds after a session's last request before its entry is evicted |
 
@@ -256,6 +259,31 @@ Three layers, all optional — use what fits:
 | **Proxy key** | `proxy_key = "secret"` | Requires `x-api-key` header match (401) |
 
 IP check runs first, then proxy key. Both apply to all endpoints including `/_stats`.
+
+### Credential-path hardening (LAB-1191)
+
+The proxy forwards operator OAuth/API tokens upstream, so the paths a request
+can steer are locked down by default:
+
+- **Endpoint hosts are pinned.** An `anthropic`-protocol endpoint whose
+  `base_url` host isn't `api.anthropic.com` fails startup validation —
+  a typo'd or tampered URL would ship the account token to that host.
+  Deliberate mirrors opt in per endpoint with `allow_nonstandard_host = true`.
+- **Redirects are never followed.** The upstream HTTP client uses
+  `redirect::Policy::none()`; a `3xx` from an upstream surfaces to the caller
+  as a `502` with a distinct log line instead of re-sending credentials to
+  the `Location` target.
+- **Response headers are allow-listed.** Only `content-type`,
+  `content-length`, `cache-control`, `request-id`, and `retry-after` are
+  reflected to callers (plus the proxy's own `x-budget-status`).
+  `anthropic-ratelimit-*` (the pooled capacity of every account),
+  `set-cookie`, and org-identifying headers are stripped;
+  `expose_upstream_ratelimit_headers = true` restores the ratelimit
+  passthrough for trusted networks.
+- **Client beta flags are allow-listed.** On OAuth endpoints, client
+  `anthropic-beta` values outside `allowed_client_betas` are dropped before
+  forwarding, logged at `warn`, and counted in
+  `anthropic_beta_flag_dropped_total{flag}`.
 
 > [!WARNING]
 > With no `proxy_key` and no `allowed_ips`, the proxy is **open to all**. This is fine on a private network (VPN) or localhost, but never expose an open proxy to the internet.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ token = "sk-ant-api03-..."
 | `emergency_threshold` | `f64` | `0.88` | Utilization threshold for emergency brake |
 | `redis_url` | `String?` | `None` | Redis/Valkey URL for distributed state |
 | `expose_upstream_ratelimit_headers` | `bool` | `false` | Reflect upstream `anthropic-ratelimit-*` headers to callers — they reveal the pooled capacity of every account, so enable on trusted networks only |
-| `allowed_client_betas` | `[String]?` | built-in list | Client `anthropic-beta` flags forwarded upstream on OAuth endpoints (`*` suffix wildcard); unlisted flags are dropped, logged, and counted (`anthropic_beta_flag_dropped_total`) so a caller can't activate arbitrary beta features against the operator's accounts |
+| `allowed_client_betas` | `[String]?` | built-in list | Client `anthropic-beta` flags forwarded upstream on OAuth endpoints (`*` suffix wildcard); a configured list **replaces** the built-in default — copy the defaults alongside additions. Unlisted flags are dropped, logged, and counted (`anthropic_beta_flag_dropped_total`) so a caller can't activate arbitrary beta features against the operator's accounts |
 | `endpoints[].name` | `String` | — | Display name for the endpoint |
 | `endpoints[].protocol` | `String` | `"anthropic"` | `"anthropic"` (default) or `"openai"` |
 | `endpoints[].base_url` | `String?` | `https://api.anthropic.com` | Base URL; required and must be `https://` for `openai` |

--- a/config.toml.example
+++ b/config.toml.example
@@ -45,6 +45,25 @@ probe_interval_secs = 300
 # connections could pin the budget indefinitely. Default: 60. Set to 0 to disable.
 # body_read_timeout_secs = 60
 
+# Reflect upstream anthropic-ratelimit-* response headers to callers. They
+# reveal the pooled capacity of every account behind the proxy, so the default
+# strips them; enable only on a trusted network where tooling reads them.
+# expose_upstream_ratelimit_headers = false
+
+# Client-supplied anthropic-beta flags forwarded upstream on OAuth endpoints
+# ("*" = suffix wildcard). Anything not listed is dropped (logged +
+# anthropic_beta_flag_dropped_total metric) — otherwise any caller could
+# activate arbitrary beta features against the operator's accounts. Omit to
+# use the built-in default (the flags Claude Code sends + context-1m*).
+# allowed_client_betas = [
+#   "oauth-2025-04-20",
+#   "claude-code-20250219",
+#   "interleaved-thinking-2025-05-14",
+#   "fine-grained-tool-streaming-2025-05-14",
+#   "prompt-caching-2024-07-31",
+#   "context-1m*",
+# ]
+
 # Redis/Valkey URL for distributed state (multi-replica coordination).
 # When set, budget enforcement and hard-limit propagation use Redis for cross-replica sync.
 # Omit for single-instance deployments (local-only state).
@@ -101,3 +120,13 @@ token = "sk-ant-oat01-YOUR_TOKEN_HERE"
 #base_url = "https://portkey.example.dev/v1"
 #token = "your-api-key"
 #priority = 100
+
+# An anthropic-protocol endpoint whose base_url host is NOT api.anthropic.com
+# is rejected at startup — the endpoint token would be sent to that host on
+# every request, so a typo'd or tampered base_url is credential exfiltration.
+# A deliberate mirror needs the explicit opt-in:
+#[[endpoints]]
+#name = "staging-mirror"
+#base_url = "https://staging.anthropic.example"
+#token = "sk-ant-api-staging"
+#allow_nonstandard_host = true

--- a/config.toml.example
+++ b/config.toml.example
@@ -54,13 +54,15 @@ probe_interval_secs = 300
 # ("*" = suffix wildcard). Anything not listed is dropped (logged +
 # anthropic_beta_flag_dropped_total metric) — otherwise any caller could
 # activate arbitrary beta features against the operator's accounts. Omit to
-# use the built-in default (the flags Claude Code sends + context-1m*).
+# use the built-in default (the flag families Claude Code sends + context-1m*).
+# NOTE: a configured list REPLACES the default — it does not extend it. To
+# allow one extra flag, copy the defaults below and add yours:
 # allowed_client_betas = [
 #   "oauth-2025-04-20",
 #   "claude-code-20250219",
-#   "interleaved-thinking-2025-05-14",
-#   "fine-grained-tool-streaming-2025-05-14",
-#   "prompt-caching-2024-07-31",
+#   "interleaved-thinking-*",
+#   "fine-grained-tool-streaming-*",
+#   "prompt-caching-*",
 #   "context-1m*",
 # ]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4164,10 +4164,19 @@ impl AppState {
                  (a configured allowed_client_betas REPLACES the default list — \
                  include the defaults plus the flags to permit)"
             );
-        } else {
+        }
+        // The repeat subset gets its own debug line even when the same call
+        // also carried a first sighting — every dropped flag leaves a log
+        // trace on every request it was dropped from (AC-12).
+        let repeats: Vec<&str> = truncated
+            .iter()
+            .filter(|f| !first_seen.contains(f))
+            .copied()
+            .collect();
+        if !repeats.is_empty() {
             debug!(
                 client_id,
-                flags = %truncated.join(","),
+                flags = %repeats.join(","),
                 "dropped client anthropic-beta flags (previously reported)"
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,11 +108,12 @@ struct Config {
     expose_upstream_ratelimit_headers: Option<bool>,
     /// Client-supplied `anthropic-beta` flags forwarded upstream on OAuth
     /// endpoints ("*" suffix wildcards, like `endpoints[].models`). Absent =
-    /// built-in default (`DEFAULT_CLIENT_BETA_ALLOWLIST`). Flags not on the
-    /// list are dropped, logged, and counted
-    /// (`anthropic_beta_flag_dropped_total`) — otherwise any caller could
-    /// activate arbitrary beta features against the operator's accounts
-    /// (LAB-1191).
+    /// built-in default (`DEFAULT_CLIENT_BETA_ALLOWLIST`); a configured
+    /// value REPLACES that default (it does not extend it), so include the
+    /// defaults alongside any addition. Flags not on the list are dropped,
+    /// logged, and counted (`anthropic_beta_flag_dropped_total`) — otherwise
+    /// any caller could activate arbitrary beta features against the
+    /// operator's accounts (LAB-1191).
     allowed_client_betas: Option<Vec<String>>,
 }
 
@@ -557,13 +558,7 @@ impl Endpoint {
         if self.models.is_empty() || model.is_empty() {
             return true;
         }
-        self.models.iter().any(|pattern| {
-            if let Some(prefix) = pattern.strip_suffix('*') {
-                model.starts_with(prefix)
-            } else {
-                model == pattern
-            }
-        })
+        self.models.iter().any(|p| suffix_wildcard_match(p, model))
     }
 }
 
@@ -1712,15 +1707,15 @@ impl AppState {
             "anthropic-dangerous-direct-browser-access",
             HeaderValue::from_static("true"),
         );
-        // Probe headers carry only OAUTH_BETA_FLAGS (always allow-listed), so
-        // nothing can be dropped here.
-        let dropped = inject_account_auth(
+        // Probe headers carry only OAUTH_BETA_FLAGS, which the filter never
+        // drops (they are unconditionally re-added), so the returned drop
+        // list is provably empty — nothing to record.
+        let _ = inject_account_auth(
             &mut headers,
             &ep.token,
             ep.passthrough,
             &self.allowed_client_betas,
         );
-        self.record_dropped_beta_flags("probe", &dropped);
 
         let req = self.client.post(&url).headers(headers).json(&body);
 
@@ -2082,15 +2077,18 @@ const OAUTH_BETA_FLAGS: &[&str] = &["oauth-2025-04-20", "claude-code-20250219"];
 /// Default `anthropic-beta` flags a client may forward upstream on OAuth
 /// endpoints (LAB-1191 / audit finding 5). Contains the flags the LB itself
 /// depends on (`OAUTH_BETA_FLAGS`, the `context-1m*` flag the context-window
-/// accounting reads) plus the flags Claude Code sends on every request —
-/// dropping those would degrade the proxy's primary traffic. Extend via
-/// `allowed_client_betas` in config; "*" is a suffix wildcard.
+/// accounting reads) plus the flag FAMILIES Claude Code sends on every
+/// request, wildcarded on their date suffix so a Claude Code auto-update
+/// that bumps a date can't silently degrade the proxy's primary traffic.
+/// A configured `allowed_client_betas` REPLACES this list (it does not
+/// extend it) — copy these entries alongside any addition; "*" is a suffix
+/// wildcard.
 const DEFAULT_CLIENT_BETA_ALLOWLIST: &[&str] = &[
     "oauth-2025-04-20",
     "claude-code-20250219",
-    "interleaved-thinking-2025-05-14",
-    "fine-grained-tool-streaming-2025-05-14",
-    "prompt-caching-2024-07-31",
+    "interleaved-thinking-*",
+    "fine-grained-tool-streaming-*",
+    "prompt-caching-*",
     "context-1m*",
 ];
 
@@ -2098,15 +2096,25 @@ const DEFAULT_CLIENT_BETA_ALLOWLIST: &[&str] = &[
 /// client-controlled input. Past the cap, drops count under `_other`.
 const MAX_DROPPED_BETA_FLAGS: usize = 50;
 
-/// Same "*" suffix-wildcard semantics as `Endpoint::serves_model`.
+/// Length bound for a single flag key in `beta_flags_dropped` and its warn
+/// log — the value is client-controlled, and 50 multi-kilobyte keys replayed
+/// into every `/metrics` scrape is the cardinality decision's spirit broken
+/// by size instead of count.
+const MAX_DROPPED_BETA_FLAG_LEN: usize = 64;
+
+/// "*" suffix-wildcard match, shared by the model allowlist
+/// (`Endpoint::serves_model`) and the beta-flag allowlist
+/// (`beta_flag_allowed`) so the two can never drift.
+fn suffix_wildcard_match(pattern: &str, value: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        value.starts_with(prefix)
+    } else {
+        value == pattern
+    }
+}
+
 fn beta_flag_allowed(allowed: &[String], flag: &str) -> bool {
-    allowed.iter().any(|pattern| {
-        if let Some(prefix) = pattern.strip_suffix('*') {
-            flag.starts_with(prefix)
-        } else {
-            flag == pattern
-        }
-    })
+    allowed.iter().any(|p| suffix_wildcard_match(p, flag))
 }
 
 /// Legacy dynamic-capacity override threshold. If the affinity-picked account's
@@ -4112,23 +4120,37 @@ impl AppState {
     /// vanished must be diagnosable from the logs and
     /// `anthropic_beta_flag_dropped_total{flag}`). Flag names are
     /// client-controlled, so the counter map is capped at
-    /// `MAX_DROPPED_BETA_FLAGS` distinct flags; overflow counts as `_other`.
+    /// `MAX_DROPPED_BETA_FLAGS` distinct flags (overflow counts as `_other`)
+    /// and each key is truncated to `MAX_DROPPED_BETA_FLAG_LEN` bytes —
+    /// count-capped but length-unbounded keys would still bloat every
+    /// `/metrics` scrape.
     fn record_dropped_beta_flags(&self, client_id: &str, dropped: &[String]) {
         if dropped.is_empty() {
             return;
         }
+        let truncated: Vec<&str> = dropped
+            .iter()
+            .map(|f| {
+                let mut end = f.len().min(MAX_DROPPED_BETA_FLAG_LEN);
+                while !f.is_char_boundary(end) {
+                    end -= 1;
+                }
+                &f[..end]
+            })
+            .collect();
         warn!(
             client_id,
-            flags = %dropped.join(","),
+            flags = %truncated.join(","),
             "dropped client anthropic-beta flags not on the allow-list \
-             (extend allowed_client_betas in config to permit them)"
+             (a configured allowed_client_betas REPLACES the default list — \
+             include the defaults plus the flags to permit)"
         );
         let Ok(mut map) = self.beta_flags_dropped.lock() else {
             return;
         };
-        for flag in dropped {
+        for flag in truncated {
             if map.contains_key(flag) || map.len() < MAX_DROPPED_BETA_FLAGS {
-                *map.entry(flag.clone()).or_insert(0) += 1;
+                *map.entry(flag.to_string()).or_insert(0) += 1;
             } else {
                 *map.entry("_other".to_string()).or_insert(0) += 1;
             }
@@ -4548,7 +4570,11 @@ fn inject_account_auth(
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
-            if beta_flag_allowed(allowed_betas, flag) {
+            // OAUTH_BETA_FLAGS are unconditionally (re-)added below, so a
+            // client flag in that set is never actually dropped — reporting
+            // it as such (e.g. under a custom allowlist omitting them) would
+            // make the drop diagnostics lie.
+            if beta_flag_allowed(allowed_betas, flag) || OAUTH_BETA_FLAGS.contains(&flag) {
                 if !flags.iter().any(|f| f == flag) {
                     flags.push(flag.to_string());
                 }
@@ -5803,12 +5829,19 @@ fn describe_reqwest_error(e: &reqwest::Error) -> String {
 /// `Err(ForwardOutcome::Retry { .. })`. For any non-retry status (2xx
 /// success or 4xx client error) it returns `Ok(resp)` — handing the
 /// response back so the caller can continue.
+///
+/// `openai_error_shape` picks the error-body format for the terminal 3xx
+/// arm: callers whose downstream parses OpenAI errors (`/v1/chat/completions`
+/// passthrough) get `{"error":{...}}`, Anthropic-surface callers get
+/// `{"type":"error",...}` — matching how every other error arm on those
+/// paths translates per surface.
 async fn classify_retry_status(
     state: &AppState,
     status: StatusCode,
     rate_info: &RwLock<RateLimitInfo>,
     endpoint_name: &str,
     resp: reqwest::Response,
+    openai_error_shape: bool,
 ) -> Result<reqwest::Response, ForwardOutcome> {
     // 3xx → deliberate 502. The upstream client follows no redirects
     // (`Policy::none()`), because following one would re-send the account
@@ -5829,16 +5862,25 @@ async fn classify_retry_status(
             location,
             "upstream returned a redirect — refusing to follow with credentials attached"
         );
-        let body = serde_json::json!({
-            "type": "error",
-            "error": {
-                "type": "api_error",
-                "message": format!(
-                    "upstream returned {} redirect; refusing to follow with credentials",
-                    status.as_u16()
-                ),
-            }
-        })
+        let message = format!(
+            "upstream returned {} redirect; refusing to follow with credentials",
+            status.as_u16()
+        );
+        let body = if openai_error_shape {
+            serde_json::json!({
+                "error": {
+                    "message": message,
+                    "type": "api_error",
+                    "param": null,
+                    "code": null
+                }
+            })
+        } else {
+            serde_json::json!({
+                "type": "error",
+                "error": { "type": "api_error", "message": message }
+            })
+        }
         .to_string();
         return Err(ForwardOutcome::Done(
             Response::builder()
@@ -6061,22 +6103,15 @@ fn untranslatable_request_response(message: &str) -> Response {
         .into_response()
 }
 
-/// Forward one Anthropic-protocol request to a single `Endpoint`. The caller
-/// passes the picked endpoint and its pool index (used for `skip` and usage
-/// accounting).
-/// `ep` is the endpoint to forward to; `endpoint_idx` is its index in
-/// `state.endpoints`. Both are required: the streaming path spawns a
-/// detached 'static task that must re-borrow the endpoint from a cloned
-/// Arc<AppState> — a borrowed &Endpoint cannot cross the spawn boundary,
-/// so the task captures the Copy `endpoint_idx` and re-indexes.
-/// Copy the allow-listed upstream response headers onto `builder`. This is
-/// the ONLY place upstream headers are reflected to callers — everything not
-/// listed here stays behind the proxy (LAB-1191 / 2026-06-02 audit finding 3:
-/// the old copy-everything loop leaked `anthropic-ratelimit-*` — the pooled
-/// capacity of every account — plus `set-cookie` and org-identifying headers).
-/// `expose_ratelimit` (config `expose_upstream_ratelimit_headers`, trusted
-/// networks only) restores the `anthropic-ratelimit-*` passthrough for
-/// tooling that reads it.
+/// Copy the allow-listed upstream response headers onto `builder`. Everything
+/// not listed here stays behind the proxy (LAB-1191 / 2026-06-02 audit
+/// finding 3: the old copy-everything loop leaked `anthropic-ratelimit-*` —
+/// the pooled capacity of every account — plus `set-cookie` and
+/// org-identifying headers). `expose_ratelimit` (config
+/// `expose_upstream_ratelimit_headers`, trusted networks only) restores the
+/// `anthropic-ratelimit-*` passthrough for tooling that reads it. One other
+/// site reflects upstream headers: `forward_anthropic`'s body-read-failure
+/// 502 arm copies `anthropic-ratelimit-*` behind the same flag.
 fn reflect_upstream_headers(
     mut builder: axum::http::response::Builder,
     headers: &reqwest::header::HeaderMap,
@@ -6145,6 +6180,14 @@ fn body_wants_stream(body: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
+/// Forward one Anthropic-protocol request to a single `Endpoint`. The caller
+/// passes the picked endpoint and its pool index (used for `skip` and usage
+/// accounting).
+/// `ep` is the endpoint to forward to; `endpoint_idx` is its index in
+/// `state.endpoints`. Both are required: the streaming path spawns a
+/// detached 'static task that must re-borrow the endpoint from a cloned
+/// Arc<AppState> — a borrowed &Endpoint cannot cross the spawn boundary,
+/// so the task captures the Copy `endpoint_idx` and re-indexes.
 #[allow(clippy::too_many_arguments)]
 async fn forward_anthropic(
     state: &Arc<AppState>,
@@ -6309,11 +6352,11 @@ async fn forward_anthropic(
     state.update_burn_rate(&ep.burn_rate, client_id);
 
     // Classify 429 / 529 / other 5xx into a retry decision (shared helper).
-    let mut resp = match classify_retry_status(state, status, rate_info, endpoint_name, resp).await
-    {
-        Ok(resp) => resp,
-        Err(outcome) => return outcome,
-    };
+    let mut resp =
+        match classify_retry_status(state, status, rate_info, endpoint_name, resp, false).await {
+            Ok(resp) => resp,
+            Err(outcome) => return outcome,
+        };
 
     // Clear hard limit and burst counter only on a genuine 2xx success.
     // A 4xx (e.g. invalid_request_error, auth failure) is not evidence
@@ -7152,10 +7195,14 @@ async fn try_fallback_upstream(
     // it for the cooldown window, and a 529 flags the long-base BEBO backoff.
     // Previously this was a bare rotate — every subsequent request re-hammered
     // the still-rate-limited endpoint before rotating (GH #97).
-    let mut resp = match classify_retry_status(state, status, &ep.rate_info, &ep.name, resp).await {
-        Ok(resp) => resp,
-        Err(outcome) => return outcome,
-    };
+    // Downstream parses OpenAI errors on the passthrough path
+    // (translate = false); Anthropic errors when translating back.
+    let mut resp =
+        match classify_retry_status(state, status, &ep.rate_info, &ep.name, resp, !translate).await
+        {
+            Ok(resp) => resp,
+            Err(outcome) => return outcome,
+        };
 
     if !status.is_success() {
         let err_body = resp
@@ -10560,11 +10607,11 @@ async fn forward_openai_compat_anthropic(
     state.update_burn_rate(&ep.burn_rate, client_id);
 
     // Classify 429 / 529 / other 5xx into a retry decision (shared helper).
-    let mut resp = match classify_retry_status(state, status, rate_info, endpoint_name, resp).await
-    {
-        Ok(resp) => resp,
-        Err(outcome) => return outcome,
-    };
+    let mut resp =
+        match classify_retry_status(state, status, rate_info, endpoint_name, resp, true).await {
+            Ok(resp) => resp,
+            Err(outcome) => return outcome,
+        };
 
     // Clear hard limit and burst counter only on a genuine 2xx success.
     // A 4xx (e.g. invalid_request_error, auth failure) is not evidence

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,18 @@ struct Config {
     /// Opt-in encrypted response cache on `/v1/messages` (LAB-933).
     /// Absent, or present with an empty `clients` list = feature entirely inert.
     response_cache: Option<ResponseCacheConfig>,
+    /// Reflect upstream `anthropic-ratelimit-*` response headers to callers.
+    /// They reveal the pooled capacity of every account behind the proxy, so
+    /// this is trusted-network-only. Default: false (LAB-1191).
+    expose_upstream_ratelimit_headers: Option<bool>,
+    /// Client-supplied `anthropic-beta` flags forwarded upstream on OAuth
+    /// endpoints ("*" suffix wildcards, like `endpoints[].models`). Absent =
+    /// built-in default (`DEFAULT_CLIENT_BETA_ALLOWLIST`). Flags not on the
+    /// list are dropped, logged, and counted
+    /// (`anthropic_beta_flag_dropped_total`) — otherwise any caller could
+    /// activate arbitrary beta features against the operator's accounts
+    /// (LAB-1191).
+    allowed_client_betas: Option<Vec<String>>,
 }
 
 /// `[response_cache]` — opt-in, client-side-encrypted response cache on
@@ -162,6 +174,11 @@ struct EndpointConfig {
     /// demoting its priority by `overage_penalty` so included (Max) capacity
     /// drains first. Non-Fable routing is unaffected. Default: true.
     fable_included: Option<bool>,
+    /// Opt-in: allow a `protocol = "anthropic"` endpoint whose `base_url`
+    /// host is not `api.anthropic.com` (e.g. a staging mirror). Without it,
+    /// startup fails — a typo'd or tampered base_url would otherwise send the
+    /// account's OAuth/API token to an arbitrary HTTPS host. Default: false.
+    allow_nonstandard_host: Option<bool>,
 }
 
 /// Wire format on config / state: "anthropic" | "openai".
@@ -633,6 +650,17 @@ struct AppState {
     /// Count of requests shed because the body was not fully received within
     /// `body_read_timeout`. Exposed as `anthropic_body_read_timeout_total`.
     body_read_timeout_total: AtomicU64,
+    /// Reflect upstream `anthropic-ratelimit-*` headers to callers (see
+    /// `Config::expose_upstream_ratelimit_headers`). Default: false.
+    expose_upstream_ratelimit_headers: bool,
+    /// `anthropic-beta` flags a client may forward upstream on OAuth
+    /// endpoints ("*" suffix wildcards). Flags outside the list are dropped.
+    allowed_client_betas: Vec<String>,
+    /// Dropped client beta flags → drop count, for
+    /// `anthropic_beta_flag_dropped_total{flag}`. Flag names are
+    /// client-controlled input, so the map is bounded
+    /// (`MAX_DROPPED_BETA_FLAGS`); overflow lands in the `_other` bucket.
+    beta_flags_dropped: Mutex<HashMap<String, u64>>,
     /// Live session registry: affinity routing key → last-seen context-window
     /// occupancy (LAB-916). Visibility only — routing never reads it. Sync
     /// mutex, never held across `.await`; bounded by `session_registry_max`
@@ -1684,7 +1712,15 @@ impl AppState {
             "anthropic-dangerous-direct-browser-access",
             HeaderValue::from_static("true"),
         );
-        inject_account_auth(&mut headers, &ep.token, ep.passthrough);
+        // Probe headers carry only OAUTH_BETA_FLAGS (always allow-listed), so
+        // nothing can be dropped here.
+        let dropped = inject_account_auth(
+            &mut headers,
+            &ep.token,
+            ep.passthrough,
+            &self.allowed_client_betas,
+        );
+        self.record_dropped_beta_flags("probe", &dropped);
 
         let req = self.client.post(&url).headers(headers).json(&body);
 
@@ -2042,6 +2078,36 @@ const DEFAULT_MAX_INFLIGHT_BODY_BYTES: u64 = 128 * 1024 * 1024;
 /// Required OAuth beta flags. Both needed: oauth-2025-04-20 for OAuth auth,
 /// claude-code-20250219 for Claude Code API access quota routing.
 const OAUTH_BETA_FLAGS: &[&str] = &["oauth-2025-04-20", "claude-code-20250219"];
+
+/// Default `anthropic-beta` flags a client may forward upstream on OAuth
+/// endpoints (LAB-1191 / audit finding 5). Contains the flags the LB itself
+/// depends on (`OAUTH_BETA_FLAGS`, the `context-1m*` flag the context-window
+/// accounting reads) plus the flags Claude Code sends on every request —
+/// dropping those would degrade the proxy's primary traffic. Extend via
+/// `allowed_client_betas` in config; "*" is a suffix wildcard.
+const DEFAULT_CLIENT_BETA_ALLOWLIST: &[&str] = &[
+    "oauth-2025-04-20",
+    "claude-code-20250219",
+    "interleaved-thinking-2025-05-14",
+    "fine-grained-tool-streaming-2025-05-14",
+    "prompt-caching-2024-07-31",
+    "context-1m*",
+];
+
+/// Cardinality bound for `beta_flags_dropped` — flag names are
+/// client-controlled input. Past the cap, drops count under `_other`.
+const MAX_DROPPED_BETA_FLAGS: usize = 50;
+
+/// Same "*" suffix-wildcard semantics as `Endpoint::serves_model`.
+fn beta_flag_allowed(allowed: &[String], flag: &str) -> bool {
+    allowed.iter().any(|pattern| {
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            flag.starts_with(prefix)
+        } else {
+            flag == pattern
+        }
+    })
+}
 
 /// Legacy dynamic-capacity override threshold. If the affinity-picked account's
 /// weight is below 50% of the alternative, stickiness is broken immediately.
@@ -4041,6 +4107,34 @@ impl AppState {
         }
     }
 
+    /// Log + count client `anthropic-beta` flags dropped by the allow-list
+    /// (AC-12: silent stripping is not acceptable — a caller whose feature
+    /// vanished must be diagnosable from the logs and
+    /// `anthropic_beta_flag_dropped_total{flag}`). Flag names are
+    /// client-controlled, so the counter map is capped at
+    /// `MAX_DROPPED_BETA_FLAGS` distinct flags; overflow counts as `_other`.
+    fn record_dropped_beta_flags(&self, client_id: &str, dropped: &[String]) {
+        if dropped.is_empty() {
+            return;
+        }
+        warn!(
+            client_id,
+            flags = %dropped.join(","),
+            "dropped client anthropic-beta flags not on the allow-list \
+             (extend allowed_client_betas in config to permit them)"
+        );
+        let Ok(mut map) = self.beta_flags_dropped.lock() else {
+            return;
+        };
+        for flag in dropped {
+            if map.contains_key(flag) || map.len() < MAX_DROPPED_BETA_FLAGS {
+                *map.entry(flag.clone()).or_insert(0) += 1;
+            } else {
+                *map.entry("_other".to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+
     /// Flush this replica's accumulated transport-error deltas into the shared
     /// Redis hash (`TRANSPORT_ERRORS_KEY`) so the fleet-wide count is visible
     /// cluster-wide. `upstream_transport_errors` is a DELTA accumulator: it is
@@ -4415,14 +4509,23 @@ impl SseUsageScanner {
 }
 
 /// Inject account authentication headers. Handles API keys, OAuth tokens,
-/// and passthrough mode. For OAuth, merges required beta flags with any
-/// existing flags from the client.
-fn inject_account_auth(headers: &mut axum::http::HeaderMap, token: &str, passthrough: bool) {
+/// and passthrough mode. For OAuth, merges required beta flags with the
+/// client flags that survive the `allowed_betas` allow-list; the flags it
+/// dropped are returned so the caller can log and count them (LAB-1191 /
+/// audit finding 5 — an unfiltered merge let any caller activate arbitrary
+/// beta features against the operator's account).
+fn inject_account_auth(
+    headers: &mut axum::http::HeaderMap,
+    token: &str,
+    passthrough: bool,
+    allowed_betas: &[String],
+) -> Vec<String> {
     if passthrough {
-        return;
+        return Vec::new();
     }
     headers.remove("authorization");
     headers.remove("x-api-key");
+    let mut dropped: Vec<String> = Vec::new();
     if token.starts_with("sk-ant-api") {
         headers.insert("x-api-key", HeaderValue::from_str(token).unwrap());
     } else if token.starts_with("sk-ant-oat") {
@@ -4434,16 +4537,25 @@ fn inject_account_auth(headers: &mut axum::http::HeaderMap, token: &str, passthr
             "anthropic-dangerous-direct-browser-access",
             HeaderValue::from_static("true"),
         );
-        // Merge required OAuth beta flags with any existing client flags
+        // Merge required OAuth beta flags with the allow-listed client flags.
         // Use get_all to handle multiple anthropic-beta headers
-        let mut flags: Vec<String> = headers
+        let mut flags: Vec<String> = Vec::new();
+        for flag in headers
             .get_all("anthropic-beta")
             .iter()
             .filter_map(|v| v.to_str().ok())
             .flat_map(|s| s.split(','))
-            .map(|s| s.trim().to_string())
+            .map(str::trim)
             .filter(|s| !s.is_empty())
-            .collect();
+        {
+            if beta_flag_allowed(allowed_betas, flag) {
+                if !flags.iter().any(|f| f == flag) {
+                    flags.push(flag.to_string());
+                }
+            } else if !dropped.iter().any(|f| f == flag) {
+                dropped.push(flag.to_string());
+            }
+        }
         for flag in OAUTH_BETA_FLAGS {
             if !flags.iter().any(|f| f == flag) {
                 flags.push(flag.to_string());
@@ -4456,6 +4568,7 @@ fn inject_account_auth(headers: &mut axum::http::HeaderMap, token: &str, passthr
     } else {
         headers.insert("x-api-key", HeaderValue::from_str(token).unwrap());
     }
+    dropped
 }
 
 /// Client identity extracted from request headers.
@@ -5655,6 +5768,9 @@ fn describe_reqwest_error(e: &reqwest::Error) -> String {
     if e.is_request() {
         kinds.push("request");
     }
+    // With `Policy::none()` on the upstream clients a redirect is a normal
+    // 3xx *response* (handled in `classify_retry_status`), so this kind can
+    // no longer fire there — kept because this describer is generic.
     if e.is_redirect() {
         kinds.push("redirect");
     }
@@ -5694,6 +5810,47 @@ async fn classify_retry_status(
     endpoint_name: &str,
     resp: reqwest::Response,
 ) -> Result<reqwest::Response, ForwardOutcome> {
+    // 3xx → deliberate 502. The upstream client follows no redirects
+    // (`Policy::none()`), because following one would re-send the account
+    // credential to the Location host. A redirect from a configured endpoint
+    // is anomalous (misconfig or tampering), so it terminates the request
+    // with a distinct log rather than rotating — retrying other accounts
+    // against a redirecting upstream would just spray more credentialed
+    // requests at it (LAB-1191 / 2026-06-02 audit finding 2).
+    if status.is_redirection() {
+        let location = resp
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("-");
+        warn!(
+            account = endpoint_name,
+            status = status.as_u16(),
+            location,
+            "upstream returned a redirect — refusing to follow with credentials attached"
+        );
+        let body = serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "api_error",
+                "message": format!(
+                    "upstream returned {} redirect; refusing to follow with credentials",
+                    status.as_u16()
+                ),
+            }
+        })
+        .to_string();
+        return Err(ForwardOutcome::Done(
+            Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap_or_else(|_| {
+                    (StatusCode::BAD_GATEWAY, "upstream redirect refused").into_response()
+                }),
+        ));
+    }
+
     // 429 → mark hard-limited and try next account
     if status == StatusCode::TOO_MANY_REQUESTS {
         state
@@ -5912,10 +6069,49 @@ fn untranslatable_request_response(message: &str) -> Response {
 /// detached 'static task that must re-borrow the endpoint from a cloned
 /// Arc<AppState> — a borrowed &Endpoint cannot cross the spawn boundary,
 /// so the task captures the Copy `endpoint_idx` and re-indexes.
+/// Copy the allow-listed upstream response headers onto `builder`. This is
+/// the ONLY place upstream headers are reflected to callers — everything not
+/// listed here stays behind the proxy (LAB-1191 / 2026-06-02 audit finding 3:
+/// the old copy-everything loop leaked `anthropic-ratelimit-*` — the pooled
+/// capacity of every account — plus `set-cookie` and org-identifying headers).
+/// `expose_ratelimit` (config `expose_upstream_ratelimit_headers`, trusted
+/// networks only) restores the `anthropic-ratelimit-*` passthrough for
+/// tooling that reads it.
+fn reflect_upstream_headers(
+    mut builder: axum::http::response::Builder,
+    headers: &reqwest::header::HeaderMap,
+    expose_ratelimit: bool,
+) -> axum::http::response::Builder {
+    // What SDKs need to function: body framing (content-type/length),
+    // SSE cache hint, the Anthropic request id for error reports, and
+    // retry-after on forwarded 4xx.
+    const ALLOWED: &[&str] = &[
+        "content-type",
+        "content-length",
+        "cache-control",
+        "request-id",
+        "retry-after",
+    ];
+    for (k, v) in headers.iter() {
+        let name = k.as_str();
+        if ALLOWED.contains(&name) || (expose_ratelimit && name.starts_with("anthropic-ratelimit-"))
+        {
+            builder = builder.header(k, v);
+        }
+    }
+    builder
+}
+
 /// Shared knob chain for both upstream clients — `client` layers the SSE-tuned
 /// `read_timeout` on top; `client_nonstreaming` takes it as-is (LAB-718).
 fn upstream_client_builder() -> reqwest::ClientBuilder {
     Client::builder()
+        // Never follow redirects: every upstream request carries an account
+        // credential (Authorization / x-api-key), and reqwest re-sends it to
+        // the redirect target. A 3xx surfaces as a response and is turned
+        // into a deliberate 502 by `classify_retry_status` (LAB-1191 /
+        // 2026-06-02 audit finding 2).
+        .redirect(reqwest::redirect::Policy::none())
         .timeout(Duration::from_secs(900))
         // 4s (was 10): a blackholed connect fails fast so the transient
         // backoff-retry recovers in seconds. pool_idle_timeout stays 300s —
@@ -6007,7 +6203,13 @@ async fn forward_anthropic(
     }
 
     // Auth: passthrough keeps caller's headers, otherwise inject account token
-    inject_account_auth(&mut headers, token, passthrough);
+    let dropped = inject_account_auth(
+        &mut headers,
+        token,
+        passthrough,
+        &state.allowed_client_betas,
+    );
+    state.record_dropped_beta_flags(client_id, &dropped);
 
     // Debug: log outbound auth method and key headers
     if tracing::enabled!(tracing::Level::DEBUG) {
@@ -6169,16 +6371,14 @@ async fn forward_anthropic(
     let resp_status = StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
     let resp_headers = resp.headers().clone();
 
-    let mut builder = Response::builder().status(resp_status);
-    for (k, v) in resp_headers.iter() {
-        if k == "transfer-encoding" {
-            continue;
-        }
-        builder = builder.header(k, v);
-    }
+    let builder = reflect_upstream_headers(
+        Response::builder().status(resp_status),
+        &resp_headers,
+        state.expose_upstream_ratelimit_headers,
+    );
 
     // Inject budget status header
-    builder = builder.header("x-budget-status", budget_status);
+    let builder = builder.header("x-budget-status", budget_status);
 
     // Detect streaming from content-type
     let is_streaming = resp_headers
@@ -6298,17 +6498,20 @@ async fn forward_anthropic(
                     }
                 })
                 .to_string();
-                // Forward the upstream's rate-limit headers + budget status so the
-                // client's limit tracking stays consistent with the success arms.
+                // Forward the upstream's rate-limit headers (behind the same
+                // trusted-network flag as the success arms) + budget status so
+                // the client's limit tracking stays consistent.
                 // Deliberately NOT content-length: the upstream's value describes
                 // the truncated body it promised, not our short JSON frame.
                 let mut err_builder = Response::builder()
                     .status(StatusCode::BAD_GATEWAY)
                     .header("content-type", "application/json")
                     .header("x-budget-status", budget_status);
-                for (k, v) in resp_headers.iter() {
-                    if k.as_str().starts_with("anthropic-ratelimit-") {
-                        err_builder = err_builder.header(k, v);
+                if state.expose_upstream_ratelimit_headers {
+                    for (k, v) in resp_headers.iter() {
+                        if k.as_str().starts_with("anthropic-ratelimit-") {
+                            err_builder = err_builder.header(k, v);
+                        }
                     }
                 }
                 return ForwardOutcome::Done(err_builder.body(Body::from(body)).unwrap_or_else(
@@ -7926,6 +8129,12 @@ async fn metrics_handler(
         .ok()
         .map(|g| g.iter().map(|(k, v)| (k.clone(), *v)).collect())
         .unwrap_or_default();
+    let beta_flags_dropped: Vec<(String, u64)> = state
+        .beta_flags_dropped
+        .lock()
+        .ok()
+        .map(|g| g.iter().map(|(k, v)| (k.clone(), *v)).collect())
+        .unwrap_or_default();
     let (session_buckets, session_tokens_sum) = state.session_tokens_histogram(now_epoch);
 
     // ── Phase 2: Serialize (sync — no locks held) ──────────────────
@@ -8735,6 +8944,23 @@ async fn metrics_handler(
             &mut buf,
             "anthropic_prompt_too_long_total",
             &[("model", model.as_str())],
+            *n,
+        );
+    }
+
+    // Client anthropic-beta flags dropped by the allow-list (LAB-1191).
+    // Per-replica, in-memory; bounded via `_other` overflow.
+    prom_header(
+        &mut buf,
+        "anthropic_beta_flag_dropped_total",
+        "counter",
+        "Client anthropic-beta flags dropped by the allow-list",
+    );
+    for (flag, n) in &beta_flags_dropped {
+        prom_counter(
+            &mut buf,
+            "anthropic_beta_flag_dropped_total",
+            &[("flag", flag.as_str())],
             *n,
         );
     }
@@ -10255,7 +10481,13 @@ async fn forward_openai_compat_anthropic(
     headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
 
     // Auth injection
-    inject_account_auth(&mut headers, token, passthrough);
+    let dropped = inject_account_auth(
+        &mut headers,
+        token,
+        passthrough,
+        &state.allowed_client_betas,
+    );
+    state.record_dropped_beta_flags(client_id, &dropped);
 
     // Use OAuth variant (with CC system prompt) for OAuth tokens
     let req_body = if token.starts_with("sk-ant-oat") {
@@ -10901,8 +11133,9 @@ async fn openai_chat_handler(
 // ── Main ────────────────────────────────────────────────────────────
 
 /// Validate endpoint configuration. Returns the first hard error encountered.
-/// Soft warnings (non-canonical anthropic host, priority collision with an
-/// openai endpoint) are emitted as `warn!` and do not return an error.
+/// A non-canonical host on an anthropic endpoint is a hard error unless the
+/// endpoint opts in via `allow_nonstandard_host` (then it degrades to the
+/// `warn!`). Priority collision with an openai endpoint stays a soft warning.
 fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
     for ep in endpoints {
         if let Some(url) = ep.base_url.as_deref() {
@@ -10931,6 +11164,19 @@ fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
                         .ok()
                         .and_then(|u| u.host_str().map(str::to_string));
                     if host.as_deref() != Some("api.anthropic.com") {
+                        // This endpoint's token is forwarded to that host on
+                        // every request — a typo here is credential exfil, so
+                        // it must be an explicit opt-in, not a scrolled-past
+                        // warning (LAB-1191 / 2026-06-02 audit finding 1).
+                        if ep.allow_nonstandard_host != Some(true) {
+                            return Err(format!(
+                                "endpoint '{}': base_url host '{}' is not api.anthropic.com — \
+                                 the endpoint token would be sent to a non-Anthropic host. \
+                                 Set allow_nonstandard_host = true on this endpoint if intentional",
+                                ep.name,
+                                host.as_deref().unwrap_or("<unparseable>")
+                            ));
+                        }
                         warn!(
                             endpoint = ep.name,
                             base_url = url,
@@ -11310,6 +11556,16 @@ async fn main() {
         session_registry_ttl_secs: config
             .session_registry_ttl_secs
             .unwrap_or(DEFAULT_SESSION_REGISTRY_TTL_SECS),
+        expose_upstream_ratelimit_headers: config
+            .expose_upstream_ratelimit_headers
+            .unwrap_or(false),
+        allowed_client_betas: config.allowed_client_betas.clone().unwrap_or_else(|| {
+            DEFAULT_CLIENT_BETA_ALLOWLIST
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        }),
+        beta_flags_dropped: Mutex::new(HashMap::new()),
         prompt_too_long: Mutex::new(HashMap::new()),
         unsupported_models: Mutex::new(HashMap::new()),
         response_cache,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4138,22 +4138,38 @@ impl AppState {
                 &f[..end]
             })
             .collect();
-        warn!(
-            client_id,
-            flags = %truncated.join(","),
-            "dropped client anthropic-beta flags not on the allow-list \
-             (a configured allowed_client_betas REPLACES the default list — \
-             include the defaults plus the flags to permit)"
-        );
         let Ok(mut map) = self.beta_flags_dropped.lock() else {
             return;
         };
-        for flag in truncated {
-            if map.contains_key(flag) || map.len() < MAX_DROPPED_BETA_FLAGS {
+        // Loud line only on a flag's FIRST sighting — a misconfigured client
+        // sends the same unlisted flag at request rate, and the counter
+        // already carries the volume. Repeats log at debug for correlation.
+        let mut first_seen: Vec<&str> = Vec::new();
+        for flag in &truncated {
+            if map.contains_key(*flag) || map.len() < MAX_DROPPED_BETA_FLAGS {
+                if !map.contains_key(*flag) {
+                    first_seen.push(flag);
+                }
                 *map.entry(flag.to_string()).or_insert(0) += 1;
             } else {
                 *map.entry("_other".to_string()).or_insert(0) += 1;
             }
+        }
+        drop(map);
+        if !first_seen.is_empty() {
+            warn!(
+                client_id,
+                flags = %first_seen.join(","),
+                "dropped client anthropic-beta flags not on the allow-list \
+                 (a configured allowed_client_betas REPLACES the default list — \
+                 include the defaults plus the flags to permit)"
+            );
+        } else {
+            debug!(
+                client_id,
+                flags = %truncated.join(","),
+                "dropped client anthropic-beta flags (previously reported)"
+            );
         }
     }
 
@@ -6206,10 +6222,6 @@ async fn forward_anthropic(
     session_key: Option<&str>,
     request_start: std::time::Instant,
 ) -> ForwardOutcome {
-    // Context window for the session registry: 200k, or 1M when the request
-    // carries the `context-1m` beta (per-request, so a mixed client is
-    // tracked at the window each request actually ran under).
-    let context_window = context_window_for(model, request_has_1m_beta(&parts.headers));
     let token = ep.token.as_str();
     let passthrough = ep.passthrough;
     let endpoint_name = ep.name.as_str();
@@ -6253,6 +6265,14 @@ async fn forward_anthropic(
         &state.allowed_client_betas,
     );
     state.record_dropped_beta_flags(client_id, &dropped);
+
+    // Context window for the session registry: 200k, or 1M when the request
+    // carries the `context-1m` beta (per-request, so a mixed client is
+    // tracked at the window each request actually ran under). Read from the
+    // FILTERED outbound headers, not the client's raw ones — if the beta
+    // allow-list stripped `context-1m`, the upstream runs this request at
+    // 200k and the accounting must agree (PR #116 review).
+    let context_window = context_window_for(model, request_has_1m_beta(&headers));
 
     // Debug: log outbound auth method and key headers
     if tracing::enabled!(tracing::Level::DEBUG) {
@@ -10504,10 +10524,6 @@ async fn forward_openai_compat_anthropic(
     json_mode: bool,
     request_start: std::time::Instant,
 ) -> ForwardOutcome {
-    // Session registry window (LAB-916). OpenAI-compat callers can't send the
-    // `context-1m` beta through translation, but check anyway — the header is
-    // forwarded when present.
-    let context_window = context_window_for(model, request_has_1m_beta(&parts.headers));
     let token = ep.token.as_str();
     let passthrough = ep.passthrough;
     let endpoint_name = ep.name.as_str();
@@ -10535,6 +10551,13 @@ async fn forward_openai_compat_anthropic(
         &state.allowed_client_betas,
     );
     state.record_dropped_beta_flags(client_id, &dropped);
+
+    // Session registry window (LAB-916). OpenAI-compat callers can't send the
+    // `context-1m` beta through translation, but check anyway — the header is
+    // forwarded when present. Read from the FILTERED outbound headers so the
+    // accounting matches what the upstream actually ran under (PR #116
+    // review), same as forward_anthropic.
+    let context_window = context_window_for(model, request_has_1m_beta(&headers));
 
     // Use OAuth variant (with CC system prompt) for OAuth tokens
     let req_body = if token.starts_with("sk-ant-oat") {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16196,3 +16196,68 @@ async fn upstream_redirect_becomes_openai_shaped_502_on_chat_completions() {
     );
     assert_eq!(target_hits.load(Ordering::SeqCst), 0);
 }
+
+/// PR #116 review (Kody + CodeRabbit): the 1M-context accounting must read
+/// the FILTERED outbound headers. If a custom allow-list strips
+/// `context-1m`, the upstream runs the request at 200k — recording the
+/// session at 1M would inflate /_stats occupancy.
+#[test]
+fn stripped_context_1m_flag_is_invisible_to_accounting() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_static("context-1m-2025-08-07"),
+    );
+    // Custom allow-list that omits context-1m*.
+    let restrictive = vec!["oauth-2025-04-20".to_string()];
+    let dropped = inject_account_auth(&mut headers, "sk-ant-oat01-test", false, &restrictive);
+    assert_eq!(dropped, vec!["context-1m-2025-08-07".to_string()]);
+    assert!(
+        !request_has_1m_beta(&headers),
+        "post-filter headers must not carry the stripped 1M flag"
+    );
+}
+
+/// Same defect end-to-end: with a restrictive allow-list, a request carrying
+/// the 1M beta must be registered in the session registry at the 200k window
+/// the upstream actually ran under — not at 1M.
+#[tokio::test]
+async fn session_registry_window_matches_filtered_beta() {
+    // Raw-TCP mock: its canned body carries `usage`, which session
+    // registration requires (the axum mock's body has none).
+    let (upstream_url, _hits) = spawn_flaky_upstream(0, ANTHROPIC_OK_BODY).await;
+    let mut state = test_state_with(vec![mk_endpoint_at(
+        "acct-a",
+        "sk-ant-oat01-test-aaa",
+        &upstream_url,
+    )]);
+    Arc::get_mut(&mut state)
+        .expect("test fixture should be uniquely owned")
+        .allowed_client_betas = vec!["oauth-2025-04-20".to_string()];
+    let sessions_state = state.clone();
+    let addr = serve(build_router(state)).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-session-id", "sess-1m-strip")
+        .header("anthropic-beta", "context-1m-2025-08-07")
+        .body(r#"{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let windows: Vec<u64> = sessions_state
+        .sessions
+        .lock()
+        .unwrap()
+        .values()
+        .map(|s| s.context_window)
+        .collect();
+    assert_eq!(
+        windows,
+        vec![DEFAULT_CONTEXT_WINDOW],
+        "session must be tracked at the window the upstream ran (flag was stripped)"
+    );
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16091,14 +16091,12 @@ fn dropped_beta_flag_counter_is_bounded() {
 #[tokio::test]
 async fn dropped_beta_flag_appears_in_metrics() {
     let (upstream_url, _handle) = spawn_mock_upstream().await;
-    let mut state = test_state_with(vec![mk_endpoint_at(
+    // test_state_base already carries the default allow-list.
+    let state = test_state_with(vec![mk_endpoint_at(
         "acct-a",
         "sk-ant-oat01-test-aaa",
         &upstream_url,
     )]);
-    Arc::get_mut(&mut state)
-        .expect("test fixture should be uniquely owned")
-        .allowed_client_betas = default_betas();
     let addr = serve(build_router(state)).await;
 
     let resp = reqwest::Client::new()
@@ -16124,4 +16122,77 @@ async fn dropped_beta_flag_appears_in_metrics() {
             .contains("anthropic_beta_flag_dropped_total{flag=\"totally-unknown-2026-07-30\"} 1"),
         "metrics must report the dropped flag"
     );
+}
+
+/// Panel follow-up (LAB-1191): a client flag that IS one of the required
+/// OAUTH_BETA_FLAGS is always forwarded (the merge re-adds it), so it must
+/// never be reported as dropped — even under a custom allow-list that
+/// omits it. A false drop here would make the diagnostics lie.
+#[test]
+fn oauth_beta_filter_never_reports_required_flags_as_dropped() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_static("oauth-2025-04-20,claude-code-20250219"),
+    );
+    // Custom allow-list omitting the OAuth flags entirely.
+    let restrictive = vec!["context-1m*".to_string()];
+    let dropped = inject_account_auth(&mut headers, "sk-ant-oat01-test", false, &restrictive);
+    assert!(
+        dropped.is_empty(),
+        "required OAuth flags are always sent — reporting them dropped is a lie: {dropped:?}"
+    );
+    let sent = headers.get("anthropic-beta").unwrap().to_str().unwrap();
+    for flag in OAUTH_BETA_FLAGS {
+        assert!(sent.contains(flag));
+    }
+}
+
+/// Panel follow-up (LAB-1191): dropped-flag keys are length-bounded before
+/// logging/counting — a multi-kilobyte client "flag" must not be pinned
+/// verbatim into every /metrics scrape.
+#[test]
+fn dropped_beta_flag_keys_are_length_bounded() {
+    let state = test_state_with(vec![]);
+    let huge = "x".repeat(5000);
+    state.record_dropped_beta_flags("t", &[huge]);
+    let map = state.beta_flags_dropped.lock().unwrap();
+    let key = map.keys().next().unwrap();
+    assert!(
+        key.len() <= MAX_DROPPED_BETA_FLAG_LEN,
+        "key must be truncated, got {} bytes",
+        key.len()
+    );
+}
+
+/// Panel follow-up (LAB-1191 AC-5): on the OpenAI-compat surface an upstream
+/// 3xx must surface as a 502 in the OPENAI error shape — those clients'
+/// parsers cannot read an Anthropic error envelope.
+#[tokio::test]
+async fn upstream_redirect_becomes_openai_shaped_502_on_chat_completions() {
+    use std::sync::atomic::Ordering;
+    let (target_url, target_hits) = spawn_flaky_upstream(0, ANTHROPIC_OK_BODY).await;
+    let redirecting = spawn_redirecting_upstream(target_url).await;
+
+    let state = test_state_with(vec![mk_endpoint_at("a", "sk-ant-oat01-aaa", &redirecting)]);
+    let addr = serve(build_router(state)).await;
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/chat/completions"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_GATEWAY);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body.get("error").and_then(|e| e.get("message")).is_some(),
+        "OpenAI-surface 502 must be OpenAI-shaped: {body}"
+    );
+    assert!(
+        body.get("type").is_none(),
+        "must not be the Anthropic error envelope: {body}"
+    );
+    assert_eq!(target_hits.load(Ordering::SeqCst), 0);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -148,7 +148,9 @@ token = "sk-ant-test"
 }
 
 #[test]
-fn validate_endpoints_warns_on_non_anthropic_host() {
+fn validate_endpoints_rejects_non_anthropic_host() {
+    // LAB-1191 AC-1: a non-canonical host on an anthropic endpoint would send
+    // the account token to that host — hard startup error naming the endpoint.
     let endpoints = vec![EndpointConfig {
         name: "primary".to_string(),
         protocol: Protocol::Anthropic,
@@ -157,6 +159,65 @@ fn validate_endpoints_warns_on_non_anthropic_host() {
         models: vec![],
         priority: 0,
         fable_included: None,
+        allow_nonstandard_host: None,
+    }];
+    let err = validate_endpoints(&endpoints).unwrap_err();
+    assert!(
+        err.contains("primary"),
+        "error must name the endpoint: {err}"
+    );
+    assert!(
+        err.contains("allow_nonstandard_host"),
+        "error must name the opt-out: {err}"
+    );
+}
+
+#[test]
+fn validate_endpoints_allows_non_anthropic_host_with_opt_in() {
+    // LAB-1191 AC-2: explicit opt-in keeps the old warn-only behaviour.
+    let endpoints = vec![EndpointConfig {
+        name: "staging".to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: Some("https://staging.anthropic.example".to_string()),
+        token: "sk-ant".to_string(),
+        models: vec![],
+        priority: 0,
+        fable_included: None,
+        allow_nonstandard_host: Some(true),
+    }];
+    assert!(validate_endpoints(&endpoints).is_ok());
+}
+
+#[test]
+fn validate_endpoints_rejects_lookalike_anthropic_host() {
+    // LAB-1191 AC-3: exact-host comparison — a canonical-prefix lookalike
+    // domain must NOT pass as canonical.
+    let endpoints = vec![EndpointConfig {
+        name: "evil".to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: Some("https://api.anthropic.com.evil.example".to_string()),
+        token: "sk-ant".to_string(),
+        models: vec![],
+        priority: 0,
+        fable_included: None,
+        allow_nonstandard_host: None,
+    }];
+    let err = validate_endpoints(&endpoints).unwrap_err();
+    assert!(err.contains("evil"));
+}
+
+#[test]
+fn validate_endpoints_accepts_canonical_anthropic_host() {
+    // LAB-1191 AC-3: the canonical host boots without opt-in.
+    let endpoints = vec![EndpointConfig {
+        name: "primary".to_string(),
+        protocol: Protocol::Anthropic,
+        base_url: Some("https://api.anthropic.com".to_string()),
+        token: "sk-ant".to_string(),
+        models: vec![],
+        priority: 0,
+        fable_included: None,
+        allow_nonstandard_host: None,
     }];
     assert!(validate_endpoints(&endpoints).is_ok());
 }
@@ -171,6 +232,7 @@ fn validate_endpoints_rejects_http_base_url() {
         models: vec![],
         priority: 0,
         fable_included: None,
+        allow_nonstandard_host: None,
     }];
     let err = validate_endpoints(&endpoints).unwrap_err();
     assert!(err.contains("https"), "error must mention https: {err}");
@@ -187,6 +249,7 @@ fn validate_endpoints_requires_base_url_for_openai() {
         models: vec![],
         priority: 100,
         fable_included: None,
+        allow_nonstandard_host: None,
     }];
     let err = validate_endpoints(&endpoints).unwrap_err();
     assert!(err.contains("base_url"));
@@ -204,6 +267,7 @@ fn validate_endpoints_accepts_well_formed_mix() {
             models: vec![],
             priority: 0,
             fable_included: None,
+            allow_nonstandard_host: None,
         },
         EndpointConfig {
             name: "gateway".to_string(),
@@ -213,6 +277,7 @@ fn validate_endpoints_accepts_well_formed_mix() {
             models: vec![],
             priority: 100,
             fable_included: None,
+            allow_nonstandard_host: None,
         },
     ];
     assert!(validate_endpoints(&endpoints).is_ok());
@@ -293,11 +358,13 @@ fn make_endpoint(name: &str, protocol: Protocol) -> Endpoint {
 /// production's 0.90.
 fn test_state_base() -> AppState {
     AppState {
-        client: Client::builder()
+        // Production knob chain (incl. redirect Policy::none — LAB-1191) with
+        // a short test timeout layered on top.
+        client: upstream_client_builder()
             .timeout(Duration::from_secs(5))
             .build()
             .unwrap(),
-        client_nonstreaming: Client::builder()
+        client_nonstreaming: upstream_client_builder()
             .timeout(Duration::from_secs(5))
             .build()
             .unwrap(),
@@ -337,6 +404,12 @@ fn test_state_base() -> AppState {
         sessions: Mutex::new(HashMap::new()),
         session_registry_max: DEFAULT_SESSION_REGISTRY_MAX,
         session_registry_ttl_secs: DEFAULT_SESSION_REGISTRY_TTL_SECS,
+        expose_upstream_ratelimit_headers: false,
+        allowed_client_betas: DEFAULT_CLIENT_BETA_ALLOWLIST
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        beta_flags_dropped: Mutex::new(HashMap::new()),
         prompt_too_long: Mutex::new(HashMap::new()),
         unsupported_models: Mutex::new(HashMap::new()),
         response_cache: None,
@@ -423,6 +496,18 @@ async fn mock_upstream_handler(req: Request<Body>) -> Response {
         "anthropic-ratelimit-unified-5h-reset",
         HeaderValue::from_str(&reset_epoch).unwrap(),
     );
+    // Headers a real upstream may attach that must NOT reach the caller by
+    // default (LAB-1191 finding 3) + one allow-listed header that must.
+    headers.insert(
+        "anthropic-ratelimit-unified-5h-status",
+        HeaderValue::from_static("allowed"),
+    );
+    headers.insert("set-cookie", HeaderValue::from_static("upstream=leak"));
+    headers.insert(
+        "anthropic-organization-id",
+        HeaderValue::from_static("org-secret"),
+    );
+    headers.insert("request-id", HeaderValue::from_static("req_mock_123"));
     resp
 }
 
@@ -2154,10 +2239,26 @@ async fn proxy_returns_502_when_upstream_body_read_fails() {
         }
     });
 
-    let (app, _state) = test_app(
-        &format!("http://{}", mock_addr),
-        Some("secret-key".to_string()),
-    );
+    // Ratelimit reflection is opt-in since LAB-1191; this test asserts the
+    // error-arm parity that the opt-in restores, so flip it on.
+    let mut state = test_state_with(vec![
+        mk_endpoint_at(
+            "acct-a",
+            "sk-ant-api-test-aaa",
+            &format!("http://{}", mock_addr),
+        ),
+        mk_endpoint_at(
+            "acct-b",
+            "sk-ant-api-test-bbb",
+            &format!("http://{}", mock_addr),
+        ),
+    ]);
+    {
+        let s = Arc::get_mut(&mut state).expect("test fixture should be uniquely owned");
+        s.proxy_key = Some("secret-key".to_string());
+        s.expose_upstream_ratelimit_headers = true;
+    }
+    let app = build_router(state);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -2184,15 +2285,16 @@ async fn proxy_returns_502_when_upstream_body_read_fails() {
         reqwest::StatusCode::BAD_GATEWAY,
         "truncated upstream body must become a 502, not a silent empty 200"
     );
-    // The 502 must still forward the upstream's rate-limit headers (and the
-    // budget status) so the client's limit tracking doesn't go blind on the
-    // error arm — parity with every success arm.
+    // With expose_upstream_ratelimit_headers = true, the 502 must still
+    // forward the upstream's rate-limit headers (and the budget status) so
+    // the client's limit tracking doesn't go blind on the error arm — parity
+    // with every success arm.
     assert_eq!(
         resp.headers()
             .get("anthropic-ratelimit-unified-5h-utilization")
             .and_then(|v| v.to_str().ok()),
         Some("0.42"),
-        "502 should forward upstream anthropic-ratelimit-* headers"
+        "502 should forward upstream anthropic-ratelimit-* headers when exposed"
     );
     assert!(
         resp.headers().contains_key("x-budget-status"),
@@ -13616,7 +13718,7 @@ async fn openai_compat_translates_upstream_raw_error() {
 fn inject_auth_api_key() {
     let mut headers = axum::http::HeaderMap::new();
     headers.insert("authorization", HeaderValue::from_static("Bearer old"));
-    inject_account_auth(&mut headers, "sk-ant-api-test123", false);
+    inject_account_auth(&mut headers, "sk-ant-api-test123", false, &default_betas());
     assert_eq!(headers.get("x-api-key").unwrap(), "sk-ant-api-test123");
     assert!(headers.get("authorization").is_none());
 }
@@ -13624,7 +13726,7 @@ fn inject_auth_api_key() {
 #[test]
 fn inject_auth_oauth_token() {
     let mut headers = axum::http::HeaderMap::new();
-    inject_account_auth(&mut headers, "sk-ant-oat-test123", false);
+    inject_account_auth(&mut headers, "sk-ant-oat-test123", false, &default_betas());
     assert_eq!(
         headers.get("authorization").unwrap(),
         "Bearer sk-ant-oat-test123"
@@ -13642,17 +13744,25 @@ fn inject_auth_oauth_token() {
 
 #[test]
 fn inject_auth_oauth_merges_multi_value_beta() {
+    // Allow-listed flags split across TWO header values (LAB-1191: unlisted
+    // flags are dropped, so the merge is exercised with allowed ones).
     let mut headers = axum::http::HeaderMap::new();
-    headers.append("anthropic-beta", HeaderValue::from_static("existing-flag"));
-    headers.append("anthropic-beta", HeaderValue::from_static("another-flag"));
-    inject_account_auth(&mut headers, "sk-ant-oat-test123", false);
+    headers.append(
+        "anthropic-beta",
+        HeaderValue::from_static("interleaved-thinking-2025-05-14"),
+    );
+    headers.append(
+        "anthropic-beta",
+        HeaderValue::from_static("fine-grained-tool-streaming-2025-05-14"),
+    );
+    inject_account_auth(&mut headers, "sk-ant-oat-test123", false, &default_betas());
     let beta = headers.get("anthropic-beta").unwrap().to_str().unwrap();
     assert!(
-        beta.contains("existing-flag"),
+        beta.contains("interleaved-thinking-2025-05-14"),
         "should preserve first header"
     );
     assert!(
-        beta.contains("another-flag"),
+        beta.contains("fine-grained-tool-streaming-2025-05-14"),
         "should preserve second header"
     );
     assert!(beta.contains("oauth-2025-04-20"), "should add oauth flag");
@@ -13667,7 +13777,7 @@ fn inject_auth_passthrough_preserves_headers() {
         HeaderValue::from_static("Bearer user-token"),
     );
     headers.insert("x-api-key", HeaderValue::from_static("user-key"));
-    inject_account_auth(&mut headers, "passthrough", true);
+    inject_account_auth(&mut headers, "passthrough", true, &default_betas());
     assert_eq!(headers.get("authorization").unwrap(), "Bearer user-token");
     assert_eq!(headers.get("x-api-key").unwrap(), "user-key");
 }
@@ -15725,5 +15835,293 @@ async fn response_cache_skips_oversized_bodies() {
             .stores
             .load(Ordering::Relaxed),
         1
+    );
+}
+
+// ── LAB-1191: token-exfil audit findings (redirects, header reflection,
+//    client beta flags) ────────────────────────────────────────────────
+
+/// Raw-TCP upstream that answers every request with a 302 to `target`.
+async fn spawn_redirecting_upstream(target: String) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let target = target.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 8192];
+                let _ = sock.read(&mut buf).await;
+                let resp = format!(
+                    "HTTP/1.1 302 Found\r\nlocation: {target}/v1/messages\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.flush().await;
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+/// AC-4/5/6: a 3xx from upstream must NOT be followed (the follow-up request
+/// would re-send the account credential to the Location host) and must
+/// surface as a deliberate 502, not a forwarded 302 or an endless retry.
+#[tokio::test]
+async fn upstream_redirect_not_followed_and_becomes_502() {
+    use std::sync::atomic::Ordering;
+    // The redirect target counts every connection it receives — with
+    // Policy::none() it must stay at zero.
+    let (target_url, target_hits) = spawn_flaky_upstream(0, ANTHROPIC_OK_BODY).await;
+    let redirecting = spawn_redirecting_upstream(target_url).await;
+
+    let state = test_state_with(vec![mk_endpoint_at("a", "sk-ant-api-aaa", &redirecting)]);
+    let addr = serve(build_router(state)).await;
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_GATEWAY,
+        "upstream 3xx must become a deliberate 502"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("redirect"), "502 body must say why: {body}");
+    assert_eq!(
+        target_hits.load(Ordering::SeqCst),
+        0,
+        "no request may follow the redirect with credentials attached"
+    );
+}
+
+/// AC-7/AC-10: by default the caller must not see the upstream's rate-limit
+/// capacity, cookies, or org identity — only the allow-listed headers.
+#[tokio::test]
+async fn upstream_headers_stripped_by_default() {
+    let (upstream_url, _handle) = spawn_mock_upstream().await;
+    let (app, _state) = test_app(&upstream_url, None);
+    let addr = serve(app).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    for leaked in [
+        "anthropic-ratelimit-unified-5h-utilization",
+        "anthropic-ratelimit-unified-5h-status",
+        "set-cookie",
+        "anthropic-organization-id",
+    ] {
+        assert!(
+            !resp.headers().contains_key(leaked),
+            "{leaked} must not be reflected by default"
+        );
+    }
+    // Allow-listed headers still flow.
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/json"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("request-id")
+            .and_then(|v| v.to_str().ok()),
+        Some("req_mock_123"),
+        "request-id is allow-listed for SDK error reports"
+    );
+    assert!(resp.headers().contains_key("x-budget-status"));
+}
+
+/// AC-8/AC-10: expose_upstream_ratelimit_headers = true restores the
+/// anthropic-ratelimit-* passthrough (trusted networks) — and ONLY that:
+/// cookies and org identity stay stripped.
+#[tokio::test]
+async fn upstream_ratelimit_headers_reflected_with_flag() {
+    let (upstream_url, _handle) = spawn_mock_upstream().await;
+    let mut state = test_state_with(vec![mk_endpoint_at(
+        "acct-a",
+        "sk-ant-api-test-aaa",
+        &upstream_url,
+    )]);
+    Arc::get_mut(&mut state)
+        .expect("test fixture should be uniquely owned")
+        .expose_upstream_ratelimit_headers = true;
+    let addr = serve(build_router(state)).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .body(r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get("anthropic-ratelimit-unified-5h-utilization")
+            .and_then(|v| v.to_str().ok()),
+        Some("0.25"),
+        "flag must restore anthropic-ratelimit-* passthrough"
+    );
+    assert!(
+        !resp.headers().contains_key("set-cookie"),
+        "set-cookie stays stripped even with the ratelimit flag on"
+    );
+    assert!(
+        !resp.headers().contains_key("anthropic-organization-id"),
+        "org identity stays stripped even with the ratelimit flag on"
+    );
+}
+
+fn default_betas() -> Vec<String> {
+    DEFAULT_CLIENT_BETA_ALLOWLIST
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// AC-11/AC-13: an unknown client beta flag is dropped from the forwarded
+/// header and reported back; the LB's own OAuth flags are still appended.
+#[test]
+fn oauth_beta_filter_drops_unknown_flags() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_static("evil-feature-2026-01-01,interleaved-thinking-2025-05-14"),
+    );
+    let dropped = inject_account_auth(&mut headers, "sk-ant-oat01-test", false, &default_betas());
+    assert_eq!(dropped, vec!["evil-feature-2026-01-01".to_string()]);
+    let sent = headers.get("anthropic-beta").unwrap().to_str().unwrap();
+    assert!(
+        !sent.contains("evil-feature-2026-01-01"),
+        "unknown flag must not be forwarded: {sent}"
+    );
+    assert!(sent.contains("interleaved-thinking-2025-05-14"));
+    for flag in OAUTH_BETA_FLAGS {
+        assert!(sent.contains(flag), "required OAuth flag missing: {flag}");
+    }
+}
+
+/// AC-13: every default-allowed flag survives the filter, including the
+/// wildcard-matched 1M-context flag — and 1M detection still fires on the
+/// filtered header map.
+#[test]
+fn oauth_beta_filter_keeps_default_allowed_flags() {
+    let client_flags = [
+        "oauth-2025-04-20",
+        "claude-code-20250219",
+        "interleaved-thinking-2025-05-14",
+        "fine-grained-tool-streaming-2025-05-14",
+        "prompt-caching-2024-07-31",
+        "context-1m-2025-08-07",
+    ];
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_str(&client_flags.join(",")).unwrap(),
+    );
+    let dropped = inject_account_auth(&mut headers, "sk-ant-oat01-test", false, &default_betas());
+    assert!(dropped.is_empty(), "nothing should be dropped: {dropped:?}");
+    let sent = headers.get("anthropic-beta").unwrap().to_str().unwrap();
+    for flag in client_flags {
+        assert!(sent.contains(flag), "allowed flag missing: {flag}");
+    }
+    assert!(
+        request_has_1m_beta(&headers),
+        "1M-context detection must still fire after filtering"
+    );
+}
+
+/// AC-13: passthrough endpoints return early — caller headers untouched,
+/// nothing dropped.
+#[test]
+fn oauth_beta_filter_passthrough_unchanged() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert("authorization", HeaderValue::from_static("Bearer caller"));
+    headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_static("anything-goes-2026"),
+    );
+    let dropped = inject_account_auth(&mut headers, "passthrough", true, &default_betas());
+    assert!(dropped.is_empty());
+    assert_eq!(
+        headers.get("authorization").unwrap(),
+        "Bearer caller",
+        "passthrough must not touch caller auth"
+    );
+    assert_eq!(
+        headers.get("anthropic-beta").unwrap(),
+        "anything-goes-2026",
+        "passthrough must not filter caller betas"
+    );
+}
+
+/// AC-12: dropped flags land in the bounded counter map; past the cap they
+/// fold into `_other` instead of growing per-client-controlled cardinality.
+#[test]
+fn dropped_beta_flag_counter_is_bounded() {
+    let state = test_state_with(vec![]);
+    for i in 0..(MAX_DROPPED_BETA_FLAGS + 10) {
+        state.record_dropped_beta_flags("t", &[format!("flag-{i}")]);
+    }
+    let map = state.beta_flags_dropped.lock().unwrap();
+    assert_eq!(map.len(), MAX_DROPPED_BETA_FLAGS + 1, "cap + _other bucket");
+    assert_eq!(map.get("_other"), Some(&10u64));
+    drop(map);
+    // Existing keys keep counting past the cap.
+    state.record_dropped_beta_flags("t", &["flag-0".to_string()]);
+    assert_eq!(
+        state.beta_flags_dropped.lock().unwrap().get("flag-0"),
+        Some(&2u64)
+    );
+}
+
+/// AC-12/AC-13 end-to-end: a request carrying an unknown beta flag is served,
+/// the flag never reaches the upstream, and /metrics reports the drop.
+#[tokio::test]
+async fn dropped_beta_flag_appears_in_metrics() {
+    let (upstream_url, _handle) = spawn_mock_upstream().await;
+    let mut state = test_state_with(vec![mk_endpoint_at(
+        "acct-a",
+        "sk-ant-oat01-test-aaa",
+        &upstream_url,
+    )]);
+    Arc::get_mut(&mut state)
+        .expect("test fixture should be uniquely owned")
+        .allowed_client_betas = default_betas();
+    let addr = serve(build_router(state)).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("anthropic-beta", "totally-unknown-2026-07-30")
+        .body(r#"{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let metrics = reqwest::Client::new()
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        metrics
+            .contains("anthropic_beta_flag_dropped_total{flag=\"totally-unknown-2026-07-30\"} 1"),
+        "metrics must report the dropped flag"
     );
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR closes four token-exfiltration audit findings (LAB-1191, 2026-06-02 audit) by hardening the credential paths that a request can steer. Since the proxy forwards operator OAuth/API tokens upstream, each of these findings addressed a way that credentials or account information could leak to an unintended destination.

## Changes

### 1. Endpoint host pinning (audit finding 1)
An `anthropic`-protocol endpoint whose `base_url` host is not `api.anthropic.com` now **fails startup validation** instead of only emitting a warning. A typo'd or tampered URL would otherwise ship the account token to that host on every request. Operators can opt in per endpoint with `allow_nonstandard_host = true` for deliberate mirrors (e.g. staging). Host comparison is exact, so lookalike domains (`api.anthropic.com.evil.example`) are rejected.

### 2. Redirects are never followed (audit finding 2)
The upstream HTTP client now uses `redirect::Policy::none()`. A `3xx` response is turned into a deliberate `502` with a distinct log line rather than re-sending credentials to the `Location` target. The error is shaped per surface — OpenAI-compat callers get `{"error":{...}}`, Anthropic-surface callers get `{"type":"error",...}`.

### 3. Response headers are allow-listed (audit finding 3)
The previous copy-everything header loop leaked `anthropic-ratelimit-*` (pooled capacity of every account), `set-cookie`, and org-identifying headers to callers. Now only `content-type`, `content-length`, `cache-control`, `request-id`, and `retry-after` are reflected (plus the proxy's own `x-budget-status`). A new `expose_upstream_ratelimit_headers` config option (default `false`) restores the ratelimit passthrough for trusted networks — and only that, cookies and org identity stay stripped.

### 4. Client beta flags are allow-listed (audit finding 5)
On OAuth endpoints, client-supplied `anthropic-beta` flags outside `allowed_client_betas` are now dropped before forwarding, preventing callers from activating arbitrary beta features against the operator's accounts. Dropped flags are logged at `warn` and counted in the new `anthropic_beta_flag_dropped_total{flag}` metric. A built-in default allow-list covers the flags the LB depends on plus the flag families Claude Code sends (wildcarded on date suffix); a configured list **replaces** the default rather than extending it. The counter map is bounded (`MAX_DROPPED_BETA_FLAGS`, overflow into `_other`) and keys are length-truncated, since flag names are client-controlled input.

## Supporting changes
- Extracted a shared `suffix_wildcard_match` helper so the model allowlist and beta-flag allowlist can't drift.
- `inject_account_auth` now returns the list of dropped flags; required `OAUTH_BETA_FLAGS` are never reported as dropped (they're always re-added).
- Documentation added across `README.md`, `CLAUDE.md`, and `config.toml.example` describing the new config options and the credential-path hardening.
- Comprehensive test coverage for all four findings, including redirect handling on both surfaces, header stripping/reflection, beta-flag filtering, counter bounds, and end-to-end metrics reporting.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controls for forwarding Anthropic rate-limit headers and filtering forwarded client beta flags.
  - Added explicit opt-in for Anthropic endpoints using non-standard hosts.
  - Added metrics and diagnostics for dropped beta flags.

- **Bug Fixes**
  - Upstream redirects are no longer followed and now return a clear `502`.
  - Restricted exposed upstream response headers, including reflected rate-limit headers.

- **Documentation**
  - Updated configuration references, security guidance, and the example configuration with the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->