### PR TITLE
LAB-929: route count_tokens through the existing response cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,12 +516,15 @@ When Redis is connected, `/_stats` includes a `cluster` section with replica cou
 
 ## Response Cache (opt-in, encrypted)
 
-An **opt-in** response cache for non-streaming `POST /v1/messages`. When an
-allow-listed client replays a byte-identical request, the previous response is
-served from cache — **the upstream call is skipped entirely, so a hit burns
-zero 5h/7d rate-limit headroom and does not count against the client's daily
-token budget**. That is the point: eval reruns, pipeline replays, and retries
-after client-side timeouts stop costing quota.
+An **opt-in** response cache for non-streaming `POST /v1/messages` and
+`POST /v1/messages/count_tokens`. When an allow-listed client replays a
+byte-identical request, the previous response is served from cache — **the
+upstream call is skipped entirely, so a hit burns zero 5h/7d rate-limit
+headroom and does not count against the client's daily token budget**. That
+is the point: eval reruns, pipeline replays, and retries after client-side
+timeouts stop costing quota. The two endpoints share one allow-list and key
+scheme but never cross-serve — the cache key folds in which endpoint a
+request came in on, so a body sent to both never gets the wrong one back.
 
 **Default-off.** Without a `[response_cache]` section — or with an empty
 `clients` list — behavior is byte-identical to a build without the feature.
@@ -550,9 +553,9 @@ master_key = "…64 hex chars…"
 ```
 
 **What is cached:** the full response body (status + content-type + JSON body)
-of **2xx, non-streaming** `/v1/messages` responses. Streaming (`"stream": true`)
-requests always bypass the cache, as do non-JSON responses and bodies over
-1 MiB. Error responses are never cached.
+of **2xx, non-streaming** `/v1/messages` and `/v1/messages/count_tokens`
+responses. Streaming (`"stream": true`) requests always bypass the cache, as
+do non-JSON responses and bodies over 1 MiB. Error responses are never cached.
 
 **Where it lands, and what the backend can read:** entries are encrypted
 **client-side** (in the proxy process) with AES-256-GCM before touching any
@@ -560,8 +563,8 @@ storage layer — the in-process L1, local Redis, or cachekit.io only ever hold
 **ciphertext**. Per-client keys are derived from `master_key` via HKDF with the
 client ID as tenant, so two clients sending identical prompts get separate,
 mutually-undecryptable entries. Cache keys are content digests (Blake2s-256 of
-model + canonical body + beta headers + client ID) — no prompt text appears in
-keys, logs, or metrics.
+model + canonical body + beta headers + client ID + endpoint) — no prompt text
+appears in keys, logs, or metrics.
 
 **How a hit looks:** identical response body, plus an `x-alb-cache: hit`
 header. Upstream per-request headers (request IDs, rate-limit snapshots) are
@@ -570,8 +573,9 @@ not replayed — they described the original exchange.
 **Fail-open:** a slow, dead, or misconfigured cache backend never blocks a
 request. Every cache operation is bounded by `op_timeout_ms`; on any error the
 request proceeds upstream exactly as if the cache did not exist. Hit / miss /
-store / error counters are exposed on `/metrics`
-(`anthropic_response_cache_*_total{surface="messages"}`).
+store / error counters are exposed on `/metrics`, one series per endpoint
+(`anthropic_response_cache_*_total{surface="messages"}` and
+`{surface="count_tokens"}`).
 
 > [!WARNING]
 > **Allow-listed clients must mutually trust each other.** Client identity is

--- a/src/main.rs
+++ b/src/main.rs
@@ -976,6 +976,26 @@ struct CachedResponse {
     body: Vec<u8>,
 }
 
+/// Which endpoint a response-cache entry belongs to (LAB-929). Folded into
+/// the cache key itself (not just the metric label) so a client that sends
+/// byte-identical bodies to `/v1/messages` and `/v1/messages/count_tokens`
+/// (a common pattern — count before you send) can never have one surface's
+/// cached entry served back for the other.
+#[derive(Clone, Copy)]
+enum CacheSurface {
+    Messages,
+    CountTokens,
+}
+
+impl CacheSurface {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Messages => "messages",
+            Self::CountTokens => "count_tokens",
+        }
+    }
+}
+
 /// Runtime handle for the response cache: one shared backend, one
 /// `cachekit::CacheKit` per allow-listed client with `tenant_id =
 /// client_id`. HKDF-SHA256 then derives a distinct AES-256-GCM key per
@@ -992,6 +1012,13 @@ struct ResponseCache {
     misses: AtomicU64,
     errors: AtomicU64,
     stores: AtomicU64,
+    // LAB-929: count_tokens gets its own series (AC4) rather than sharing
+    // the /v1/messages counters above — a HashMap<&str, _> would be more
+    // machinery than two fixed, permanent surfaces warrant.
+    count_tokens_hits: AtomicU64,
+    count_tokens_misses: AtomicU64,
+    count_tokens_errors: AtomicU64,
+    count_tokens_stores: AtomicU64,
 }
 
 /// First 16 hex chars of a cache-key digest — the ONLY form a cache key may
@@ -1022,9 +1049,9 @@ fn decode_hex_key(s: &str) -> Result<Vec<u8>, String> {
 
 /// Derive the response-cache storage key (AC6): hex Blake2s-256 over
 /// (model ␟ canonical body JSON ␟ sorted anthropic-beta values ␟
-/// anthropic-version ␟ URI query ␟ client_id ␟ fp ␟ fps). The full-body
-/// digest is what carries correctness — two requests differing anywhere,
-/// including a nested structural position, serialize differently
+/// anthropic-version ␟ URI query ␟ client_id ␟ fp ␟ fps ␟ surface). The
+/// full-body digest is what carries correctness — two requests differing
+/// anywhere, including a nested structural position, serialize differently
 /// (`preserve_order` keeps the client's key order) and get different keys.
 /// anthropic-version and the query string are keyed because they change the
 /// RESPONSE schema for an identical body (an SDK upgrade mid-TTL must miss,
@@ -1033,8 +1060,13 @@ fn decode_hex_key(s: &str) -> Result<Vec<u8>, String> {
 /// deliberately not trusted alone: 48 bits over prompt content is collision
 /// territory, and a key collision here would serve someone the wrong
 /// completion. client_id in the material separates keys per client on top
-/// of the per-tenant encryption (AC7). The emitted key is a digest only —
-/// no prompt content ever appears in a storage key or diagnostic line (AC5).
+/// of the per-tenant encryption (AC7). `surface` (LAB-929) separates
+/// `/v1/messages` from `/v1/messages/count_tokens` so an identical body
+/// posted to both endpoints never cross-serves — a count vs. a completion
+/// are not interchangeable, no matter how the key material lines up
+/// otherwise. The emitted key is a digest only — no prompt content ever
+/// appears in a storage key or diagnostic line (AC5).
+#[allow(clippy::too_many_arguments)]
 fn response_cache_key(
     model: &str,
     body: &serde_json::Value,
@@ -1043,6 +1075,7 @@ fn response_cache_key(
     client_id: &str,
     fp: &str,
     fps: &str,
+    surface: &str,
 ) -> String {
     use blake2::{Blake2s256, Digest};
     let mut betas: Vec<&str> = headers
@@ -1066,6 +1099,7 @@ fn response_cache_key(
         client_id,
         fp,
         fps,
+        surface,
     ] {
         h.update(part.as_bytes());
         h.update([0x1f]);
@@ -1193,32 +1227,69 @@ impl ResponseCache {
             misses: AtomicU64::new(0),
             errors: AtomicU64::new(0),
             stores: AtomicU64::new(0),
+            count_tokens_hits: AtomicU64::new(0),
+            count_tokens_misses: AtomicU64::new(0),
+            count_tokens_errors: AtomicU64::new(0),
+            count_tokens_stores: AtomicU64::new(0),
         })
+    }
+
+    fn hits_for(&self, surface: CacheSurface) -> &AtomicU64 {
+        match surface {
+            CacheSurface::Messages => &self.hits,
+            CacheSurface::CountTokens => &self.count_tokens_hits,
+        }
+    }
+
+    fn misses_for(&self, surface: CacheSurface) -> &AtomicU64 {
+        match surface {
+            CacheSurface::Messages => &self.misses,
+            CacheSurface::CountTokens => &self.count_tokens_misses,
+        }
+    }
+
+    fn errors_for(&self, surface: CacheSurface) -> &AtomicU64 {
+        match surface {
+            CacheSurface::Messages => &self.errors,
+            CacheSurface::CountTokens => &self.count_tokens_errors,
+        }
+    }
+
+    fn stores_for(&self, surface: CacheSurface) -> &AtomicU64 {
+        match surface {
+            CacheSurface::Messages => &self.stores,
+            CacheSurface::CountTokens => &self.count_tokens_stores,
+        }
     }
 
     /// Read an entry. Every failure mode — no encryption handle, backend
     /// error, decrypt error, timeout — degrades to `None` and the request
     /// proceeds upstream (AC10). Diagnostics carry the key digest only,
     /// never content (AC5).
-    async fn lookup(&self, client_id: &str, key: &str) -> Option<CachedResponse> {
+    async fn lookup(
+        &self,
+        client_id: &str,
+        key: &str,
+        surface: CacheSurface,
+    ) -> Option<CachedResponse> {
         let cache = self.clients.get(client_id)?;
         let op = async { cache.secure()?.get::<CachedResponse>(key).await };
         match tokio::time::timeout(self.op_timeout, op).await {
             Ok(Ok(Some(entry))) => {
-                self.hits.fetch_add(1, Ordering::Relaxed);
+                self.hits_for(surface).fetch_add(1, Ordering::Relaxed);
                 Some(entry)
             }
             Ok(Ok(None)) => {
-                self.misses.fetch_add(1, Ordering::Relaxed);
+                self.misses_for(surface).fetch_add(1, Ordering::Relaxed);
                 None
             }
             Ok(Err(e)) => {
-                self.errors.fetch_add(1, Ordering::Relaxed);
+                self.errors_for(surface).fetch_add(1, Ordering::Relaxed);
                 warn!(key_digest = key_digest_prefix(key), error = %e, "response cache read failed — proceeding upstream");
                 None
             }
             Err(_) => {
-                self.errors.fetch_add(1, Ordering::Relaxed);
+                self.errors_for(surface).fetch_add(1, Ordering::Relaxed);
                 warn!(
                     key_digest = key_digest_prefix(key),
                     timeout_ms = self.op_timeout.as_millis() as u64,
@@ -1231,21 +1302,27 @@ impl ResponseCache {
 
     /// Write an entry. Failures are counted and logged (digest only) but
     /// never affect the client response (AC10).
-    async fn store(&self, client_id: &str, key: &str, entry: &CachedResponse) {
+    async fn store(
+        &self,
+        client_id: &str,
+        key: &str,
+        entry: &CachedResponse,
+        surface: CacheSurface,
+    ) {
         let Some(cache) = self.clients.get(client_id) else {
             return;
         };
         let op = async { cache.secure()?.set(key, entry).await };
         match tokio::time::timeout(self.op_timeout, op).await {
             Ok(Ok(())) => {
-                self.stores.fetch_add(1, Ordering::Relaxed);
+                self.stores_for(surface).fetch_add(1, Ordering::Relaxed);
             }
             Ok(Err(e)) => {
-                self.errors.fetch_add(1, Ordering::Relaxed);
+                self.errors_for(surface).fetch_add(1, Ordering::Relaxed);
                 warn!(key_digest = key_digest_prefix(key), error = %e, "response cache write failed — skipped");
             }
             Err(_) => {
-                self.errors.fetch_add(1, Ordering::Relaxed);
+                self.errors_for(surface).fetch_add(1, Ordering::Relaxed);
                 warn!(
                     key_digest = key_digest_prefix(key),
                     timeout_ms = self.op_timeout.as_millis() as u64,
@@ -6375,12 +6452,12 @@ async fn forward_anthropic(
 /// client response is returned unchanged either way.
 async fn maybe_cache_store(
     state: &AppState,
-    cache_key: Option<&str>,
+    cache_key: Option<(&str, CacheSurface)>,
     client_id: &str,
     req_id: &str,
     resp: Response,
 ) -> Response {
-    let (Some(rc), Some(key)) = (&state.response_cache, cache_key) else {
+    let (Some(rc), Some((key, surface))) = (&state.response_cache, cache_key) else {
         return resp;
     };
     if !resp.status().is_success() {
@@ -6436,6 +6513,7 @@ async fn maybe_cache_store(
             content_type,
             body: bytes.to_vec(),
         },
+        surface,
     )
     .await;
     Response::from_parts(parts, Body::from(bytes))
@@ -6525,29 +6603,42 @@ async fn proxy_handler(
             // (below) to reflect the breakpoints actually forwarded upstream.
             let (fp, fps) = content_fingerprints(&parsed);
 
-            // LAB-933: derive the response-cache key on the PRE-injection
-            // body — the request exactly as the client sent it — so the
-            // deterministic auto-cache/OAuth mutations below never affect
-            // cache identity. Gated here on opt-in (AC2), the /v1/messages
-            // path, and non-streaming (AC8; same predicate as
-            // `request_wants_stream`, evaluated on the parsed body).
+            // LAB-933/LAB-929: derive the response-cache key on the
+            // PRE-injection body — the request exactly as the client sent
+            // it — so the deterministic auto-cache/OAuth mutations below
+            // never affect cache identity. Gated here on opt-in (AC2), the
+            // /v1/messages or /v1/messages/count_tokens path, and
+            // non-streaming (AC8; same predicate as `request_wants_stream`,
+            // evaluated on the parsed body). `surface` travels with the key
+            // so both endpoints share one allow-list and one key scheme
+            // (LAB-929 AC2/AC3) while staying unable to cross-serve.
             let cache_key = match &state.response_cache {
                 // The per-client map doubles as the opt-in allow-list (AC2).
                 Some(rc)
                     if rc.clients.contains_key(&client_id)
                         && parts.method == hyper::Method::POST
-                        && parts.uri.path() == "/v1/messages"
                         && !body_wants_stream(&parsed) =>
                 {
-                    Some(response_cache_key(
-                        &model,
-                        &parsed,
-                        &parts.headers,
-                        parts.uri.query(),
-                        &client_id,
-                        &fp,
-                        &fps,
-                    ))
+                    let surface = match parts.uri.path() {
+                        "/v1/messages" => Some(CacheSurface::Messages),
+                        "/v1/messages/count_tokens" => Some(CacheSurface::CountTokens),
+                        _ => None,
+                    };
+                    surface.map(|surface| {
+                        (
+                            response_cache_key(
+                                &model,
+                                &parsed,
+                                &parts.headers,
+                                parts.uri.query(),
+                                &client_id,
+                                &fp,
+                                &fps,
+                                surface.label(),
+                            ),
+                            surface,
+                        )
+                    })
                 }
                 _ => None,
             };
@@ -6657,9 +6748,9 @@ async fn proxy_handler(
     // opted-in clients; a hit then never touches an upstream — no rate-limit
     // headroom burned, no budget decrement, no usage recorded (AC9). Only
     // the hit counter and a digest-only log line observe it (AC5).
-    if let Some(key) = cache_key.as_deref() {
+    if let Some((key, surface)) = cache_key.as_ref().map(|(k, s)| (k.as_str(), *s)) {
         if let Some(rc) = &state.response_cache {
-            if let Some(entry) = rc.lookup(&client_id, key).await {
+            if let Some(entry) = rc.lookup(&client_id, key, surface).await {
                 info!(
                     req_id,
                     client_id = %client_id,
@@ -6764,7 +6855,7 @@ async fn proxy_handler(
                 RetryStep::Return(resp) => {
                     return maybe_cache_store(
                         &state,
-                        cache_key.as_deref(),
+                        cache_key.as_ref().map(|(k, s)| (k.as_str(), *s)),
                         &client_id,
                         &req_id,
                         resp,
@@ -8841,40 +8932,56 @@ async fn metrics_handler(
         state.body_read_timeout_total.load(Ordering::Relaxed),
     );
 
-    // LAB-933 response cache counters (AC12). Emitted only when the cache is
-    // configured; the `surface` label leaves room for the LAB-929
-    // count_tokens cache to join the same series without a rename.
+    // LAB-933/LAB-929 response cache counters (AC12 / LAB-929 AC4). Emitted
+    // only when the cache is configured; `messages` and `count_tokens` are
+    // separate series on the same metric names, distinguished by the
+    // `surface` label.
     if let Some(rc) = &state.response_cache {
-        let series: [(&str, &AtomicU64, &str); 4] = [
+        let headers: [(&str, &str); 4] = [
             (
                 "anthropic_response_cache_hits_total",
-                &rc.hits,
                 "Requests served from the response cache (no upstream call, no headroom burned)",
             ),
             (
                 "anthropic_response_cache_misses_total",
-                &rc.misses,
                 "Opted-in cacheable requests that proceeded upstream on a cache miss",
             ),
             (
                 "anthropic_response_cache_stores_total",
-                &rc.stores,
                 "2xx responses written to the response cache",
             ),
             (
                 "anthropic_response_cache_errors_total",
-                &rc.errors,
                 "Response cache operations that failed or timed out (request failed open)",
             ),
         ];
-        for (name, counter, help) in series {
+        for (name, help) in headers {
             prom_header(&mut buf, name, "counter", help);
-            prom_counter(
-                &mut buf,
-                name,
-                &[("surface", "messages")],
-                counter.load(Ordering::Relaxed),
-            );
+        }
+        for surface in [CacheSurface::Messages, CacheSurface::CountTokens] {
+            let series: [(&str, &AtomicU64); 4] = [
+                ("anthropic_response_cache_hits_total", rc.hits_for(surface)),
+                (
+                    "anthropic_response_cache_misses_total",
+                    rc.misses_for(surface),
+                ),
+                (
+                    "anthropic_response_cache_stores_total",
+                    rc.stores_for(surface),
+                ),
+                (
+                    "anthropic_response_cache_errors_total",
+                    rc.errors_for(surface),
+                ),
+            ];
+            for (name, counter) in series {
+                prom_counter(
+                    &mut buf,
+                    name,
+                    &[("surface", surface.label())],
+                    counter.load(Ordering::Relaxed),
+                );
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8935,51 +8935,42 @@ async fn metrics_handler(
     // LAB-933/LAB-929 response cache counters (AC12 / LAB-929 AC4). Emitted
     // only when the cache is configured; `messages` and `count_tokens` are
     // separate series on the same metric names, distinguished by the
-    // `surface` label.
+    // `surface` label. Looped metric-major (header, then both surfaces'
+    // samples, then the next metric) so each family's samples stay
+    // contiguous — the exposition format requires all samples of one metric
+    // grouped together, and OpenMetrics-strict scrapers reject interleaving.
     if let Some(rc) = &state.response_cache {
-        let headers: [(&str, &str); 4] = [
+        type SurfaceCounter = fn(&ResponseCache, CacheSurface) -> &AtomicU64;
+        let series: [(&str, &str, SurfaceCounter); 4] = [
             (
                 "anthropic_response_cache_hits_total",
                 "Requests served from the response cache (no upstream call, no headroom burned)",
+                ResponseCache::hits_for,
             ),
             (
                 "anthropic_response_cache_misses_total",
                 "Opted-in cacheable requests that proceeded upstream on a cache miss",
+                ResponseCache::misses_for,
             ),
             (
                 "anthropic_response_cache_stores_total",
                 "2xx responses written to the response cache",
+                ResponseCache::stores_for,
             ),
             (
                 "anthropic_response_cache_errors_total",
                 "Response cache operations that failed or timed out (request failed open)",
+                ResponseCache::errors_for,
             ),
         ];
-        for (name, help) in headers {
+        for (name, help, counter_for) in series {
             prom_header(&mut buf, name, "counter", help);
-        }
-        for surface in [CacheSurface::Messages, CacheSurface::CountTokens] {
-            let series: [(&str, &AtomicU64); 4] = [
-                ("anthropic_response_cache_hits_total", rc.hits_for(surface)),
-                (
-                    "anthropic_response_cache_misses_total",
-                    rc.misses_for(surface),
-                ),
-                (
-                    "anthropic_response_cache_stores_total",
-                    rc.stores_for(surface),
-                ),
-                (
-                    "anthropic_response_cache_errors_total",
-                    rc.errors_for(surface),
-                ),
-            ];
-            for (name, counter) in series {
+            for surface in [CacheSurface::Messages, CacheSurface::CountTokens] {
                 prom_counter(
                     &mut buf,
                     name,
                     &[("surface", surface.label())],
-                    counter.load(Ordering::Relaxed),
+                    counter_for(rc, surface).load(Ordering::Relaxed),
                 );
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15588,6 +15588,22 @@ async fn response_cache_count_tokens_metrics_exposed() {
     assert!(text.contains(r#"anthropic_response_cache_hits_total{surface="messages"} 0"#));
     assert!(text.contains(r#"anthropic_response_cache_misses_total{surface="messages"} 1"#));
     assert!(text.contains(r#"anthropic_response_cache_stores_total{surface="messages"} 1"#));
+
+    // Panel fix: the exposition format requires all samples of one metric
+    // grouped together (no other metric's lines interleaved) — assert both
+    // surfaces' `hits_total` samples are adjacent, not separated by
+    // misses/stores/errors lines from the metric-major/surface-minor loop.
+    let hits_lines: Vec<&str> = text
+        .lines()
+        .filter(|l| l.starts_with("anthropic_response_cache_hits_total"))
+        .collect();
+    let all_lines: Vec<&str> = text.lines().collect();
+    let first_idx = all_lines.iter().position(|l| *l == hits_lines[0]).unwrap();
+    assert_eq!(
+        all_lines[first_idx + 1],
+        hits_lines[1],
+        "hits_total samples for both surfaces must be contiguous, not interleaved with other metrics"
+    );
 }
 
 // LAB-929 AC5: a dead cache backend fails open on the count_tokens path too

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15011,6 +15011,17 @@ async fn post_messages(addr: SocketAddr, client_id: &str, body: &str) -> reqwest
         .unwrap()
 }
 
+async fn post_count_tokens(addr: SocketAddr, client_id: &str, body: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("http://{addr}/v1/messages/count_tokens"))
+        .header("content-type", "application/json")
+        .header("x-client-id", client_id)
+        .body(body.to_string())
+        .send()
+        .await
+        .unwrap()
+}
+
 // AC6: the key is a full-body canonical digest — same raw text in a
 // different structural position must produce a different key.
 #[test]
@@ -15026,19 +15037,19 @@ fn response_cache_key_differs_on_nested_structure() {
     .unwrap();
     let (fpa, fpsa) = content_fingerprints(&a);
     let (fpb, fpsb) = content_fingerprints(&b);
-    let ka = response_cache_key("m", &a, &headers, None, "c", &fpa, &fpsa);
-    let kb = response_cache_key("m", &b, &headers, None, "c", &fpb, &fpsb);
+    let ka = response_cache_key("m", &a, &headers, None, "c", &fpa, &fpsa, "messages");
+    let kb = response_cache_key("m", &b, &headers, None, "c", &fpb, &fpsb, "messages");
     assert_ne!(ka, kb, "structural difference must change the key");
 
     // Model and beta headers are key material too.
-    let ka2 = response_cache_key("m2", &a, &headers, None, "c", &fpa, &fpsa);
+    let ka2 = response_cache_key("m2", &a, &headers, None, "c", &fpa, &fpsa, "messages");
     assert_ne!(ka, ka2, "model must change the key");
     let mut beta_headers = hyper::HeaderMap::new();
     beta_headers.insert(
         "anthropic-beta",
         HeaderValue::from_static("context-1m-2025"),
     );
-    let ka3 = response_cache_key("m", &a, &beta_headers, None, "c", &fpa, &fpsa);
+    let ka3 = response_cache_key("m", &a, &beta_headers, None, "c", &fpa, &fpsa, "messages");
     assert_ne!(ka, ka3, "anthropic-beta must change the key");
 
     // Key format: hex digest only, never content (AC5).
@@ -15052,9 +15063,36 @@ fn response_cache_key_isolates_clients() {
     let headers = hyper::HeaderMap::new();
     let body: serde_json::Value = serde_json::from_str(CACHE_TEST_BODY).unwrap();
     let (fp, fps) = content_fingerprints(&body);
-    let ka = response_cache_key("test", &body, &headers, None, "client-a", &fp, &fps);
-    let kb = response_cache_key("test", &body, &headers, None, "client-b", &fp, &fps);
+    let ka = response_cache_key(
+        "test", &body, &headers, None, "client-a", &fp, &fps, "messages",
+    );
+    let kb = response_cache_key(
+        "test", &body, &headers, None, "client-b", &fp, &fps, "messages",
+    );
     assert_ne!(ka, kb);
+}
+
+// LAB-929 AC2/AC7: identical body posted to /v1/messages vs
+// /v1/messages/count_tokens must NOT collide — a client that counts before
+// sending (same model+messages to both endpoints) must never have one
+// surface's cached entry served back as the other's.
+#[test]
+fn response_cache_key_isolates_surface() {
+    let headers = hyper::HeaderMap::new();
+    let body: serde_json::Value = serde_json::from_str(CACHE_TEST_BODY).unwrap();
+    let (fp, fps) = content_fingerprints(&body);
+    let k_messages = response_cache_key("test", &body, &headers, None, "c", &fp, &fps, "messages");
+    let k_count_tokens = response_cache_key(
+        "test",
+        &body,
+        &headers,
+        None,
+        "c",
+        &fp,
+        &fps,
+        "count_tokens",
+    );
+    assert_ne!(k_messages, k_count_tokens);
 }
 
 #[test]
@@ -15302,7 +15340,7 @@ async fn response_cache_backend_sees_only_ciphertext() {
         .into_bytes(),
     };
     let key = "a".repeat(64);
-    rc.store("geo", &key, &entry).await;
+    rc.store("geo", &key, &entry, CacheSurface::Messages).await;
     assert_eq!(rc.stores.load(Ordering::Relaxed), 1, "store must succeed");
 
     let writes = backend.writes.lock().unwrap().clone();
@@ -15320,7 +15358,7 @@ async fn response_cache_backend_sees_only_ciphertext() {
 
     // Right key decrypts.
     let got = rc
-        .lookup("geo", &key)
+        .lookup("geo", &key, CacheSurface::Messages)
         .await
         .expect("right-key read must hit");
     assert_eq!(got.body, entry.body);
@@ -15335,7 +15373,10 @@ async fn response_cache_backend_sees_only_ciphertext() {
     )
     .unwrap();
     assert!(
-        rc_wrong.lookup("geo", &key).await.is_none(),
+        rc_wrong
+            .lookup("geo", &key, CacheSurface::Messages)
+            .await
+            .is_none(),
         "wrong-key read must not return plaintext"
     );
     assert_eq!(
@@ -15356,7 +15397,10 @@ async fn response_cache_backend_sees_only_ciphertext() {
     )
     .unwrap();
     assert!(
-        rc_other.lookup("other-client", &key).await.is_none(),
+        rc_other
+            .lookup("other-client", &key, CacheSurface::Messages)
+            .await
+            .is_none(),
         "cross-tenant read must not decrypt"
     );
 }
@@ -15440,6 +15484,130 @@ async fn response_cache_metrics_exposed() {
     assert!(text.contains(r#"anthropic_response_cache_errors_total{surface="messages"} 0"#));
 }
 
+// LAB-929 AC2: replaying an identical /v1/messages/count_tokens request is
+// served from cache (one upstream call); a differing body forwards again.
+#[tokio::test]
+async fn response_cache_count_tokens_hit_replays_without_upstream() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, hits, state) = serve_cache_app(backend, &["geo"]).await;
+
+    let first = post_count_tokens(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+    assert!(first.headers().get("x-alb-cache").is_none());
+
+    let second = post_count_tokens(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(second.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        second
+            .headers()
+            .get("x-alb-cache")
+            .map(|v| v.to_str().unwrap()),
+        Some("hit")
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "identical replay must not reach upstream"
+    );
+
+    // A differing body (different max_tokens) is a genuine miss.
+    let differing =
+        r#"{"model":"test","max_tokens":2,"messages":[{"role":"user","content":"hi"}]}"#;
+    let third = post_count_tokens(addr, "geo", differing).await;
+    assert_eq!(third.status(), reqwest::StatusCode::OK);
+    assert!(third.headers().get("x-alb-cache").is_none());
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "a differing body must forward upstream again"
+    );
+
+    let rc = state.response_cache.as_ref().unwrap();
+    assert_eq!(rc.count_tokens_hits.load(Ordering::Relaxed), 1);
+    assert_eq!(rc.count_tokens_misses.load(Ordering::Relaxed), 2);
+    assert_eq!(rc.count_tokens_stores.load(Ordering::Relaxed), 2);
+    // The /v1/messages series must stay untouched by count_tokens traffic.
+    assert_eq!(rc.hits.load(Ordering::Relaxed), 0);
+    assert_eq!(rc.misses.load(Ordering::Relaxed), 0);
+}
+
+// LAB-929 AC2/AC7: a client that sends the SAME body to /v1/messages and
+// /v1/messages/count_tokens (a common pattern — count before you send) must
+// never have one surface's cached entry served back as the other's.
+#[tokio::test]
+async fn response_cache_messages_and_count_tokens_do_not_cross_serve() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, hits, state) = serve_cache_app(backend, &["geo"]).await;
+
+    let ct = post_count_tokens(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(ct.status(), reqwest::StatusCode::OK);
+    assert!(ct.headers().get("x-alb-cache").is_none());
+
+    // Byte-identical body to /v1/messages must still miss — not read back
+    // the count_tokens entry.
+    let msg = post_messages(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(msg.status(), reqwest::StatusCode::OK);
+    assert!(
+        msg.headers().get("x-alb-cache").is_none(),
+        "a /v1/messages request must never be served from the count_tokens entry"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "both surfaces must independently reach upstream"
+    );
+
+    let rc = state.response_cache.as_ref().unwrap();
+    assert_eq!(rc.count_tokens_stores.load(Ordering::Relaxed), 1);
+    assert_eq!(rc.stores.load(Ordering::Relaxed), 1);
+}
+
+// LAB-929 AC4: count_tokens and messages hits/misses/stores/errors are
+// separable series on /metrics via the `surface` label, sharing metric names.
+#[tokio::test]
+async fn response_cache_count_tokens_metrics_exposed() {
+    let backend = std::sync::Arc::new(RecordingBackend::default());
+    let (addr, _hits, _state) = serve_cache_app(backend, &["geo"]).await;
+    post_count_tokens(addr, "geo", CACHE_TEST_BODY).await; // miss + store
+    post_count_tokens(addr, "geo", CACHE_TEST_BODY).await; // hit
+    post_messages(addr, "geo", CACHE_TEST_BODY).await; // separate surface: miss + store
+    let text = reqwest::Client::new()
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        text.contains(r#"anthropic_response_cache_hits_total{surface="count_tokens"} 1"#),
+        "{text}"
+    );
+    assert!(text.contains(r#"anthropic_response_cache_misses_total{surface="count_tokens"} 1"#));
+    assert!(text.contains(r#"anthropic_response_cache_stores_total{surface="count_tokens"} 1"#));
+    assert!(text.contains(r#"anthropic_response_cache_hits_total{surface="messages"} 0"#));
+    assert!(text.contains(r#"anthropic_response_cache_misses_total{surface="messages"} 1"#));
+    assert!(text.contains(r#"anthropic_response_cache_stores_total{surface="messages"} 1"#));
+}
+
+// LAB-929 AC5: a dead cache backend fails open on the count_tokens path too
+// — inherited from ResponseCache, no new failure handling.
+#[tokio::test]
+async fn response_cache_count_tokens_fails_open_on_backend_error() {
+    let backend = std::sync::Arc::new(ErroringBackend);
+    let (addr, hits, state) = serve_cache_app(backend, &["geo"]).await;
+    let resp = post_count_tokens(addr, "geo", CACHE_TEST_BODY).await;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "must fail open to upstream"
+    );
+    assert!(resp.headers().get("x-alb-cache").is_none());
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+    let rc = state.response_cache.as_ref().unwrap();
+    assert!(rc.count_tokens_errors.load(Ordering::Relaxed) >= 2);
+}
+
 // Metrics stay silent when the cache is not configured (no phantom series).
 #[tokio::test]
 async fn response_cache_metrics_absent_without_config() {
@@ -15477,7 +15645,10 @@ async fn response_cache_redis_backend_fails_open_when_down() {
         .expect("dead redis must not be a config error")
         .expect("allow-list is non-empty");
     let started = std::time::Instant::now();
-    assert!(rc.lookup("geo", &"a".repeat(64)).await.is_none());
+    assert!(rc
+        .lookup("geo", &"a".repeat(64), CacheSurface::Messages)
+        .await
+        .is_none());
     assert!(started.elapsed() < Duration::from_secs(5));
     assert!(rc.errors.load(Ordering::Relaxed) >= 1);
 }
@@ -15571,16 +15742,18 @@ async fn response_cache_cachekitio_live_round_trip() {
         "live-test",
         "fp",
         "fps",
+        "messages",
     );
     let entry = CachedResponse {
         status: 200,
         content_type: "application/json".into(),
         body: b"{\"live\":true}".to_vec(),
     };
-    rc.store("live-test", &key, &entry).await;
+    rc.store("live-test", &key, &entry, CacheSurface::Messages)
+        .await;
     assert_eq!(rc.stores.load(Ordering::Relaxed), 1, "live store failed");
     let got = rc
-        .lookup("live-test", &key)
+        .lookup("live-test", &key, CacheSurface::Messages)
         .await
         .expect("live read-back failed");
     assert_eq!(got.body, entry.body);
@@ -15595,15 +15768,24 @@ fn response_cache_key_varies_on_version_and_query() {
     let plain = hyper::HeaderMap::new();
     let mut versioned = hyper::HeaderMap::new();
     versioned.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
-    let base = response_cache_key("m", &body, &plain, None, "c", &fp, &fps);
+    let base = response_cache_key("m", &body, &plain, None, "c", &fp, &fps, "messages");
     assert_ne!(
         base,
-        response_cache_key("m", &body, &versioned, None, "c", &fp, &fps),
+        response_cache_key("m", &body, &versioned, None, "c", &fp, &fps, "messages"),
         "anthropic-version must change the key"
     );
     assert_ne!(
         base,
-        response_cache_key("m", &body, &plain, Some("beta=true"), "c", &fp, &fps),
+        response_cache_key(
+            "m",
+            &body,
+            &plain,
+            Some("beta=true"),
+            "c",
+            &fp,
+            &fps,
+            "messages"
+        ),
         "URI query must change the key"
     );
 }
@@ -15688,7 +15870,15 @@ async fn response_cache_skips_oversized_bodies() {
         .header("content-type", "application/json")
         .body(Body::from(big.clone()))
         .unwrap();
-    let out = maybe_cache_store(&state, Some(&"a".repeat(64)), "geo", "rid", resp).await;
+    let key_a = "a".repeat(64);
+    let out = maybe_cache_store(
+        &state,
+        Some((key_a.as_str(), CacheSurface::Messages)),
+        "geo",
+        "rid",
+        resp,
+    )
+    .await;
     assert_eq!(out.status(), StatusCode::OK);
     let out_bytes = axum::body::to_bytes(out.into_body(), usize::MAX)
         .await
@@ -15716,7 +15906,15 @@ async fn response_cache_skips_oversized_bodies() {
         .header("content-type", "application/json")
         .body(Body::from(ok_body))
         .unwrap();
-    let _ = maybe_cache_store(&state, Some(&"b".repeat(64)), "geo", "rid", resp).await;
+    let key_b = "b".repeat(64);
+    let _ = maybe_cache_store(
+        &state,
+        Some((key_b.as_str(), CacheSurface::Messages)),
+        "geo",
+        "rid",
+        resp,
+    )
+    .await;
     assert_eq!(
         state
             .response_cache


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR extends the existing response cache to cover the `POST /v1/messages/count_tokens` endpoint (LAB-929), which was previously only supported for `POST /v1/messages`.

## What Changed

**Cache coverage for count_tokens**
- The response cache now serves cached results for byte-identical `count_tokens` requests from allow-listed clients, skipping the upstream call entirely — the same quota-saving behavior already available for `/v1/messages`.
- Both endpoints share a single allow-list and key scheme.

**Surface isolation to prevent cross-serving**
- A new `CacheSurface` enum (`Messages` / `CountTokens`) is introduced and folded into the cache key material (via `response_cache_key`). This ensures that a client sending an identical body to both endpoints — a common "count before you send" pattern — can never have one endpoint's cached response served back for the other. A count result and a completion are not interchangeable.

**Separate metrics per endpoint (AC4)**
- Dedicated counters were added for count_tokens (`count_tokens_hits/misses/errors/stores`).
- The `/metrics` output now emits one series per endpoint, distinguished by the `surface` label (`surface="messages"` and `surface="count_tokens"`), sharing the same metric names.

**Fail-open behavior inherited**
- The count_tokens path reuses the existing `ResponseCache` lookup/store logic, so a dead, slow, or misconfigured backend still fails open to upstream with no new failure handling.

## Documentation
- The README is updated to document count_tokens caching, the shared-but-isolated key scheme, the endpoint folded into the cache key digest, and the per-endpoint metric series.

## Tests
New tests verify:
- Identical count_tokens replays hit the cache; differing bodies miss and forward upstream.
- Identical bodies to `/v1/messages` and `/v1/messages/count_tokens` do **not** cross-serve.
- count_tokens and messages metrics are separable via the `surface` label.
- The count_tokens path fails open on backend errors.
- The cache key varies by surface.

Existing tests were updated to pass the new `surface` argument through `response_cache_key`, `lookup`, `store`, and `maybe_cache_store`.
<!-- kody-pr-summary:end -->