### PR TITLE
LAB-1083: per-client authenticated identity ([[clients]] keys, constant-time compare) + per-client model allow-lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,14 +45,14 @@ Single Rust binary: all implementation in `src/main.rs` (~9800 lines) with secti
 ### Core Data Flow
 
 ```text
-Request → IP allowlist check → proxy_key auth → pre_request_gate(operator bypass → budget → utilization limit → emergency brake) → pick_endpoint(affinity, model, skip) → forward to endpoint → parse rate-limit headers → extract token usage → shadow log → persist state (+ Redis sync)
+Request → IP allowlist check → authenticate([[clients]] key, else legacy proxy_key) → resolve client_id (authenticated principal, else x-client-id/IP map) → pre_request_gate(operator bypass → model allow-list → budget → utilization limit → emergency brake) → pick_endpoint(affinity, model, skip) → forward to endpoint → parse rate-limit headers → extract token usage → shadow log → persist state (+ Redis sync)
 ```
 
 ### Key Sections (in source order)
 
 | Section | What it does |
 |---------|-------------|
-| **Config** (`Config`, `EndpointConfig`) | TOML deserialization structs |
+| **Config** (`Config`, `ClientConfig`, `EndpointConfig`) | TOML deserialization structs |
 | **Runtime state** (`AppState`, `Endpoint`, `RateLimitInfo`) | Shared via `Arc<AppState>`, per-endpoint `RwLock<RateLimitInfo>`, atomic counters, optional Redis `ConnectionManager` |
 | **Persistence** (`PersistedState`) | JSON state file at `<config_path>.state.json`, saved after every request and on shutdown. Redis for cross-replica state when configured. |
 | **Token usage** (`TokenUsage`, `record_usage`) | Extracts token counts from responses (streaming SSE + non-streaming JSON), tracks per-endpoint and per-client |
@@ -125,7 +125,10 @@ Routing consequences (`constraining_7d_claims`):
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `listen` | string | required | Bind address (e.g. `"0.0.0.0:8080"`) |
-| `proxy_key` | string? | none | Shared secret for `x-api-key` auth |
+| `clients[].name` | string | required | Identity the credential resolves to — becomes `client_id`, overriding `x-client-id` and `client_names` entirely |
+| `clients[].key` | string | required | Per-client secret (`x-api-key`; also `Authorization: Bearer` on `/v1/chat/completions`). Constant-time compared |
+| `clients[].models` | string[]? | [] (all) | Models this client may request; same exact + `*`-suffix matcher as `endpoints[].models`. Violation = 403 |
+| `proxy_key` | string? | none | **Legacy** single shared secret for `x-api-key` auth. Mutually exclusive with `[[clients]]` — both = startup panic |
 | `allowed_ips` | string[]? | none (allow all) | IP/CIDR allowlist |
 | `auto_cache` | bool? | true | Auto-inject prompt cache breakpoints |
 | `shadow_log` | string? | none | Path for JSONL audit trail |
@@ -133,7 +136,7 @@ Routing consequences (`constraining_7d_claims`):
 | `client_names` | map? | {} | IP→client name mapping |
 | `client_budgets` | map? | {} | client_id→daily token limit |
 | `client_utilization_limits` | map? | {} | client_id→utilization ceiling (0.0–1.0) |
-| `operators` | string[]? | [] | Client IDs that bypass budget, utilization, and emergency brake enforcement (trust-based, not IP-verified; does not bypass IP allowlist) |
+| `operators` | string[]? | [] | Client IDs that bypass the model allow-list, budget, utilization, and emergency brake enforcement (does not bypass IP allowlist). Under `[[clients]]` these name authenticated principals; without it, operator status is trust-based and forgeable |
 | `emergency_brake` | bool? | true | Enable/disable the emergency brake |
 | `emergency_threshold` | f64? | 0.88 | Utilization threshold for the emergency brake — applied only to `Protocol::Anthropic` endpoints; OpenAI endpoints (stub `RateLimitInfo`) are excluded so they cannot prevent the brake from firing |
 | `redis_url` | string? | none | Redis/Valkey URL for distributed state (`redis://` or `rediss://`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Routing consequences (`constraining_7d_claims`):
 | `clients[].name` | string | required | Identity the credential resolves to — becomes `client_id`, overriding `x-client-id` and `client_names` entirely |
 | `clients[].key` | string | required | Per-client secret (`x-api-key`; also `Authorization: Bearer` on `/v1/chat/completions`). Constant-time compared |
 | `clients[].models` | string[]? | [] (all) | Models this client may request; same exact + `*`-suffix matcher as `endpoints[].models`. Violation = 403 |
-| `proxy_key` | string? | none | **Legacy** single shared secret for `x-api-key` auth. Mutually exclusive with `[[clients]]` — both = startup panic |
+| `proxy_key` | string? | none | **Legacy** single shared secret for `x-api-key` auth. Mutually exclusive with `[[clients]]` — configuring both is rejected at startup |
 | `allowed_ips` | string[]? | none (allow all) | IP/CIDR allowlist |
 | `auto_cache` | bool? | true | Auto-inject prompt cache breakpoints |
 | `shadow_log` | string? | none | Path for JSONL audit trail |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "subtle",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ cachekit-rs = { version = "0.5", features = ["redis"] }
 # Same versions cachekit-rs already pins — zero marginal dependency weight.
 blake2 = "0.10"
 serde_bytes = "0.11"
+# Constant-time credential comparison (LAB-1083). Already in the tree via
+# cachekit-rs' AEAD stack — direct use costs no extra compile.
+subtle = "2.6"
 
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/README.md
+++ b/README.md
@@ -334,7 +334,9 @@ IP check runs first, then the credential check. Both apply to every route includ
 | `/_stats` | GET | JSON stats (utilization, tokens, budgets, live sessions) |
 | `/metrics` | GET | Prometheus-format metrics |
 
-All endpoints are gated by `proxy_key` and `allowed_ips` when configured.
+All endpoints are gated by `[[clients]]` (or legacy `proxy_key`) and
+`allowed_ips` when configured. Any valid client credential grants access to
+`/_stats` and `/metrics` — they are not operator-scoped (see Known Limitations).
 
 ### Session context-window visibility
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,9 @@ Claude Code sends it as `x-api-key`; the proxy validates it and swaps in the rea
 > [!IMPORTANT]
 > With `[[clients]]` configured, **`x-client-id` and the `client_names` IP map are ignored entirely** — `client_id` comes from the verified credential. That is what makes per-client budgets, utilization ceilings, operator status, model allow-lists and response-cache tenancy enforceable rather than advisory: all five key on `client_id`.
 
-Keys are compared in constant time against the whole table. Duplicate names, duplicate keys, and a `[response_cache].clients` entry naming no configured client all fail at startup.
+Keys are compared in constant time against the whole table. Startup rejects anything that would otherwise fail silently at runtime: duplicate names, duplicate keys, a name with stray whitespace, and any `client_budgets` / `client_utilization_limits` / `operators` / `[response_cache].clients` entry naming no configured client. That last class matters — an unknown client passes the budget and utilization checks, so a one-character typo would mean *unlimited* spend with no log line and no metric.
+
+`[[clients]]` is also incompatible with `token = "passthrough"` endpoints, and that combination is rejected at startup. Passthrough forwards the caller's auth headers upstream untouched, but under `[[clients]]` those headers carry the caller's *proxy* credential — forwarding them would hand every client key to the upstream.
 
 ### Legacy shared secret (`proxy_key`)
 
@@ -267,7 +269,16 @@ proxy_key = "your-secret-key-here"
 
 One secret for everyone, sent as `x-api-key`. It authenticates but does **not** identify — every caller presents the same string, so `client_id` still comes from the client-asserted `X-Client-ID` header and a per-client model allow-list would be defeated by editing one header.
 
-**Migration:** replace `proxy_key` with one `[[clients]]` entry per caller, hand each its own key, then drop `proxy_key`. Setting both is rejected at startup with a named error rather than silently precedence-ordered, so a half-applied migration cannot leave the weaker scheme quietly in force. Do it in this order — add `[[clients]]`, cut over the callers, remove `proxy_key` — and no caller breaks mid-flight.
+**Migration is a flag day, not a rolling cutover.** Setting both `proxy_key` and `[[clients]]` is rejected at startup with a named error rather than silently precedence-ordered — a half-applied migration cannot leave the weaker scheme quietly in force, but it also means there is no window where both credentials are accepted. Plan for it:
+
+1. Mint one key per caller and stage it wherever each caller reads its credential from.
+2. In a single config change, delete `proxy_key` and add the `[[clients]]` table; restart.
+3. Flip every caller to its own key in the same maintenance window. Anything still sending the old shared secret gets a `401` from the moment the new config is live.
+
+Keep the previous config to hand: rolling back is the same single-step swap in reverse.
+
+> [!WARNING]
+> Under `[[clients]]`, `/_stats` and `/metrics` require a credential too. If a Prometheus scrape, an uptime check, or a Kubernetes `httpGet` probe hits this proxy unauthenticated today, it will start returning `401` — give those callers a key in the same change, or a failing probe becomes a restart loop.
 
 ### Client Identification
 
@@ -287,8 +298,7 @@ Per-client token usage and budget status appear in `/_stats`.
 
 A request for a model outside the list is rejected with **403** — a policy denial, distinct from the 429s that mean "capacity, try later" — and counted as `anthropic_client_model_denied_total{client,model}`. Operators bypass it, as they do every other gate check. The check sits in `pre_request_gate`, which both `/v1/messages` and `/v1/chat/completions` route through, so it covers both surfaces.
 
-> [!WARNING]
-> An allow-list is only as strong as the identity it keys on. Under the legacy `proxy_key` (or an open proxy) `client_id` is caller-asserted, so the allow-list is advisory at best — configure `[[clients]]` if you need it enforced.
+It **fails closed** on a model it cannot read. The proxy takes the model from the top-level `model` key of a JSON body; a body that does not parse, or a route that nests the model elsewhere (`/v1/messages/batches` puts it under `requests[].params.model`), yields no model — and a client that has an allow-list is then denied rather than waved through. Clients with no allow-list are unaffected.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,15 @@ listen = "127.0.0.1:8082"
 rate_limit_cooldown_secs = 60
 probe_interval_secs = 300
 
-# Proxy authentication (optional — omit for local / trusted-network use)
+# Authentication — per-client keys. The key IS the identity: the matched
+# entry's name becomes client_id, and x-client-id is ignored.
+# [[clients]]
+# name = "geo-pipeline"
+# key = "<openssl rand -hex 32>"
+# models = ["claude-sonnet-*", "claude-haiku-*"]  # optional; empty = all
+
+# LEGACY single shared secret. Mutually exclusive with [[clients]] —
+# configuring both fails startup. Omitting both leaves the proxy OPEN.
 # proxy_key = "your-secret-key-here"
 
 # IP allowlist (optional — omit to allow all source IPs)
@@ -148,8 +156,11 @@ token = "sk-ant-api03-..."
 | `listen` | `String` | — | Bind address (e.g. `"127.0.0.1:8082"`) |
 | `rate_limit_cooldown_secs` | `u64` | `60` | Seconds to cool down after 429 |
 | `probe_interval_secs` | `u64` | `300` | Seconds between utilization probes (0 = disabled) |
-| `proxy_key` | `String?` | `None` | Shared secret for proxy access |
-| `allowed_ips` | `[String]?` | `None` | IP/CIDR allowlist |
+| `clients[].name` | `String` | — | Identity this credential resolves to — becomes `client_id` |
+| `clients[].key` | `String` | — | Per-client secret (`x-api-key`; also `Bearer` on `/v1/chat/completions`) |
+| `clients[].models` | `[String]` | `[]` | Models this client may request (empty = all; `*` suffix wildcards) |
+| `proxy_key` | `String?` | `None` | **Legacy** shared secret. Mutually exclusive with `[[clients]]` |
+| `allowed_ips` | `[String]?` | `None` | IP/CIDR allowlist (unset = **allow all**) |
 | `auto_cache` | `bool` | `true` | Inject prompt caching beta header |
 | `shadow_log` | `String?` | `None` | Path to JSONL shadow log file |
 | `soft_limit` | `f64` | `0.90` | Utilization ceiling — accounts above are excluded from routing |
@@ -221,21 +232,48 @@ export ANTHROPIC_BASE_URL=http://localhost:8082
 
 Clients can use their own OAuth login (`claude login`) or set a dummy `ANTHROPIC_API_KEY` — either way the proxy strips client auth and injects the real account token.
 
-### Exposed to the Internet (with proxy_key)
+### Authenticated clients (`[[clients]]`)
 
-Set `proxy_key` in config. Clients send it as their API key:
+Give each caller its own key. The key **is** the identity:
+
+```toml
+[[clients]]
+name = "geo-pipeline"
+key = "<openssl rand -hex 32>"
+models = ["claude-sonnet-*", "claude-haiku-*"]   # optional; empty = all models
+
+[[clients]]
+name = "radar"
+key = "<openssl rand -hex 32>"
+```
 
 ```bash
 export ANTHROPIC_BASE_URL=https://your-proxy.example.com
-export ANTHROPIC_API_KEY=your-proxy-secret
+export ANTHROPIC_API_KEY=<that client's key>
 ```
 
+Claude Code sends it as `x-api-key`; the proxy validates it and swaps in the real account token, so no Anthropic credentials or OAuth login are needed on the client. `/v1/chat/completions` additionally accepts `Authorization: Bearer <key>`, since OpenAI SDKs send nothing else.
+
 > [!IMPORTANT]
-> Claude Code sends the proxy key as `x-api-key`. The proxy validates it and swaps in the real account token. No Anthropic credentials or OAuth login needed on the client.
+> With `[[clients]]` configured, **`x-client-id` and the `client_names` IP map are ignored entirely** — `client_id` comes from the verified credential. That is what makes per-client budgets, utilization ceilings, operator status, model allow-lists and response-cache tenancy enforceable rather than advisory: all five key on `client_id`.
+
+Keys are compared in constant time against the whole table. Duplicate names, duplicate keys, and a `[response_cache].clients` entry naming no configured client all fail at startup.
+
+### Legacy shared secret (`proxy_key`)
+
+```toml
+proxy_key = "your-secret-key-here"
+```
+
+One secret for everyone, sent as `x-api-key`. It authenticates but does **not** identify — every caller presents the same string, so `client_id` still comes from the client-asserted `X-Client-ID` header and a per-client model allow-list would be defeated by editing one header.
+
+**Migration:** replace `proxy_key` with one `[[clients]]` entry per caller, hand each its own key, then drop `proxy_key`. Setting both is rejected at startup with a named error rather than silently precedence-ordered, so a half-applied migration cannot leave the weaker scheme quietly in force. Do it in this order — add `[[clients]]`, cut over the callers, remove `proxy_key` — and no caller breaks mid-flight.
 
 ### Client Identification
 
-Clients are identified for usage tracking and budget enforcement:
+With `[[clients]]`: the authenticated principal's `name`. Full stop.
+
+Without it (legacy / open), identity is resolved from the request:
 
 1. **`X-Client-ID` header** — explicit, takes priority
 2. **`client_names` IP mapping** — fallback based on source IP
@@ -243,26 +281,36 @@ Clients are identified for usage tracking and budget enforcement:
 
 Per-client token usage and budget status appear in `/_stats`.
 
+### Per-client model allow-lists
+
+`clients[].models` restricts which models a client may request, using the same exact-match + `*`-suffix wildcard semantics as `endpoints[].models`. Empty or absent = all models allowed.
+
+A request for a model outside the list is rejected with **403** — a policy denial, distinct from the 429s that mean "capacity, try later" — and counted as `anthropic_client_model_denied_total{client,model}`. Operators bypass it, as they do every other gate check. The check sits in `pre_request_gate`, which both `/v1/messages` and `/v1/chat/completions` route through, so it covers both surfaces.
+
+> [!WARNING]
+> An allow-list is only as strong as the identity it keys on. Under the legacy `proxy_key` (or an open proxy) `client_id` is caller-asserted, so the allow-list is advisory at best — configure `[[clients]]` if you need it enforced.
+
 ---
 
 ## Security
 
-Three layers, all optional — use what fits:
+> [!CAUTION]
+> **Every layer below is opt-in and OFF unless you configure it.** Unset `allowed_ips` means allow all; unset `clients` *and* `proxy_key` means no authentication at all. A default install accepts any request from any source. There is no default-deny.
 
-| Layer | Config | Effect |
-|:------|:-------|:-------|
-| **Listen binding** | `listen = "127.0.0.1:8082"` | Only accepts connections on that interface |
-| **IP allowlist** | `allowed_ips = ["100.64.0.0/10"]` | Rejects unlisted source IPs (403) |
-| **Proxy key** | `proxy_key = "secret"` | Requires `x-api-key` header match (401) |
+| Layer | Config | Effect | Unset behaviour |
+|:------|:-------|:-------|:----------------|
+| **Listen binding** | `listen = "127.0.0.1:8082"` | Only accepts connections on that interface | — (required) |
+| **IP allowlist** | `allowed_ips = ["100.64.0.0/10"]` | Rejects unlisted source IPs (403) | **allow all** |
+| **Per-client keys** | `[[clients]]` | Requires a per-client credential; identity = the credential (401) | **no auth** |
+| **Proxy key** (legacy) | `proxy_key = "secret"` | Requires a single shared `x-api-key` (401) | **no auth** |
+| **Model allow-list** | `clients[].models` | Rejects models outside a client's list (403) | all models |
 
-IP check runs first, then proxy key. Both apply to all endpoints including `/_stats`.
-
-> [!WARNING]
-> With no `proxy_key` and no `allowed_ips`, the proxy is **open to all**. This is fine on a private network (VPN) or localhost, but never expose an open proxy to the internet.
+IP check runs first, then the credential check. Both apply to every route including `/_stats` and `/metrics`. Credentials are compared in constant time.
 
 ### Known Limitations
 
-- **Client ID spoofing**: `x-client-id` header takes priority over IP-based `client_names` mapping. Any authenticated client can claim any identity, including operator names. This is acceptable because all clients are already inside the trust boundary (IP allowlist + proxy key). If you expose the proxy to untrusted networks, invert the priority in `resolve_client_id()`.
+- **`/_stats` and `/metrics` are not operator-gated**: any client holding *any* valid credential can read them, and `/_stats` exposes endpoint names and per-client usage. Restricting them to an operator principal is tracked separately.
+- **Client ID spoofing (legacy configs only)**: without `[[clients]]`, the `x-client-id` header takes priority over the `client_names` IP mapping, so any authenticated client can claim any identity — including an operator name, another client's budget, or another client's response-cache tenant. Configure `[[clients]]` to close this; it is the reason that mode exists.
 - **Emergency brake is model-blind**: The brake evaluates worst-case utilization across all model claims. If sonnet is exhausted but haiku has headroom, the brake blocks all traffic including haiku. This is intentional fail-safe behavior.
 
 ---
@@ -306,6 +354,11 @@ long"* are additionally counted as `anthropic_prompt_too_long_total{model}`
 on `/metrics` and logged as a structured WARN with the redacted session
 label plus the observed-vs-max token counts parsed from the error message.
 The 400 itself is forwarded to the client unchanged.
+
+Requests rejected by a client's model allow-list are counted as
+`anthropic_client_model_denied_total{client,model}` and logged at WARN. The
+`model` label is caller-controlled, so it is bounded — overflow past 64
+distinct pairs buckets into `model="_other"`.
 
 ### OpenAI JSON-mode compatibility
 
@@ -577,16 +630,20 @@ store / error counters are exposed on `/metrics`, one series per endpoint
 (`anthropic_response_cache_*_total{surface="messages"}` and
 `{surface="count_tokens"}`).
 
-> [!WARNING]
-> **Allow-listed clients must mutually trust each other.** Client identity is
-> the client-asserted `x-client-id` header — the proxy's identity model is
-> trust-based (see [Security](#security)). Per-client encryption keys are
-> derived from that asserted identity, so any authenticated caller who
-> *presents* an opted-in client's ID can read that client's cached responses
-> (prompt content included). This is a *read* capability on top of the
-> pre-existing impersonation surface (budget-burning). Only opt in clients
-> that already share a trust domain, and treat the allow-list as one
-> confidentiality boundary, not N.
+> [!IMPORTANT]
+> **Cache isolation is only as strong as the identity it is keyed on.**
+> Per-client encryption keys are derived from `client_id`, so what that
+> derivation buys depends on where `client_id` comes from:
+>
+> - **With `[[clients]]`** (recommended): `client_id` is a verified principal,
+>   so the derivation is a real confidentiality boundary — N clients, N
+>   boundaries. Every name in `[response_cache].clients` must match a
+>   configured client, enforced at startup.
+> - **Without it** (legacy `proxy_key` / open): `client_id` is the
+>   client-asserted `x-client-id` header, so any authenticated caller who
+>   *presents* an opted-in client's ID reads that client's cached responses,
+>   prompt content included. In that mode the allow-list is **one** trust
+>   domain, not N — only opt in clients that already trust each other.
 
 > [!WARNING]
 > **Non-determinism caveat — opting in is consent to replay.** Sampling

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,16 +9,54 @@ strategy = "dynamic-capacity-v1"
 rate_limit_cooldown_secs = 60
 probe_interval_secs = 300
 
-# Proxy authentication: clients must send this as x-api-key to access the proxy.
-# Omit to leave proxy open (only do so on a trusted/private network).
+# ── Authentication ────────────────────────────────────────────────────
+#
+# Two mutually exclusive modes. Configuring BOTH fails startup — see README
+# "Authentication".
+#
+# 1. [[clients]] (recommended): each caller gets its OWN key, and the matched
+#    entry's `name` becomes the request's client_id. The x-client-id header and
+#    the client_names IP map are then IGNORED — identity cannot be asserted by
+#    the caller. That makes client_budgets, client_utilization_limits,
+#    operators, the per-client model allow-list and the response-cache tenant
+#    all unspoofable, because every one of them keys on client_id.
+#
+#    Keys are compared in constant time. Generate one per client:
+#      openssl rand -hex 32
+#    SECRETS: like proxy_key and the endpoint tokens below, these are rendered
+#    from the secret store at deploy time — this example file holds only
+#    placeholders.
+#
+# [[clients]]
+# name = "geo-pipeline"
+# key = "<from secret store: openssl rand -hex 32>"
+# models = ["claude-sonnet-*", "claude-haiku-*"]  # omit/empty = all models
+#
+# [[clients]]
+# name = "radar"
+# key = "<from secret store: openssl rand -hex 32>"
+#
+# 2. proxy_key (LEGACY): one shared secret for everyone, sent as x-api-key. It
+#    authenticates but does NOT identify — every caller presents the same string,
+#    so client_id still comes from the (client-asserted) x-client-id header and
+#    a per-client model allow-list would be defeated by editing one header.
+#    Migrate to [[clients]].
 # proxy_key = "your-secret-key-here"
+#
+# Omitting BOTH leaves the proxy open to anyone who can reach it — only do so
+# on a trusted private network, and note that allowed_ips below is likewise
+# unset-permissive.
 
 # IP allowlist: only accept connections from these IPs/CIDRs.
 # Supports individual IPs and CIDR ranges. Omit or leave empty to allow all.
+# NOTE: omitted = ALLOW ALL. This is not a default-deny.
 # allowed_ips = ["100.64.0.0/10", "10.0.0.0/8", "1.2.3.4"]
 
-# Operators: these client_ids are never throttled by utilization limits, budget limits,
-# or the emergency brake. Identity resolved via x-client-id header or client_names IP map.
+# Operators: these client_ids are never throttled by utilization limits, budget
+# limits, the emergency brake, or the per-client model allow-list.
+# Under [[clients]] these name authenticated principals. Without it, identity is
+# resolved via the x-client-id header or the client_names IP map — i.e. operator
+# status is then trust-based and forgeable.
 # operators = ["ray", "openclaw", "claude"]
 
 # Per-client utilization limits: clients are 429'd when ALL model-compatible endpoints
@@ -56,9 +94,14 @@ probe_interval_secs = 300
 # backend only ever holds ciphertext. Omit the section (or leave clients
 # empty) to disable entirely. NOTE: an opted-in client replaying an identical
 # temperature > 0 request gets the SAME answer back, by design.
-# SECURITY: x-client-id is client-asserted, so allow-listed clients must
-# mutually trust each other — presenting an opted-in client's ID reads its
-# cached responses. One trust domain per allow-list.
+# SECURITY: entries here name client IDs, and each client's cache is encrypted
+# under a key derived from that ID. Under [[clients]] the ID is an
+# authenticated principal, so that derivation is a real isolation boundary and
+# every name below must match a configured [[clients]] entry (a typo fails
+# startup rather than silently disabling the cache for that client). WITHOUT
+# [[clients]], client IDs are client-asserted: allow-listed clients must then
+# mutually trust each other, because presenting an opted-in client's ID reads
+# its cached responses. One trust domain per allow-list in that mode.
 # SECRETS: master_key / api_key are placeholders — NEVER commit real values.
 # Like proxy_key and endpoint tokens, the rendered config file IS the secret
 # vehicle: deployments template it from the secret store at pod start (see

--- a/config.toml.example
+++ b/config.toml.example
@@ -10,23 +10,15 @@ rate_limit_cooldown_secs = 60
 probe_interval_secs = 300
 
 # ── Authentication ────────────────────────────────────────────────────
+# Full explanation: README "Authentication". Two mutually exclusive modes;
+# configuring both, or neither, is covered there.
 #
-# Two mutually exclusive modes. Configuring BOTH fails startup — see README
-# "Authentication".
-#
-# 1. [[clients]] (recommended): each caller gets its OWN key, and the matched
-#    entry's `name` becomes the request's client_id. The x-client-id header and
-#    the client_names IP map are then IGNORED — identity cannot be asserted by
-#    the caller. That makes client_budgets, client_utilization_limits,
-#    operators, the per-client model allow-list and the response-cache tenant
-#    all unspoofable, because every one of them keys on client_id.
-#
-#    Keys are compared in constant time. Generate one per client:
-#      openssl rand -hex 32
-#    SECRETS: like proxy_key and the endpoint tokens below, these are rendered
-#    from the secret store at deploy time — this example file holds only
-#    placeholders.
-#
+# [[clients]] — per-caller key; the matched entry's `name` becomes client_id,
+# so x-client-id and the client_names IP map are IGNORED. Generate keys with
+# `openssl rand -hex 32`; like proxy_key and the endpoint tokens below they are
+# rendered from the secret store at deploy time — placeholders only here.
+# Incompatible with `token = "passthrough"` endpoints (rejected at startup:
+# passthrough would forward these keys upstream).
 # [[clients]]
 # name = "geo-pipeline"
 # key = "<from secret store: openssl rand -hex 32>"
@@ -35,17 +27,10 @@ probe_interval_secs = 300
 # [[clients]]
 # name = "radar"
 # key = "<from secret store: openssl rand -hex 32>"
-#
-# 2. proxy_key (LEGACY): one shared secret for everyone, sent as x-api-key. It
-#    authenticates but does NOT identify — every caller presents the same string,
-#    so client_id still comes from the (client-asserted) x-client-id header and
-#    a per-client model allow-list would be defeated by editing one header.
-#    Migrate to [[clients]].
+
+# proxy_key — LEGACY single shared secret. Authenticates but does not identify.
+# Mutually exclusive with [[clients]]; omitting both leaves the proxy OPEN.
 # proxy_key = "your-secret-key-here"
-#
-# Omitting BOTH leaves the proxy open to anyone who can reach it — only do so
-# on a trusted private network, and note that allowed_ips below is likewise
-# unset-permissive.
 
 # IP allowlist: only accept connections from these IPs/CIDRs.
 # Supports individual IPs and CIDR ranges. Omit or leave empty to allow all.

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::{
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use subtle::ConstantTimeEq;
 use tokio::sync::RwLock;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, trace, warn};
@@ -33,8 +34,20 @@ struct Config {
     rate_limit_cooldown_secs: Option<u64>,
     /// Seconds between utilization probes per account (0 = disabled). Default: 300 (5 min)
     probe_interval_secs: Option<u64>,
-    /// Shared secret clients must send as x-api-key to access the proxy. None = open.
+    /// LEGACY single shared secret, sent as x-api-key. None = open.
+    /// Superseded by `[[clients]]`; configuring both is rejected at startup
+    /// (`reject_legacy_config_keys`) rather than silently precedence-ordered.
     proxy_key: Option<String>,
+    /// Per-client credentials (LAB-1083). When non-empty, EVERY authenticated
+    /// entry point requires a credential matching one of these keys, and the
+    /// matched entry's `name` becomes the request's `client_id` — the
+    /// `x-client-id` header and the `client_names` IP map are then ignored
+    /// entirely. That is the whole point: budgets, utilization ceilings,
+    /// operator bypass, the model allow-list and the response-cache tenant all
+    /// key on `client_id`, so making it unforgeable makes all five unforgeable
+    /// at once.
+    #[serde(default)]
+    clients: Vec<ClientConfig>,
     /// Source IP allowlist. Supports individual IPs and CIDR ranges. None/empty = allow all.
     allowed_ips: Option<Vec<String>>,
     /// Unified routing endpoints. Each entry is either Anthropic-native or
@@ -102,6 +115,39 @@ struct Config {
     /// Opt-in encrypted response cache on `/v1/messages` (LAB-933).
     /// Absent, or present with an empty `clients` list = feature entirely inert.
     response_cache: Option<ResponseCacheConfig>,
+}
+
+/// `[[clients]]` — one authenticated caller. The `key` IS the identity: it is
+/// what the caller presents, and `name` is what the proxy attributes the
+/// request to. No `x-client-id` header can override it.
+#[derive(Deserialize, Clone)]
+struct ClientConfig {
+    /// Identity this credential resolves to. Becomes `client_id`, so it is what
+    /// `client_budgets`, `client_utilization_limits`, `operators` and
+    /// `[response_cache].clients` must name.
+    name: String,
+    /// Shared secret this client presents as `x-api-key` (or, on the
+    /// OpenAI-compat surface, `Authorization: Bearer`). Compared in constant
+    /// time against the whole table.
+    key: String,
+    /// Models this client may request. Empty = all models, mirroring
+    /// `EndpointConfig.models` semantics. Same exact + `*`-suffix matcher.
+    #[serde(default)]
+    models: Vec<String>,
+}
+
+/// Hand-written, NOT derived: a derived `Debug` would print `key` verbatim into
+/// any log line, panic message or test assertion that formats this struct —
+/// which is precisely how credentials end up in a log aggregator. Same posture
+/// as `debug_header_value`'s redaction of sensitive headers.
+impl std::fmt::Debug for ClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientConfig")
+            .field("name", &self.name)
+            .field("key", &"<redacted>")
+            .field("models", &self.models)
+            .finish()
+    }
 }
 
 /// `[response_cache]` — opt-in, client-side-encrypted response cache on
@@ -374,6 +420,10 @@ const TAU_1H: f64 = 3600.0;
 /// deployments have a handful of clients, far below this; the cap only bounds
 /// unknown/abusive header values — existing clients keep updating past it.
 const MAX_TRACKED_CLIENTS: usize = 10_000;
+
+/// Cap on distinct (client, model) labels in the allowlist-denial counter.
+/// The model half is caller-controlled; overflow buckets into `_other`.
+const MAX_MODEL_DENIED_LABELS: usize = 64;
 const TAU_6H: f64 = 21600.0;
 
 /// Per-account burn rate tracker: requests per minute at three time scales.
@@ -533,20 +583,32 @@ struct Endpoint {
     last_effective_gate: AtomicU64,
 }
 
+/// Exact match with `*`-suffix wildcards. Empty pattern list, or an empty
+/// model, allows everything.
+///
+/// The SINGLE implementation behind both model allowlists: which models an
+/// *endpoint* may serve (`Endpoint::serves_model`) and which models a *client*
+/// may request (`AppState::client_allows_model`, LAB-1083). Two matchers would
+/// be two sets of wildcard semantics to keep in sync, and the divergence would
+/// show up as a policy bypass rather than a test failure.
+fn model_matches(patterns: &[String], model: &str) -> bool {
+    if patterns.is_empty() || model.is_empty() {
+        return true;
+    }
+    patterns.iter().any(|pattern| {
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            model.starts_with(prefix)
+        } else {
+            model == pattern
+        }
+    })
+}
+
 impl Endpoint {
     /// Check if this endpoint can serve the given model. Empty allowlist = all.
     /// Identical to the historical `Account::serves_model` predicate.
     fn serves_model(&self, model: &str) -> bool {
-        if self.models.is_empty() || model.is_empty() {
-            return true;
-        }
-        self.models.iter().any(|pattern| {
-            if let Some(prefix) = pattern.strip_suffix('*') {
-                model.starts_with(prefix)
-            } else {
-                model == pattern
-            }
-        })
+        model_matches(&self.models, model)
     }
 }
 
@@ -571,7 +633,13 @@ struct AppState {
     /// exercise breaker re-entry without a 30s sleep.
     transport_cooldown: Duration,
     state_path: PathBuf,
+    /// Legacy single shared secret. Mutually exclusive with `clients`.
     proxy_key: Option<String>,
+    /// Authenticated client registry (LAB-1083). Non-empty ⇒ every request
+    /// through an authenticated entry point carries a verified principal, and
+    /// `client_id` is that principal's name rather than a client-asserted
+    /// header. Empty ⇒ legacy `proxy_key` / open behaviour.
+    clients: Vec<ClientConfig>,
     allowed_ips: Vec<IpAllowEntry>,
     client_names: HashMap<String, String>,
     auto_cache: bool,
@@ -645,6 +713,12 @@ struct AppState {
     /// Upstream "prompt is too long" 400s by model (LAB-916). Exposed as
     /// `anthropic_prompt_too_long_total`; bounded via `_other` overflow.
     prompt_too_long: Mutex<HashMap<String, u64>>,
+    /// Per-client model-allowlist denials, keyed (client, model) (LAB-1083).
+    /// Exposed as `anthropic_client_model_denied_total`. `client` is an
+    /// authenticated principal so it is bounded by config, but `model` is
+    /// caller-controlled — bounded via the same `_other` overflow as
+    /// `prompt_too_long`.
+    model_denied: Mutex<HashMap<(String, String), u64>>,
     /// (endpoint idx, model) pairs an upstream rejected as unsupported — a
     /// gateway without the model, or a plan without access (LAB-941).
     /// `routing_candidates` skips these until the entry expires; because
@@ -1388,9 +1462,127 @@ impl AppState {
         self.allowed_ips.is_empty() || self.allowed_ips.iter().any(|e| e.contains(ip))
     }
 
+    /// Authenticate a request's credential (LAB-1083).
+    ///
+    /// Returns the authenticated principal when `[[clients]]` is configured,
+    /// `None` when it is not (legacy `proxy_key`, or an open proxy), and a 401
+    /// `Response` when a configured credential does not match.
+    ///
+    /// `allow_bearer` additionally accepts `Authorization: Bearer` — set only
+    /// on the OpenAI-compat surface, whose SDKs send nothing else. It is NOT
+    /// enabled on the native surface, where `Authorization` may legitimately
+    /// carry the caller's own upstream token in `passthrough` mode; widening
+    /// acceptance there would be a gratuitous auth surface on a ticket whose
+    /// whole purpose is to narrow one.
+    fn authenticate(
+        &self,
+        client_ip: &IpAddr,
+        headers: &hyper::HeaderMap,
+        allow_bearer: bool,
+    ) -> Result<Option<&ClientConfig>, Box<Response>> {
+        // Boxed Err, matching `reserve_request_body` — an inline `Response` is
+        // 128+ bytes on the hot success path (clippy::result_large_err).
+        let unauthorized = || -> Box<Response> {
+            warn!(client = %client_ip, "rejected: invalid or missing credential");
+            Box::new((StatusCode::UNAUTHORIZED, "unauthorized").into_response())
+        };
+        let from_header = headers.get("x-api-key").and_then(|v| v.to_str().ok());
+        let from_bearer = if allow_bearer {
+            headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| {
+                    // RFC 7235: auth scheme is case-insensitive
+                    if v.len() >= 7 && v[..7].eq_ignore_ascii_case("bearer ") {
+                        Some(&v[7..])
+                    } else {
+                        None
+                    }
+                })
+        } else {
+            None
+        };
+
+        if !self.clients.is_empty() {
+            for presented in [from_header, from_bearer].into_iter().flatten() {
+                if let Some(c) = self.match_client(presented) {
+                    return Ok(Some(c));
+                }
+            }
+            return Err(unauthorized());
+        }
+
+        // Legacy: one shared secret, no principal. Byte-for-byte the same
+        // accept/reject decision as before LAB-1083 — only the comparison
+        // primitive changed (audit finding 4).
+        if let Some(ref key) = self.proxy_key {
+            let ok = [from_header, from_bearer]
+                .into_iter()
+                .flatten()
+                .any(|p| bool::from(key.as_bytes().ct_eq(p.as_bytes())));
+            if !ok {
+                return Err(unauthorized());
+            }
+        }
+        Ok(None)
+    }
+
+    /// Constant-time lookup of a presented credential in the client table.
+    ///
+    /// Scans the ENTIRE table with no early exit: `break`ing on the first hit
+    /// would leak, by response time, *which* client matched — and on a miss,
+    /// how far down the table a near-miss got. `ct_eq` itself is what stops the
+    /// per-byte prefix leak that `==` has (audit finding 4). Note `ct_eq`
+    /// short-circuits on unequal lengths; credential length is not a secret.
+    fn match_client(&self, presented: &str) -> Option<&ClientConfig> {
+        let mut hit: Option<&ClientConfig> = None;
+        for c in &self.clients {
+            if bool::from(c.key.as_bytes().ct_eq(presented.as_bytes())) {
+                hit = Some(c);
+            }
+        }
+        hit
+    }
+
+    /// Whether `client_id` may request `model` (LAB-1083).
+    ///
+    /// Unknown client, or a client with an empty list, allows everything —
+    /// mirroring `Endpoint::serves_model`. "Unknown client" is only reachable
+    /// on the legacy path: with `[[clients]]` configured, `client_id` is always
+    /// a principal name, so there is no gap to slip through.
+    fn client_allows_model(&self, client_id: &str, model: &str) -> bool {
+        match self.clients.iter().find(|c| c.name == client_id) {
+            Some(c) => model_matches(&c.models, model),
+            None => true,
+        }
+    }
+
+    /// Count + log a model-allowlist denial. Model labels are bounded by
+    /// `_other` overflow (the model string is caller-controlled).
+    fn note_model_denied(&self, client_id: &str, model: &str) {
+        if let Ok(mut counts) = self.model_denied.lock() {
+            let key = (client_id.to_owned(), model.to_owned());
+            let label = if counts.len() < MAX_MODEL_DENIED_LABELS || counts.contains_key(&key) {
+                key
+            } else {
+                (client_id.to_owned(), "_other".to_owned())
+            };
+            *counts.entry(label).or_insert(0) += 1;
+        }
+        warn!(
+            client_id = %client_id,
+            model = %model,
+            "rejected: model not in client allow-list"
+        );
+    }
+
     /// Resolve client identity: x-client-id header → IP map fallback → "-"
     ///
     /// Header takes precedence to support multiple clients per IP.
+    ///
+    /// ONLY reached when no `[[clients]]` table is configured. Under
+    /// `[[clients]]`, identity comes from the verified credential
+    /// (`RequestContext::from_request`) and this client-asserted path is dead.
     fn resolve_client_id(&self, ip: &IpAddr, headers: &hyper::HeaderMap) -> String {
         if let Some(id) = headers.get("x-client-id").and_then(|v| v.to_str().ok()) {
             let id = id.trim();
@@ -4569,9 +4761,23 @@ fn affinity_routing_key(
 }
 
 impl RequestContext {
-    fn from_request(state: &AppState, client_ip: &IpAddr, headers: &axum::http::HeaderMap) -> Self {
+    /// `principal` is the authenticated client from `AppState::authenticate`.
+    /// When present it IS the identity — `x-client-id` and the `client_names`
+    /// IP map are not consulted at all. This one substitution is what makes
+    /// budgets, ceilings, operator bypass, the model allow-list and the
+    /// response-cache tenant unspoofable: every one of them keys on
+    /// `client_id`, and this is where `client_id` is born.
+    fn from_request(
+        state: &AppState,
+        client_ip: &IpAddr,
+        headers: &axum::http::HeaderMap,
+        principal: Option<&ClientConfig>,
+    ) -> Self {
         Self {
-            client_id: state.resolve_client_id(client_ip, headers),
+            client_id: match principal {
+                Some(c) => c.name.clone(),
+                None => state.resolve_client_id(client_ip, headers),
+            },
             client_ver: headers
                 .get("user-agent")
                 .and_then(|v| v.to_str().ok())
@@ -5326,6 +5532,20 @@ impl AppState {
     async fn pre_request_gate(&self, client_id: &str, model: &str) -> Result<(), Response> {
         if self.is_operator(client_id) {
             return Ok(()); // operator bypasses everything
+        }
+
+        // 0. Per-client model allow-list (LAB-1083). First because it is a
+        //    POLICY denial, not a capacity one: "you may not use this model"
+        //    must not be reported as 429 "try again later", which is what the
+        //    three checks below all mean. Reached from both proxy_handler and
+        //    openai_chat_handler, so one placement covers both surfaces.
+        if !self.client_allows_model(client_id, model) {
+            self.note_model_denied(client_id, model);
+            return Err((
+                StatusCode::FORBIDDEN,
+                format!("client '{client_id}' is not permitted to use model '{model}'"),
+            )
+                .into_response());
         }
 
         // 1. Daily token budget (existing)
@@ -6533,14 +6753,11 @@ async fn proxy_handler(
         return (StatusCode::FORBIDDEN, "forbidden").into_response();
     }
 
-    // Proxy auth: validate x-api-key against proxy_key if configured
-    if let Some(ref key) = state.proxy_key {
-        let provided = req.headers().get("x-api-key").and_then(|v| v.to_str().ok());
-        if provided != Some(key.as_str()) {
-            warn!(client = %client_ip, "rejected: invalid or missing proxy key");
-            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
-        }
-    }
+    // Proxy auth: x-api-key against the [[clients]] table, else legacy proxy_key.
+    let principal = match state.authenticate(&client_ip, req.headers(), false) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
 
     let (parts, body) = req.into_parts();
 
@@ -6551,7 +6768,7 @@ async fn proxy_handler(
     );
 
     // Extract client identification headers
-    let rctx = RequestContext::from_request(&state, &client_ip, &parts.headers);
+    let rctx = RequestContext::from_request(&state, &client_ip, &parts.headers, principal);
     let RequestContext {
         client_id,
         client_ver,
@@ -7471,11 +7688,8 @@ async fn stats_handler(
     if !state.is_ip_allowed(&client_addr.ip()) {
         return (StatusCode::FORBIDDEN, "forbidden").into_response();
     }
-    if let Some(ref key) = state.proxy_key {
-        let provided = req.headers().get("x-api-key").and_then(|v| v.to_str().ok());
-        if provided != Some(key.as_str()) {
-            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
-        }
+    if let Err(resp) = state.authenticate(&client_addr.ip(), req.headers(), false) {
+        return *resp;
     }
 
     let now_epoch = AppState::now_epoch();
@@ -7945,11 +8159,8 @@ async fn metrics_handler(
     if !state.is_ip_allowed(&client_addr.ip()) {
         return (StatusCode::FORBIDDEN, "forbidden").into_response();
     }
-    if let Some(ref key) = state.proxy_key {
-        let provided = req.headers().get("x-api-key").and_then(|v| v.to_str().ok());
-        if provided != Some(key.as_str()) {
-            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
-        }
+    if let Err(resp) = state.authenticate(&client_addr.ip(), req.headers(), false) {
+        return *resp;
     }
 
     let now_epoch = AppState::now_epoch();
@@ -8013,6 +8224,12 @@ async fn metrics_handler(
     let cluster_info = state.cluster_info_cache.lock().ok().and_then(|g| g.clone());
     let prompt_too_long: Vec<(String, u64)> = state
         .prompt_too_long
+        .lock()
+        .ok()
+        .map(|g| g.iter().map(|(k, v)| (k.clone(), *v)).collect())
+        .unwrap_or_default();
+    let model_denied: Vec<((String, String), u64)> = state
+        .model_denied
         .lock()
         .ok()
         .map(|g| g.iter().map(|(k, v)| (k.clone(), *v)).collect())
@@ -8826,6 +9043,24 @@ async fn metrics_handler(
             &mut buf,
             "anthropic_prompt_too_long_total",
             &[("model", model.as_str())],
+            *n,
+        );
+    }
+
+    // Per-client model-allowlist denials (LAB-1083). A non-zero rate here is
+    // either a misconfigured caller or a caller reaching for capacity it was
+    // deliberately denied — both worth an alert.
+    prom_header(
+        &mut buf,
+        "anthropic_client_model_denied_total",
+        "counter",
+        "Requests rejected (403) by the per-client model allow-list",
+    );
+    for ((client, model), n) in &model_denied {
+        prom_counter(
+            &mut buf,
+            "anthropic_client_model_denied_total",
+            &[("client", client.as_str()), ("model", model.as_str())],
             *n,
         );
     }
@@ -10780,27 +11015,12 @@ async fn openai_chat_handler(
         return (StatusCode::FORBIDDEN, "forbidden").into_response();
     }
 
-    // Proxy auth: accept if either x-api-key or Authorization: Bearer matches
-    if let Some(ref key) = state.proxy_key {
-        let from_header = req.headers().get("x-api-key").and_then(|v| v.to_str().ok());
-        let from_bearer = req
-            .headers()
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| {
-                // RFC 7235: auth scheme is case-insensitive
-                if v.len() >= 7 && v[..7].eq_ignore_ascii_case("bearer ") {
-                    Some(&v[7..])
-                } else {
-                    None
-                }
-            });
-        let authorized = from_header == Some(key.as_str()) || from_bearer == Some(key.as_str());
-        if !authorized {
-            warn!(client = %client_ip, "rejected: invalid or missing proxy key");
-            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
-        }
-    }
+    // Proxy auth: accept the credential from either x-api-key or
+    // Authorization: Bearer — OpenAI SDKs send only the latter.
+    let principal = match state.authenticate(&client_ip, req.headers(), true) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
 
     let (parts, body) = req.into_parts();
 
@@ -10811,7 +11031,7 @@ async fn openai_chat_handler(
     );
 
     // Extract client identification headers
-    let rctx = RequestContext::from_request(&state, &client_ip, &parts.headers);
+    let rctx = RequestContext::from_request(&state, &client_ip, &parts.headers, principal);
     let affinity_key = rctx.affinity_key(&client_ip, None);
     let affinity = affinity_key.as_deref();
     let RequestContext {
@@ -11001,6 +11221,64 @@ async fn openai_chat_handler(
 /// Validate endpoint configuration. Returns the first hard error encountered.
 /// Soft warnings (non-canonical anthropic host, priority collision with an
 /// openai endpoint) are emitted as `warn!` and do not return an error.
+/// Startup validation for the `[[clients]]` registry (LAB-1083).
+///
+/// Every rule here exists because its violation fails SILENTLY at runtime
+/// rather than loudly: a duplicate key resolves to whichever entry the scan
+/// saw last, a duplicate or empty name silently merges two callers' budgets and
+/// cache tenancy, and a `[response_cache].clients` typo makes the cache inert
+/// for that client with no signal at all. Cheap to catch at boot; expensive to
+/// notice in production.
+fn validate_clients(
+    clients: &[ClientConfig],
+    response_cache: Option<&ResponseCacheConfig>,
+) -> Result<(), String> {
+    let mut seen_names: Vec<&str> = Vec::with_capacity(clients.len());
+    let mut seen_keys: Vec<&str> = Vec::with_capacity(clients.len());
+    for c in clients {
+        if c.name.trim().is_empty() {
+            return Err("client: name must not be empty".to_string());
+        }
+        if c.name == "-" {
+            return Err(
+                "client: name must not be \"-\" (the unknown-client sentinel — budget enforcement skips it)"
+                    .to_string(),
+            );
+        }
+        if c.key.is_empty() {
+            return Err(format!("client '{}': key must not be empty", c.name));
+        }
+        if seen_names.contains(&c.name.as_str()) {
+            return Err(format!("client '{}': duplicate name", c.name));
+        }
+        // Names, not keys, in the error — never log a credential.
+        if seen_keys.contains(&c.key.as_str()) {
+            return Err(format!(
+                "client '{}': duplicate key (already used by another client)",
+                c.name
+            ));
+        }
+        seen_names.push(&c.name);
+        seen_keys.push(&c.key);
+    }
+
+    // AC-6: one client registry, not two. Only enforceable when [[clients]] is
+    // configured — on the legacy path client ids are header-derived and there
+    // is no registry to check against.
+    if !clients.is_empty() {
+        if let Some(rc) = response_cache {
+            for name in &rc.clients {
+                if !seen_names.contains(&name.as_str()) {
+                    return Err(format!(
+                        "response_cache.clients: \"{name}\" names no configured [[clients]] entry"
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
     for ep in endpoints {
         if let Some(url) = ep.base_url.as_deref() {
@@ -11092,6 +11370,17 @@ fn reject_legacy_config_keys(value: &toml::Value) -> Result<(), String> {
                 .to_string(),
         );
     }
+    // LAB-1083: `proxy_key` is the legacy single shared secret, `[[clients]]`
+    // its per-client replacement. Rejecting the combination rather than
+    // precedence-ordering it is deliberate — a silent winner between two
+    // authentication schemes is exactly the ambiguity that gets an operator's
+    // migration half-applied and the weaker one left in force.
+    if table.contains_key("proxy_key") && table.contains_key("clients") {
+        return Err(
+            "config: proxy_key and [[clients]] are mutually exclusive — [[clients]] supersedes it; remove proxy_key (see README §Authentication)"
+                .to_string(),
+        );
+    }
     Ok(())
 }
 
@@ -11113,6 +11402,9 @@ async fn main() {
         .unwrap_or_else(|e| panic!("config parse error: {e}"));
     if let Err(msg) = validate_endpoints(&config.endpoints) {
         panic!("{msg}");
+    }
+    if let Err(msg) = validate_clients(&config.clients, config.response_cache.as_ref()) {
+        panic!("config: {msg}");
     }
 
     // Set up tracing: stderr (info+) always, plus optional debug log file
@@ -11240,8 +11532,19 @@ async fn main() {
         })
         .collect();
 
-    if config.proxy_key.is_some() {
-        info!("proxy authentication enabled (x-api-key)");
+    if !config.clients.is_empty() {
+        let with_allowlist = config
+            .clients
+            .iter()
+            .filter(|c| !c.models.is_empty())
+            .count();
+        info!(
+            clients = config.clients.len(),
+            with_model_allowlist = with_allowlist,
+            "per-client authentication enabled — x-client-id is ignored, identity comes from the credential"
+        );
+    } else if config.proxy_key.is_some() {
+        warn!("legacy shared proxy_key in use — every caller shares one identity; migrate to [[clients]] (see README §Authentication)");
     } else {
         warn!("proxy authentication DISABLED — proxy is open to all");
     }
@@ -11362,6 +11665,7 @@ async fn main() {
         transport_cooldown: TRANSPORT_UNHEALTHY_COOLDOWN,
         state_path,
         proxy_key: config.proxy_key.clone(),
+        clients: config.clients.clone(),
         allowed_ips,
         client_names: config.client_names.clone(),
         auto_cache: config.auto_cache.unwrap_or(true),
@@ -11409,6 +11713,7 @@ async fn main() {
             .session_registry_ttl_secs
             .unwrap_or(DEFAULT_SESSION_REGISTRY_TTL_SECS),
         prompt_too_long: Mutex::new(HashMap::new()),
+        model_denied: Mutex::new(HashMap::new()),
         unsupported_models: Mutex::new(HashMap::new()),
         response_cache,
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1656,7 +1656,10 @@ impl AppState {
         );
         if let Some(id) = headers.get("x-client-id").and_then(|v| v.to_str().ok()) {
             let id = id.trim();
-            if !id.is_empty() && id != "-" {
+            // "_operator" is the reserved operator-aggregation label on
+            // /_stats and /metrics — a self-asserted claim to it would merge
+            // this caller's usage into the hidden operator bucket.
+            if !id.is_empty() && id != "-" && id != "_operator" {
                 return id.to_string();
             }
         }
@@ -11391,6 +11394,12 @@ fn validate_clients(config: &Config) -> Result<(), String> {
         if c.name == "-" {
             return Err(
                 "client: name must not be \"-\" (the unknown-client sentinel — budget enforcement skips it)"
+                    .to_string(),
+            );
+        }
+        if c.name == "_operator" {
+            return Err(
+                "client: name must not be \"_operator\" (the reserved operator-aggregation label on /_stats and /metrics)"
                     .to_string(),
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,6 +424,24 @@ const MAX_TRACKED_CLIENTS: usize = 10_000;
 /// Cap on distinct (client, model) labels in the allowlist-denial counter.
 /// The model half is caller-controlled; overflow buckets into `_other`.
 const MAX_MODEL_DENIED_LABELS: usize = 64;
+
+/// Max chars retained from a caller-controlled string used as a metric label
+/// or echoed in an error body. The model field is bounded only by the request
+/// body cap, so an untruncated copy would be retained for the process lifetime
+/// and re-serialized on every `/metrics` scrape.
+const MAX_LABEL_CHARS: usize = 64;
+
+/// Truncate a caller-controlled string to `MAX_LABEL_CHARS`, marking that it
+/// was cut so an operator does not read a clipped value as the literal input.
+/// Char-based, not byte-based: slicing a UTF-8 string mid-codepoint panics.
+fn truncate_label(s: &str) -> String {
+    if s.chars().count() <= MAX_LABEL_CHARS {
+        return s.to_owned();
+    }
+    let mut out: String = s.chars().take(MAX_LABEL_CHARS).collect();
+    out.push('…');
+    out
+}
 const TAU_6H: f64 = 21600.0;
 
 /// Per-account burn rate tracker: requests per minute at three time scales.
@@ -1529,11 +1547,19 @@ impl AppState {
 
     /// Constant-time lookup of a presented credential in the client table.
     ///
-    /// Scans the ENTIRE table with no early exit: `break`ing on the first hit
-    /// would leak, by response time, *which* client matched — and on a miss,
-    /// how far down the table a near-miss got. `ct_eq` itself is what stops the
-    /// per-byte prefix leak that `==` has (audit finding 4). Note `ct_eq`
-    /// short-circuits on unequal lengths; credential length is not a secret.
+    /// What this actually guarantees, precisely — do not read more into it:
+    /// `ct_eq` removes the per-byte prefix oracle that `==` has, which is the
+    /// leak that matters (it is what lets an attacker recover a key byte by
+    /// byte). Audit finding 4, closed.
+    ///
+    /// The full-table scan removes the coarse "how far down the table did we
+    /// get" signal. It does NOT make the whole function constant-time: the
+    /// `hit = Some(c)` store is a data-dependent branch the optimizer may
+    /// emit as one, and `ct_eq` short-circuits on unequal lengths. Both
+    /// residuals are a handful of instructions against milliseconds of network
+    /// and TLS jitter, and key length is not a secret — so neither is
+    /// exploitable remotely. Want the stronger property? Accumulate with
+    /// `subtle::Choice`; don't assume this already does.
     fn match_client(&self, presented: &str) -> Option<&ClientConfig> {
         let mut hit: Option<&ClientConfig> = None;
         for c in &self.clients {
@@ -1546,34 +1572,67 @@ impl AppState {
 
     /// Whether `client_id` may request `model` (LAB-1083).
     ///
-    /// Unknown client, or a client with an empty list, allows everything —
-    /// mirroring `Endpoint::serves_model`. "Unknown client" is only reachable
-    /// on the legacy path: with `[[clients]]` configured, `client_id` is always
-    /// a principal name, so there is no gap to slip through.
+    /// Unknown client, or a client with an empty list, allows everything.
+    /// "Unknown client" is only reachable on the legacy path: with
+    /// `[[clients]]` configured, `client_id` is always a principal name.
+    ///
+    /// FAILS CLOSED on an empty `model`, and this is the one place where the
+    /// shared matcher's semantics are deliberately NOT inherited. An empty
+    /// model means the caller's model is UNKNOWN to us — the body did not
+    /// parse as JSON, or it carries no top-level `model` (the batches API
+    /// nests it under `requests[].params.model`, and `proxy_handler` is the
+    /// catch-all route). For `Endpoint::serves_model` "unknown" rightly means
+    /// "don't narrow the routing pool"; for a policy gate it must mean
+    /// "deny", or a restricted client reaches any model by sending a body we
+    /// cannot read.
     fn client_allows_model(&self, client_id: &str, model: &str) -> bool {
         match self.clients.iter().find(|c| c.name == client_id) {
-            Some(c) => model_matches(&c.models, model),
+            Some(c) if c.models.is_empty() => true,
+            Some(c) => !model.is_empty() && model_matches(&c.models, model),
             None => true,
         }
     }
 
-    /// Count + log a model-allowlist denial. Model labels are bounded by
-    /// `_other` overflow (the model string is caller-controlled).
+    /// Count + log a model-allowlist denial.
+    ///
+    /// The model string is caller-controlled and bounded only by the request
+    /// body cap, so it is truncated BEFORE becoming a map key: an untruncated
+    /// label would be retained for the process lifetime and re-serialized into
+    /// the `/metrics` body on every scrape. Label COUNT is separately bounded
+    /// by `_other` overflow.
+    ///
+    /// Logs at `warn` the first time a (client, model) pair is denied and at
+    /// `debug` thereafter — a client hammering a denied model must not be able
+    /// to drive unbounded warn-level log volume. The counter still records
+    /// every denial. Mirrors the once-per-model pattern used for
+    /// unsupported-model warnings.
     fn note_model_denied(&self, client_id: &str, model: &str) {
+        let model = truncate_label(model);
+        let mut first_time = true;
         if let Ok(mut counts) = self.model_denied.lock() {
-            let key = (client_id.to_owned(), model.to_owned());
+            let key = (client_id.to_owned(), model.clone());
             let label = if counts.len() < MAX_MODEL_DENIED_LABELS || counts.contains_key(&key) {
                 key
             } else {
                 (client_id.to_owned(), "_other".to_owned())
             };
-            *counts.entry(label).or_insert(0) += 1;
+            let entry = counts.entry(label).or_insert(0);
+            first_time = *entry == 0;
+            *entry += 1;
         }
-        warn!(
-            client_id = %client_id,
-            model = %model,
-            "rejected: model not in client allow-list"
-        );
+        if first_time {
+            warn!(
+                client_id = %client_id,
+                model = %model,
+                "rejected: model not in client allow-list"
+            );
+        } else {
+            debug!(
+                client_id = %client_id,
+                model = %model,
+                "rejected: model not in client allow-list"
+            );
+        }
     }
 
     /// Resolve client identity: x-client-id header → IP map fallback → "-"
@@ -1583,7 +1642,18 @@ impl AppState {
     /// ONLY reached when no `[[clients]]` table is configured. Under
     /// `[[clients]]`, identity comes from the verified credential
     /// (`RequestContext::from_request`) and this client-asserted path is dead.
+    ///
+    /// The `debug_assert` is the choke point for that invariant. Nothing in the
+    /// type system stops a future handler from calling
+    /// `RequestContext::from_request(.., None)` and silently reinstating
+    /// header-asserted identity; this makes that mistake fail loudly in tests
+    /// and debug builds instead of quietly becoming an identity bypass.
     fn resolve_client_id(&self, ip: &IpAddr, headers: &hyper::HeaderMap) -> String {
+        debug_assert!(
+            self.clients.is_empty(),
+            "resolve_client_id reached with [[clients]] configured — a caller \
+             skipped the authenticated principal and identity is now spoofable"
+        );
         if let Some(id) = headers.get("x-client-id").and_then(|v| v.to_str().ok()) {
             let id = id.trim();
             if !id.is_empty() && id != "-" {
@@ -5541,11 +5611,19 @@ impl AppState {
         //    openai_chat_handler, so one placement covers both surfaces.
         if !self.client_allows_model(client_id, model) {
             self.note_model_denied(client_id, model);
-            return Err((
-                StatusCode::FORBIDDEN,
-                format!("client '{client_id}' is not permitted to use model '{model}'"),
-            )
-                .into_response());
+            // `model` is caller-controlled and echoed back — truncate it here
+            // too, so a 25 MB model field cannot become a 25 MB error body.
+            let body = if model.is_empty() {
+                format!(
+                    "client '{client_id}' has a model allow-list, but no model could be read from the request"
+                )
+            } else {
+                format!(
+                    "client '{client_id}' is not permitted to use model '{}'",
+                    truncate_label(model)
+                )
+            };
+            return Err((StatusCode::FORBIDDEN, body).into_response());
         }
 
         // 1. Daily token budget (existing)
@@ -11221,64 +11299,6 @@ async fn openai_chat_handler(
 /// Validate endpoint configuration. Returns the first hard error encountered.
 /// Soft warnings (non-canonical anthropic host, priority collision with an
 /// openai endpoint) are emitted as `warn!` and do not return an error.
-/// Startup validation for the `[[clients]]` registry (LAB-1083).
-///
-/// Every rule here exists because its violation fails SILENTLY at runtime
-/// rather than loudly: a duplicate key resolves to whichever entry the scan
-/// saw last, a duplicate or empty name silently merges two callers' budgets and
-/// cache tenancy, and a `[response_cache].clients` typo makes the cache inert
-/// for that client with no signal at all. Cheap to catch at boot; expensive to
-/// notice in production.
-fn validate_clients(
-    clients: &[ClientConfig],
-    response_cache: Option<&ResponseCacheConfig>,
-) -> Result<(), String> {
-    let mut seen_names: Vec<&str> = Vec::with_capacity(clients.len());
-    let mut seen_keys: Vec<&str> = Vec::with_capacity(clients.len());
-    for c in clients {
-        if c.name.trim().is_empty() {
-            return Err("client: name must not be empty".to_string());
-        }
-        if c.name == "-" {
-            return Err(
-                "client: name must not be \"-\" (the unknown-client sentinel — budget enforcement skips it)"
-                    .to_string(),
-            );
-        }
-        if c.key.is_empty() {
-            return Err(format!("client '{}': key must not be empty", c.name));
-        }
-        if seen_names.contains(&c.name.as_str()) {
-            return Err(format!("client '{}': duplicate name", c.name));
-        }
-        // Names, not keys, in the error — never log a credential.
-        if seen_keys.contains(&c.key.as_str()) {
-            return Err(format!(
-                "client '{}': duplicate key (already used by another client)",
-                c.name
-            ));
-        }
-        seen_names.push(&c.name);
-        seen_keys.push(&c.key);
-    }
-
-    // AC-6: one client registry, not two. Only enforceable when [[clients]] is
-    // configured — on the legacy path client ids are header-derived and there
-    // is no registry to check against.
-    if !clients.is_empty() {
-        if let Some(rc) = response_cache {
-            for name in &rc.clients {
-                if !seen_names.contains(&name.as_str()) {
-                    return Err(format!(
-                        "response_cache.clients: \"{name}\" names no configured [[clients]] entry"
-                    ));
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
     for ep in endpoints {
         if let Some(url) = ep.base_url.as_deref() {
@@ -11338,6 +11358,111 @@ fn validate_endpoints(endpoints: &[EndpointConfig]) -> Result<(), String> {
             anthropic = ?anthropic_at_lowest,
             "openai endpoint(s) share the lowest priority tier with anthropic endpoint(s) — paid OpenAI capacity will compete with free Anthropic capacity"
         );
+    }
+    Ok(())
+}
+
+/// Startup validation for the `[[clients]]` registry (LAB-1083).
+///
+/// Every rule here exists because its violation fails SILENTLY at runtime
+/// rather than loudly: a duplicate key resolves to whichever entry the scan
+/// saw last, a duplicate or empty name silently merges two callers' budgets and
+/// cache tenancy, and a `[response_cache].clients` typo makes the cache inert
+/// for that client with no signal at all. Cheap to catch at boot; expensive to
+/// notice in production.
+fn validate_clients(config: &Config) -> Result<(), String> {
+    let clients = &config.clients;
+    let mut seen_names: Vec<&str> = Vec::with_capacity(clients.len());
+    let mut seen_keys: Vec<&str> = Vec::with_capacity(clients.len());
+    for c in clients {
+        if c.name.trim().is_empty() {
+            return Err("client: name must not be empty".to_string());
+        }
+        // Stored untrimmed, so " geo" would become a client_id that matches no
+        // `client_budgets` / `operators` / `[response_cache].clients` key —
+        // silently unenforced budget and cache tenancy. `resolve_client_id`
+        // trims its header input; this path has nothing to trim it later.
+        if c.name != c.name.trim() {
+            return Err(format!(
+                "client '{}': name must not have leading or trailing whitespace",
+                c.name
+            ));
+        }
+        if c.name == "-" {
+            return Err(
+                "client: name must not be \"-\" (the unknown-client sentinel — budget enforcement skips it)"
+                    .to_string(),
+            );
+        }
+        if c.key.is_empty() {
+            return Err(format!("client '{}': key must not be empty", c.name));
+        }
+        if seen_names.contains(&c.name.as_str()) {
+            return Err(format!("client '{}': duplicate name", c.name));
+        }
+        // Names, not keys, in the error — never log a credential.
+        if seen_keys.contains(&c.key.as_str()) {
+            return Err(format!(
+                "client '{}': duplicate key (already used by another client)",
+                c.name
+            ));
+        }
+        seen_names.push(&c.name);
+        seen_keys.push(&c.key);
+    }
+
+    // One client registry, not five. Every one of these config surfaces keys on
+    // a client name, and every one of them fails SILENTLY on a typo — in the
+    // dangerous direction: `check_budget` and `check_utilization_limit` both
+    // return Ok(()) for an unknown client, so a mistyped budget means UNLIMITED
+    // spend against the operator's accounts with no log line and no metric; a
+    // mistyped `operators` entry silently gates the caller it was meant to
+    // exempt; a mistyped `response_cache.clients` entry silently makes the
+    // cache inert. Only enforceable when [[clients]] is configured — on the
+    // legacy path client ids are header-derived and there is no registry to
+    // check against.
+    if clients.is_empty() {
+        return Ok(());
+    }
+
+    // `token = "passthrough"` forwards the caller's auth headers to the
+    // upstream UNTOUCHED (`inject_account_auth` returns before the
+    // header-strip). Under [[clients]] the caller's `x-api-key` is its PROXY
+    // credential, not an upstream one — so the two modes together would
+    // transmit every client key verbatim to that endpoint's `base_url`. They
+    // are contradictory by construction: passthrough means "the caller brings
+    // its own upstream credential", [[clients]] means "that header is mine".
+    // Reject rather than half-handle, exactly as with proxy_key above.
+    if let Some(ep) = config.endpoints.iter().find(|e| e.token == "passthrough") {
+        return Err(format!(
+            "endpoint '{}': token = \"passthrough\" is incompatible with [[clients]] — passthrough forwards the caller's auth headers upstream, which would leak client keys to {}",
+            ep.name,
+            ep.base_url.as_deref().unwrap_or("https://api.anthropic.com")
+        ));
+    }
+
+    let known = |name: &str| seen_names.contains(&name);
+    for (surface, name) in std::iter::empty()
+        .chain(config.client_budgets.keys().map(|k| ("client_budgets", k)))
+        .chain(
+            config
+                .client_utilization_limits
+                .keys()
+                .map(|k| ("client_utilization_limits", k)),
+        )
+        .chain(config.operators.iter().map(|k| ("operators", k)))
+        .chain(
+            config
+                .response_cache
+                .iter()
+                .flat_map(|rc| rc.clients.iter().map(|k| ("response_cache.clients", k))),
+        )
+    {
+        if !known(name) {
+            return Err(format!(
+                "{surface}: \"{name}\" names no configured [[clients]] entry"
+            ));
+        }
     }
     Ok(())
 }
@@ -11403,7 +11528,7 @@ async fn main() {
     if let Err(msg) = validate_endpoints(&config.endpoints) {
         panic!("{msg}");
     }
-    if let Err(msg) = validate_clients(&config.clients, config.response_cache.as_ref()) {
+    if let Err(msg) = validate_clients(&config) {
         panic!("config: {msg}");
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -308,6 +308,7 @@ fn test_state_base() -> AppState {
         transport_cooldown: TRANSPORT_UNHEALTHY_COOLDOWN,
         state_path: PathBuf::from("/tmp/anthropic-lb-test.state.json"),
         proxy_key: None,
+        clients: vec![],
         allowed_ips: vec![],
         client_names: HashMap::new(),
         auto_cache: true,
@@ -338,6 +339,7 @@ fn test_state_base() -> AppState {
         session_registry_max: DEFAULT_SESSION_REGISTRY_MAX,
         session_registry_ttl_secs: DEFAULT_SESSION_REGISTRY_TTL_SECS,
         prompt_too_long: Mutex::new(HashMap::new()),
+        model_denied: Mutex::new(HashMap::new()),
         unsupported_models: Mutex::new(HashMap::new()),
         response_cache: None,
     }
@@ -13679,7 +13681,7 @@ fn request_context_trims_whitespace_headers() {
     headers.insert("x-agent-id", HeaderValue::from_static("  "));
     headers.insert("x-session-id", HeaderValue::from_static(" \t "));
     let ip: IpAddr = "127.0.0.1".parse().unwrap();
-    let rctx = RequestContext::from_request(&state, &ip, &headers);
+    let rctx = RequestContext::from_request(&state, &ip, &headers, None);
     assert_eq!(rctx.agent_id, "-", "whitespace-only agent_id should be -");
     assert_eq!(
         rctx.session_id, "-",
@@ -15939,5 +15941,724 @@ async fn response_cache_skips_oversized_bodies() {
             .stores
             .load(Ordering::Relaxed),
         1
+    );
+}
+
+// ── LAB-1083: per-client authenticated identity + model allow-lists ──
+//
+// The property under test throughout: with `[[clients]]` configured, a
+// caller's identity is what its CREDENTIAL says, never what its headers say.
+// Every per-client decision in the proxy keys on `client_id`, so these tests
+// mostly prove one thing from several angles — that `client_id` cannot be
+// asserted by the caller once a client table exists.
+
+fn mk_client(name: &str, key: &str, models: &[&str]) -> ClientConfig {
+    ClientConfig {
+        name: name.to_string(),
+        key: key.to_string(),
+        models: models.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn state_with_clients(clients: Vec<ClientConfig>) -> Arc<AppState> {
+    Arc::new(AppState {
+        clients,
+        ..test_state_base()
+    })
+}
+
+fn hdrs(pairs: &[(&str, &str)]) -> hyper::HeaderMap {
+    let mut h = hyper::HeaderMap::new();
+    for (k, v) in pairs {
+        h.insert(
+            hyper::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+            HeaderValue::from_str(v).unwrap(),
+        );
+    }
+    h
+}
+
+const TEST_IP: &str = "10.0.0.7";
+
+fn test_ip() -> IpAddr {
+    TEST_IP.parse().unwrap()
+}
+
+// ── AC-1: distinct key → distinct identity, with no x-client-id ──
+
+#[test]
+fn distinct_client_keys_resolve_to_distinct_identities() {
+    let state = state_with_clients(vec![
+        mk_client("geo", "key-geo", &[]),
+        mk_client("radar", "key-radar", &[]),
+    ]);
+    let ip = test_ip();
+
+    for (key, expected) in [("key-geo", "geo"), ("key-radar", "radar")] {
+        let headers = hdrs(&[("x-api-key", key)]);
+        let principal = state
+            .authenticate(&ip, &headers, false)
+            .expect("configured key must authenticate")
+            .expect("a [[clients]] match must yield a principal");
+        assert_eq!(principal.name, expected);
+        // And the identity the rest of the proxy sees follows it — with NO
+        // x-client-id header present on either request.
+        let rctx = RequestContext::from_request(&state, &ip, &headers, Some(principal));
+        assert_eq!(rctx.client_id, expected);
+    }
+}
+
+// ── AC-2: unknown / missing credential → 401 ──
+
+#[test]
+fn unknown_client_key_is_rejected() {
+    let state = state_with_clients(vec![mk_client("geo", "key-geo", &[])]);
+    let resp = state
+        .authenticate(&test_ip(), &hdrs(&[("x-api-key", "key-wrong")]), false)
+        .expect_err("unknown key must not authenticate");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn missing_credential_is_rejected_when_clients_configured() {
+    let state = state_with_clients(vec![mk_client("geo", "key-geo", &[])]);
+    let resp = state
+        .authenticate(&test_ip(), &hyper::HeaderMap::new(), false)
+        .expect_err("absent credential must not authenticate");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A near-miss must not authenticate. Guards the constant-time comparison
+/// against a length- or prefix-tolerant rewrite.
+#[test]
+fn client_key_match_is_exact_not_prefix() {
+    let state = state_with_clients(vec![mk_client("geo", "key-geo", &[])]);
+    for wrong in ["key-ge", "key-geo ", "key-geox", "", "KEY-GEO"] {
+        assert!(
+            state
+                .authenticate(&test_ip(), &hdrs(&[("x-api-key", wrong)]), false)
+                .is_err(),
+            "'{wrong}' must not authenticate as 'key-geo'"
+        );
+    }
+}
+
+// ── AC-2: bearer accepted on the OpenAI-compat surface only ──
+
+#[test]
+fn bearer_credential_accepted_only_where_enabled() {
+    let state = state_with_clients(vec![mk_client("geo", "key-geo", &[])]);
+    let ip = test_ip();
+    let headers = hdrs(&[("authorization", "Bearer key-geo")]);
+
+    let principal = state
+        .authenticate(&ip, &headers, true)
+        .expect("bearer must authenticate where enabled")
+        .expect("principal");
+    assert_eq!(principal.name, "geo");
+
+    // The native surface may carry the caller's OWN upstream token in
+    // `Authorization` (passthrough endpoints), so bearer is not accepted there.
+    assert!(state.authenticate(&ip, &headers, false).is_err());
+}
+
+#[test]
+fn bearer_scheme_match_is_case_insensitive() {
+    let state = state_with_clients(vec![mk_client("geo", "key-geo", &[])]);
+    let headers = hdrs(&[("authorization", "bEaReR key-geo")]);
+    assert_eq!(
+        state
+            .authenticate(&test_ip(), &headers, true)
+            .unwrap()
+            .unwrap()
+            .name,
+        "geo"
+    );
+}
+
+// ── AC-4: the credential wins over a spoofed x-client-id ──
+
+#[test]
+fn spoofed_x_client_id_is_ignored_under_clients_table() {
+    let state = state_with_clients(vec![
+        mk_client("alpha", "key-alpha", &[]),
+        mk_client("bravo", "key-bravo", &[]),
+    ]);
+    let ip = test_ip();
+    let headers = hdrs(&[("x-api-key", "key-alpha"), ("x-client-id", "bravo")]);
+
+    let principal = state.authenticate(&ip, &headers, false).unwrap().unwrap();
+    assert_eq!(principal.name, "alpha");
+
+    let rctx = RequestContext::from_request(&state, &ip, &headers, Some(principal));
+    assert_eq!(
+        rctx.client_id, "alpha",
+        "authenticated principal must win over the x-client-id header"
+    );
+}
+
+/// The `client_names` IP map is the other client-influenced identity source.
+/// It must also lose to the credential.
+#[test]
+fn client_names_ip_map_is_ignored_under_clients_table() {
+    let mut client_names = HashMap::new();
+    client_names.insert(TEST_IP.to_string(), "from-ip-map".to_string());
+    let state = Arc::new(AppState {
+        clients: vec![mk_client("alpha", "key-alpha", &[])],
+        client_names,
+        ..test_state_base()
+    });
+    let ip = test_ip();
+    let headers = hdrs(&[("x-api-key", "key-alpha")]);
+    let principal = state.authenticate(&ip, &headers, false).unwrap().unwrap();
+    let rctx = RequestContext::from_request(&state, &ip, &headers, Some(principal));
+    assert_eq!(rctx.client_id, "alpha");
+}
+
+// ── AC-5: legacy proxy_key path unchanged ──
+
+#[test]
+fn legacy_proxy_key_still_authenticates_and_yields_no_principal() {
+    let state = Arc::new(AppState {
+        proxy_key: Some("shared-secret".to_string()),
+        ..test_state_base()
+    });
+    let ip = test_ip();
+
+    let principal = state
+        .authenticate(&ip, &hdrs(&[("x-api-key", "shared-secret")]), false)
+        .expect("correct legacy key must authenticate");
+    assert!(
+        principal.is_none(),
+        "legacy path has no principal — identity stays header/IP-derived"
+    );
+
+    assert!(state
+        .authenticate(&ip, &hdrs(&[("x-api-key", "nope")]), false)
+        .is_err());
+    assert!(state
+        .authenticate(&ip, &hyper::HeaderMap::new(), false)
+        .is_err());
+}
+
+#[test]
+fn legacy_proxy_key_leaves_x_client_id_resolution_intact() {
+    let state = Arc::new(AppState {
+        proxy_key: Some("shared-secret".to_string()),
+        ..test_state_base()
+    });
+    let ip = test_ip();
+    let headers = hdrs(&[("x-api-key", "shared-secret"), ("x-client-id", "gastown")]);
+    let principal = state.authenticate(&ip, &headers, false).unwrap();
+    let rctx = RequestContext::from_request(&state, &ip, &headers, principal);
+    assert_eq!(
+        rctx.client_id, "gastown",
+        "without [[clients]], x-client-id remains the identity source"
+    );
+}
+
+#[test]
+fn open_proxy_authenticates_every_request() {
+    let state = test_state_with(vec![]);
+    assert!(state
+        .authenticate(&test_ip(), &hyper::HeaderMap::new(), false)
+        .unwrap()
+        .is_none());
+}
+
+// ── AC-7 / AC-8: the allow-list and its shared matcher ──
+
+#[test]
+fn model_matches_is_the_matcher_behind_serves_model() {
+    let mut ep = mk_endpoint("a", "sk-ant-api-x");
+    ep.models = vec![
+        "claude-haiku-*".to_string(),
+        "claude-sonnet-4-6".to_string(),
+    ];
+    for model in ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-5", ""] {
+        assert_eq!(
+            ep.serves_model(model),
+            model_matches(&ep.models, model),
+            "serves_model and model_matches disagree on '{model}'"
+        );
+    }
+}
+
+#[test]
+fn client_allow_list_hit_miss_wildcard_and_empty() {
+    let state = state_with_clients(vec![
+        mk_client("limited", "k1", &["claude-haiku-*", "claude-sonnet-4-6"]),
+        mk_client("unlimited", "k2", &[]),
+    ]);
+
+    // exact hit
+    assert!(state.client_allows_model("limited", "claude-sonnet-4-6"));
+    // wildcard hit
+    assert!(state.client_allows_model("limited", "claude-haiku-4-5"));
+    // miss
+    assert!(!state.client_allows_model("limited", "claude-opus-5"));
+    // a near-miss on the exact pattern is still a miss
+    assert!(!state.client_allows_model("limited", "claude-sonnet-4-6-extra"));
+    // empty list = all models
+    assert!(state.client_allows_model("unlimited", "claude-opus-5"));
+    // unknown client (legacy path only) = all models
+    assert!(state.client_allows_model("-", "claude-opus-5"));
+    // an empty model (e.g. an unparseable body) is not a denial
+    assert!(state.client_allows_model("limited", ""));
+}
+
+// ── AC-9 / AC-10: enforcement in pre_request_gate ──
+
+#[tokio::test]
+async fn gate_denies_model_outside_client_allow_list_with_403() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    let err = state
+        .pre_request_gate("limited", "claude-opus-5")
+        .await
+        .expect_err("opus must be denied");
+    assert_eq!(
+        err.status(),
+        StatusCode::FORBIDDEN,
+        "policy denial is 403, not 429 — 429 means 'retry later', which this never becomes"
+    );
+}
+
+#[tokio::test]
+async fn gate_403_body_names_the_client_and_the_model() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    let err = state
+        .pre_request_gate("limited", "claude-opus-5")
+        .await
+        .unwrap_err();
+    let body = axum::body::to_bytes(err.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("limited"),
+        "body must name the client: {text}"
+    );
+    assert!(
+        text.contains("claude-opus-5"),
+        "body must name the model: {text}"
+    );
+}
+
+#[tokio::test]
+async fn gate_allows_model_inside_client_allow_list() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    assert!(state
+        .pre_request_gate("limited", "claude-haiku-4-5")
+        .await
+        .is_ok());
+}
+
+#[tokio::test]
+async fn gate_allow_list_bypassed_by_operators() {
+    let state = Arc::new(AppState {
+        clients: vec![mk_client("limited", "k1", &["claude-haiku-*"])],
+        operators: vec!["limited".to_string()],
+        ..test_state_base()
+    });
+    assert!(
+        state
+            .pre_request_gate("limited", "claude-opus-5")
+            .await
+            .is_ok(),
+        "operators bypass the allow-list like every other gate check"
+    );
+}
+
+// ── AC-11: denial counter + bounded model cardinality ──
+
+#[tokio::test]
+async fn model_denial_increments_counter_per_client_and_model() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    for _ in 0..3 {
+        assert!(state
+            .pre_request_gate("limited", "claude-opus-5")
+            .await
+            .is_err());
+    }
+    assert!(state
+        .pre_request_gate("limited", "claude-fable-5")
+        .await
+        .is_err());
+
+    let counts = state.model_denied.lock().unwrap();
+    assert_eq!(
+        counts.get(&("limited".to_string(), "claude-opus-5".to_string())),
+        Some(&3)
+    );
+    assert_eq!(
+        counts.get(&("limited".to_string(), "claude-fable-5".to_string())),
+        Some(&1)
+    );
+}
+
+/// The model label is caller-controlled — unbounded growth here would be a
+/// metrics-cardinality DoS.
+#[test]
+fn model_denial_labels_are_bounded_by_other_overflow() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    for i in 0..(MAX_MODEL_DENIED_LABELS + 25) {
+        state.note_model_denied("limited", &format!("junk-model-{i}"));
+    }
+    let counts = state.model_denied.lock().unwrap();
+    assert!(
+        counts.len() <= MAX_MODEL_DENIED_LABELS + 1,
+        "label map grew unbounded: {} entries",
+        counts.len()
+    );
+    assert_eq!(
+        counts.get(&("limited".to_string(), "_other".to_string())),
+        Some(&25),
+        "overflow must land in the _other bucket, not be dropped"
+    );
+}
+
+// ── AC-5 / AC-6: startup validation ──
+
+#[test]
+fn config_rejects_proxy_key_and_clients_together() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+proxy_key = "legacy"
+
+[[clients]]
+name = "geo"
+key = "key-geo"
+"#;
+    let value: toml::Value = toml::from_str(toml_str).unwrap();
+    let err = reject_legacy_config_keys(&value).unwrap_err();
+    assert!(
+        err.contains("proxy_key"),
+        "error must name proxy_key: {err}"
+    );
+    assert!(err.contains("clients"), "error must name clients: {err}");
+}
+
+#[test]
+fn config_accepts_proxy_key_alone_and_clients_alone() {
+    for toml_str in [
+        "listen = \"0.0.0.0:8080\"\nproxy_key = \"legacy\"\n",
+        "listen = \"0.0.0.0:8080\"\n\n[[clients]]\nname = \"geo\"\nkey = \"key-geo\"\n",
+    ] {
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        assert!(reject_legacy_config_keys(&value).is_ok());
+    }
+}
+
+#[test]
+fn config_parses_clients_table_with_model_allow_list() {
+    let toml_str = r#"
+listen = "0.0.0.0:8080"
+
+[[clients]]
+name = "geo"
+key = "key-geo"
+models = ["claude-haiku-*", "claude-sonnet-4-6"]
+
+[[clients]]
+name = "radar"
+key = "key-radar"
+"#;
+    let cfg: Config = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.clients.len(), 2);
+    assert_eq!(cfg.clients[0].name, "geo");
+    assert_eq!(cfg.clients[0].key, "key-geo");
+    assert_eq!(cfg.clients[0].models.len(), 2);
+    assert!(
+        cfg.clients[1].models.is_empty(),
+        "omitted models must default to empty (= all allowed)"
+    );
+}
+
+#[test]
+fn validate_clients_rejects_duplicate_names_and_keys() {
+    let dup_name = vec![mk_client("geo", "k1", &[]), mk_client("geo", "k2", &[])];
+    let err = validate_clients(&dup_name, None).unwrap_err();
+    assert!(err.contains("duplicate name"), "{err}");
+
+    let dup_key = vec![mk_client("geo", "k1", &[]), mk_client("radar", "k1", &[])];
+    let err = validate_clients(&dup_key, None).unwrap_err();
+    assert!(err.contains("duplicate key"), "{err}");
+    assert!(
+        !err.contains("k1"),
+        "the error must not echo the credential: {err}"
+    );
+}
+
+#[test]
+fn validate_clients_rejects_empty_and_sentinel_names_and_empty_keys() {
+    assert!(validate_clients(&[mk_client("", "k1", &[])], None)
+        .unwrap_err()
+        .contains("name"));
+    assert!(validate_clients(&[mk_client("   ", "k1", &[])], None)
+        .unwrap_err()
+        .contains("name"));
+    assert!(validate_clients(&[mk_client("-", "k1", &[])], None)
+        .unwrap_err()
+        .contains("sentinel"));
+    assert!(validate_clients(&[mk_client("geo", "", &[])], None)
+        .unwrap_err()
+        .contains("key"));
+}
+
+#[test]
+fn validate_clients_accepts_a_well_formed_table() {
+    let clients = vec![
+        mk_client("geo", "k1", &["claude-haiku-*"]),
+        mk_client("radar", "k2", &[]),
+    ];
+    assert!(validate_clients(&clients, None).is_ok());
+}
+
+/// AC-6 — one client registry. A `[response_cache].clients` typo used to
+/// silently make the cache inert for that client; now it fails startup.
+#[test]
+fn validate_clients_rejects_response_cache_client_that_names_no_client() {
+    let clients = vec![mk_client("geo", "k1", &[])];
+    let rc = ResponseCacheConfig {
+        clients: vec!["geo-pipeline".to_string()],
+        backend: "redis".to_string(),
+        master_key: "00".repeat(32),
+        ttl_secs: None,
+        op_timeout_ms: None,
+        redis_url: Some("redis://localhost".to_string()),
+        api_key: None,
+    };
+    let err = validate_clients(&clients, Some(&rc)).unwrap_err();
+    assert!(err.contains("geo-pipeline"), "{err}");
+    assert!(err.contains("response_cache.clients"), "{err}");
+}
+
+#[test]
+fn validate_clients_accepts_response_cache_client_that_names_a_client() {
+    let clients = vec![mk_client("geo", "k1", &[])];
+    let rc = ResponseCacheConfig {
+        clients: vec!["geo".to_string()],
+        backend: "redis".to_string(),
+        master_key: "00".repeat(32),
+        ttl_secs: None,
+        op_timeout_ms: None,
+        redis_url: Some("redis://localhost".to_string()),
+        api_key: None,
+    };
+    assert!(validate_clients(&clients, Some(&rc)).is_ok());
+}
+
+/// On the legacy path there is no registry to check against, so the
+/// cross-check must not fire and break existing configs.
+#[test]
+fn validate_clients_skips_response_cache_crosscheck_without_a_client_table() {
+    let rc = ResponseCacheConfig {
+        clients: vec!["anything".to_string()],
+        backend: "redis".to_string(),
+        master_key: "00".repeat(32),
+        ttl_secs: None,
+        op_timeout_ms: None,
+        redis_url: Some("redis://localhost".to_string()),
+        api_key: None,
+    };
+    assert!(validate_clients(&[], Some(&rc)).is_ok());
+}
+
+// ── AC-4: the response-cache tenant follows the authenticated principal ──
+
+/// #113 derives the cache's per-client encryption key from `client_id`. This
+/// asserts the tenant a spoofing caller would land in is its OWN, not the one
+/// it named — i.e. the cross-tenant read that ticket accepted is now closed.
+#[test]
+fn response_cache_tenant_follows_the_authenticated_principal() {
+    let state = state_with_clients(vec![
+        mk_client("alpha", "key-alpha", &[]),
+        mk_client("bravo", "key-bravo", &[]),
+    ]);
+    let ip = test_ip();
+    let headers = hdrs(&[("x-api-key", "key-alpha"), ("x-client-id", "bravo")]);
+    let principal = state.authenticate(&ip, &headers, false).unwrap().unwrap();
+    let rctx = RequestContext::from_request(&state, &ip, &headers, Some(principal));
+
+    // The cache is keyed by this exact string (`rc.clients.get(&client_id)`),
+    // and the HKDF tenant is derived from it.
+    assert_eq!(rctx.client_id, "alpha");
+    assert_ne!(rctx.client_id, "bravo");
+}
+
+// ── Integration: both surfaces, through the real router ──
+
+fn authed_app(upstream_url: &str, clients: Vec<ClientConfig>) -> (Router, Arc<AppState>) {
+    let mut acct = mk_endpoint("acct-a", "sk-ant-api-test-aaa");
+    acct.base_url = upstream_url.to_string();
+    let state = Arc::new(AppState {
+        endpoints: vec![acct],
+        clients,
+        ..test_state_base()
+    });
+    (build_router(state.clone()), state)
+}
+
+/// Native surface: the request authenticates as `limited` while claiming to be
+/// `unlimited`. It must be gated as `limited` — 403 — not waved through.
+#[tokio::test]
+async fn native_surface_gates_spoofing_client_by_its_real_identity() {
+    let (mock_url, _handle) = spawn_mock_upstream().await;
+    let (app, state) = authed_app(
+        &mock_url,
+        vec![
+            mk_client("limited", "key-limited", &["claude-haiku-*"]),
+            mk_client("unlimited", "key-unlimited", &[]),
+        ],
+    );
+    let addr = serve(app).await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-api-key", "key-limited")
+        .header("x-client-id", "unlimited")
+        .body(r#"{"model":"claude-opus-5","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+    assert!(resp.text().await.unwrap().contains("limited"));
+
+    // Same credential, a model it IS allowed: unaffected.
+    let resp = client
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-api-key", "key-limited")
+        .body(r#"{"model":"claude-haiku-4-5","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    assert_eq!(
+        state
+            .model_denied
+            .lock()
+            .unwrap()
+            .get(&("limited".to_string(), "claude-opus-5".to_string())),
+        Some(&1)
+    );
+}
+
+/// OpenAI-compat surface: same gate, reached through the other handler —
+/// `pre_request_gate` is called from both, so one placement covers both.
+#[tokio::test]
+async fn openai_surface_enforces_the_same_allow_list() {
+    let (mock_url, _handle) = spawn_mock_upstream().await;
+    let (app, _state) = authed_app(
+        &mock_url,
+        vec![mk_client("limited", "key-limited", &["claude-haiku-*"])],
+    );
+    let addr = serve(app).await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("http://{addr}/v1/chat/completions"))
+        .header("content-type", "application/json")
+        .header("authorization", "Bearer key-limited")
+        .header("x-client-id", "someone-else")
+        .body(r#"{"model":"claude-opus-5","messages":[{"role":"user","content":"hi"}],"max_tokens":1}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+
+    let resp = client
+        .post(format!("http://{addr}/v1/chat/completions"))
+        .header("content-type", "application/json")
+        .header("authorization", "Bearer key-limited")
+        .body(r#"{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":1}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// AC-2: no site left on the old single-key path.
+#[tokio::test]
+async fn all_four_auth_sites_reject_an_unknown_key() {
+    let (mock_url, _handle) = spawn_mock_upstream().await;
+    let (app, _state) = authed_app(&mock_url, vec![mk_client("geo", "key-geo", &[])]);
+    let addr = serve(app).await;
+    let client = Client::new();
+
+    for path in ["/_stats", "/metrics"] {
+        let resp = client
+            .get(format!("http://{addr}{path}"))
+            .header("x-api-key", "key-wrong")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::UNAUTHORIZED,
+            "{path} accepted an unknown key"
+        );
+        // …and the right one still works.
+        let resp = client
+            .get(format!("http://{addr}{path}"))
+            .header("x-api-key", "key-geo")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK, "{path}");
+    }
+
+    let resp = client
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-api-key", "key-wrong")
+        .body(r#"{"model":"claude-haiku-4-5","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let resp = client
+        .post(format!("http://{addr}/v1/chat/completions"))
+        .header("content-type", "application/json")
+        .header("x-api-key", "key-wrong")
+        .body(r#"{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":1}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+}
+
+/// AC-11: the denial counter reaches /metrics under its documented name.
+#[tokio::test]
+async fn metrics_exposes_the_model_denial_counter() {
+    let (mock_url, _handle) = spawn_mock_upstream().await;
+    let (app, state) = authed_app(
+        &mock_url,
+        vec![mk_client("limited", "key-limited", &["claude-haiku-*"])],
+    );
+    assert!(state
+        .pre_request_gate("limited", "claude-opus-5")
+        .await
+        .is_err());
+
+    let addr = serve(app).await;
+    let body = Client::new()
+        .get(format!("http://{addr}/metrics"))
+        .header("x-api-key", "key-limited")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        body.contains(
+            "anthropic_client_model_denied_total{client=\"limited\",model=\"claude-opus-5\"} 1"
+        ),
+        "denial counter missing from /metrics:\n{body}"
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10125,6 +10125,20 @@ fn resolve_client_id_ignores_dash_header() {
 }
 
 #[test]
+fn resolve_client_id_ignores_reserved_operator_header() {
+    let state = test_state_with(vec![mk_endpoint("a", "sk-ant-api-x")]);
+    let ip: IpAddr = "192.168.1.100".parse().unwrap();
+    let mut headers = hyper::HeaderMap::new();
+    headers.insert("x-client-id", HeaderValue::from_static("_operator"));
+
+    let resolved = state.resolve_client_id(&ip, &headers);
+    assert_eq!(
+        resolved, "-",
+        "a self-asserted _operator identity must not merge into the operator bucket"
+    );
+}
+
+#[test]
 fn compute_pressure_status_operator_always_healthy() {
     let state = Arc::new(AppState {
         client: Client::new(),
@@ -16282,7 +16296,7 @@ async fn native_surface_denies_restricted_client_sending_unparseable_body() {
 /// Untruncated it would be retained for the process lifetime and re-serialized
 /// into `/metrics` on every scrape.
 #[test]
-fn denied_model_label_and_body_are_truncated() {
+fn denied_model_label_is_truncated() {
     let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
     let huge = "z".repeat(100_000);
     state.note_model_denied("limited", &huge);
@@ -16292,6 +16306,26 @@ fn denied_model_label_and_body_are_truncated() {
         label.chars().count() <= MAX_LABEL_CHARS + 1,
         "label not truncated: {} chars",
         label.chars().count()
+    );
+}
+
+/// The other half of the same guarantee: the 403 body echoes the denied model
+/// through `truncate_label`, so an oversized model field must not be reflected
+/// back untruncated.
+#[tokio::test]
+async fn denied_model_response_body_is_truncated() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    let huge = "z".repeat(100_000);
+    let err = state
+        .pre_request_gate("limited", &huge)
+        .await
+        .expect_err("oversized model must be denied");
+    let body = axum::body::to_bytes(err.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&body).chars().count() < 1_000,
+        "403 body must not echo the untruncated model"
     );
 }
 
@@ -16498,6 +16532,13 @@ fn validate_clients_rejects_bad_names_and_empty_keys() {
         ("[[clients]]\nname = \"\"\nkey = \"k1\"\n", "name"),
         ("[[clients]]\nname = \"   \"\nkey = \"k1\"\n", "name"),
         ("[[clients]]\nname = \"-\"\nkey = \"k1\"\n", "sentinel"),
+        // Reserved: /_stats and /metrics rewrite operator identities to the
+        // literal "_operator", so a real tenant with that name would silently
+        // merge with the aggregated operator bucket.
+        (
+            "[[clients]]\nname = \"_operator\"\nkey = \"k1\"\n",
+            "_operator",
+        ),
         ("[[clients]]\nname = \"geo\"\nkey = \"\"\n", "key"),
         // Untrimmed: stored verbatim, so it would become a client_id matching
         // no client_budgets / operators / response_cache.clients key.
@@ -16768,6 +16809,24 @@ async fn all_four_auth_sites_reject_an_unknown_key() {
         .await
         .unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // The bearer branch is reachable only on this surface — cover its reject
+    // path too: wrong key, bare scheme, and a valid key without the scheme.
+    for auth in ["Bearer key-wrong", "Bearer", "key-geo"] {
+        let resp = client
+            .post(format!("http://{addr}/v1/chat/completions"))
+            .header("content-type", "application/json")
+            .header("authorization", auth)
+            .body(r#"{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":1}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::UNAUTHORIZED,
+            "'{auth}' must not authenticate"
+        );
+    }
 }
 
 /// AC-11: the denial counter reaches /metrics under its documented name.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16168,20 +16168,29 @@ fn open_proxy_authenticates_every_request() {
 
 // ── AC-7 / AC-8: the allow-list and its shared matcher ──
 
+/// `serves_model` delegates to `model_matches`, so asserting the two agree
+/// would be `A == A`. Pin the concrete wildcard semantics instead — including
+/// the empty-model ALLOW, which is correct for routing (don't narrow the pool
+/// on an unknown model) and is deliberately NOT what the client allow-list
+/// does.
 #[test]
-fn model_matches_is_the_matcher_behind_serves_model() {
+fn endpoint_model_matcher_semantics() {
     let mut ep = mk_endpoint("a", "sk-ant-api-x");
     ep.models = vec![
         "claude-haiku-*".to_string(),
         "claude-sonnet-4-6".to_string(),
     ];
-    for model in ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-5", ""] {
-        assert_eq!(
-            ep.serves_model(model),
-            model_matches(&ep.models, model),
-            "serves_model and model_matches disagree on '{model}'"
-        );
-    }
+    assert!(ep.serves_model("claude-haiku-4-5"), "wildcard hit");
+    assert!(ep.serves_model("claude-sonnet-4-6"), "exact hit");
+    assert!(!ep.serves_model("claude-opus-5"), "miss");
+    assert!(
+        !ep.serves_model("claude-sonnet-4-6-x"),
+        "exact is not a prefix"
+    );
+    assert!(ep.serves_model(""), "unknown model must not narrow routing");
+
+    ep.models.clear();
+    assert!(ep.serves_model("claude-opus-5"), "empty list = all models");
 }
 
 #[test]
@@ -16203,14 +16212,103 @@ fn client_allow_list_hit_miss_wildcard_and_empty() {
     assert!(state.client_allows_model("unlimited", "claude-opus-5"));
     // unknown client (legacy path only) = all models
     assert!(state.client_allows_model("-", "claude-opus-5"));
-    // an empty model (e.g. an unparseable body) is not a denial
-    assert!(state.client_allows_model("limited", ""));
+}
+
+/// The allow-list must FAIL CLOSED on an unreadable model.
+///
+/// `proxy_handler` sets `model = ""` whenever the body does not parse as JSON,
+/// and only ever reads a TOP-LEVEL `model` key — so a request to a route that
+/// nests it (`/v1/messages/batches` puts it under `requests[].params.model`),
+/// or any body the parser rejects, arrives at the gate with no model. If that
+/// allowed, a client restricted to haiku would reach opus by sending a body we
+/// cannot read. The endpoint matcher's empty-allows-all is right for routing
+/// and wrong here; this test is the line between them.
+#[test]
+fn client_allow_list_denies_an_unreadable_model() {
+    let state = state_with_clients(vec![
+        mk_client("limited", "k1", &["claude-haiku-*"]),
+        mk_client("unlimited", "k2", &[]),
+    ]);
+    assert!(
+        !state.client_allows_model("limited", ""),
+        "a client WITH an allow-list must be denied when the model is unknown"
+    );
+    assert!(
+        state.client_allows_model("unlimited", ""),
+        "a client with no allow-list is unaffected — nothing to enforce"
+    );
+}
+
+#[tokio::test]
+async fn gate_denies_unreadable_model_for_restricted_client() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    let err = state
+        .pre_request_gate("limited", "")
+        .await
+        .expect_err("unknown model must be denied for a restricted client");
+    assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    let body = axum::body::to_bytes(err.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("no model could be read"),
+        "body should explain the empty-model denial, got: {text}"
+    );
+}
+
+/// End-to-end proof of the same thing: an unparseable body must not smuggle a
+/// restricted client past its allow-list.
+#[tokio::test]
+async fn native_surface_denies_restricted_client_sending_unparseable_body() {
+    let (mock_url, _handle) = spawn_mock_upstream().await;
+    let (app, _state) = authed_app(
+        &mock_url,
+        vec![mk_client("limited", "key-limited", &["claude-haiku-*"])],
+    );
+    let addr = serve(app).await;
+    let resp = Client::new()
+        .post(format!("http://{addr}/v1/messages"))
+        .header("content-type", "application/json")
+        .header("x-api-key", "key-limited")
+        .body("this is not json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+/// The model string is caller-controlled and bounded only by the body cap.
+/// Untruncated it would be retained for the process lifetime and re-serialized
+/// into `/metrics` on every scrape.
+#[test]
+fn denied_model_label_and_body_are_truncated() {
+    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
+    let huge = "z".repeat(100_000);
+    state.note_model_denied("limited", &huge);
+    let counts = state.model_denied.lock().unwrap();
+    let (_, label) = counts.keys().next().unwrap();
+    assert!(
+        label.chars().count() <= MAX_LABEL_CHARS + 1,
+        "label not truncated: {} chars",
+        label.chars().count()
+    );
+}
+
+/// Truncation is char-based: slicing a multi-byte string on a byte boundary
+/// would panic.
+#[test]
+fn truncate_label_handles_multibyte_without_panicking() {
+    let s = "é".repeat(200);
+    let out = truncate_label(&s);
+    assert!(out.chars().count() <= MAX_LABEL_CHARS + 1);
+    assert_eq!(truncate_label("short"), "short");
 }
 
 // ── AC-9 / AC-10: enforcement in pre_request_gate ──
 
 #[tokio::test]
-async fn gate_denies_model_outside_client_allow_list_with_403() {
+async fn gate_denies_model_outside_client_allow_list_with_403_naming_both() {
     let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
     let err = state
         .pre_request_gate("limited", "claude-opus-5")
@@ -16221,15 +16319,6 @@ async fn gate_denies_model_outside_client_allow_list_with_403() {
         StatusCode::FORBIDDEN,
         "policy denial is 403, not 429 — 429 means 'retry later', which this never becomes"
     );
-}
-
-#[tokio::test]
-async fn gate_403_body_names_the_client_and_the_model() {
-    let state = state_with_clients(vec![mk_client("limited", "k1", &["claude-haiku-*"])]);
-    let err = state
-        .pre_request_gate("limited", "claude-opus-5")
-        .await
-        .unwrap_err();
     let body = axum::body::to_bytes(err.into_body(), 64 * 1024)
         .await
         .unwrap();
@@ -16374,14 +16463,28 @@ key = "key-radar"
     );
 }
 
+/// Build a `Config` from a TOML fragment. Goes through the real deserializer,
+/// so these tests also pin the config surface, and it beats hand-writing
+/// ~30-field `Config` / 7-field `ResponseCacheConfig` literals per case.
+fn cfg(fragment: &str) -> Config {
+    toml::from_str(&format!("listen = \"127.0.0.1:0\"\n{fragment}"))
+        .unwrap_or_else(|e| panic!("test config parse error: {e}\n---\n{fragment}"))
+}
+
+const RC_BLOCK: &str = "\n[response_cache]\nbackend = \"redis\"\nredis_url = \"redis://localhost\"\nmaster_key = \"0000000000000000000000000000000000000000000000000000000000000000\"\n";
+
 #[test]
 fn validate_clients_rejects_duplicate_names_and_keys() {
-    let dup_name = vec![mk_client("geo", "k1", &[]), mk_client("geo", "k2", &[])];
-    let err = validate_clients(&dup_name, None).unwrap_err();
+    let err = validate_clients(&cfg(
+        "[[clients]]\nname = \"geo\"\nkey = \"k1\"\n\n[[clients]]\nname = \"geo\"\nkey = \"k2\"\n",
+    ))
+    .unwrap_err();
     assert!(err.contains("duplicate name"), "{err}");
 
-    let dup_key = vec![mk_client("geo", "k1", &[]), mk_client("radar", "k1", &[])];
-    let err = validate_clients(&dup_key, None).unwrap_err();
+    let err = validate_clients(&cfg(
+        "[[clients]]\nname = \"geo\"\nkey = \"k1\"\n\n[[clients]]\nname = \"radar\"\nkey = \"k1\"\n",
+    ))
+    .unwrap_err();
     assert!(err.contains("duplicate key"), "{err}");
     assert!(
         !err.contains("k1"),
@@ -16390,78 +16493,113 @@ fn validate_clients_rejects_duplicate_names_and_keys() {
 }
 
 #[test]
-fn validate_clients_rejects_empty_and_sentinel_names_and_empty_keys() {
-    assert!(validate_clients(&[mk_client("", "k1", &[])], None)
-        .unwrap_err()
-        .contains("name"));
-    assert!(validate_clients(&[mk_client("   ", "k1", &[])], None)
-        .unwrap_err()
-        .contains("name"));
-    assert!(validate_clients(&[mk_client("-", "k1", &[])], None)
-        .unwrap_err()
-        .contains("sentinel"));
-    assert!(validate_clients(&[mk_client("geo", "", &[])], None)
-        .unwrap_err()
-        .contains("key"));
+fn validate_clients_rejects_bad_names_and_empty_keys() {
+    for (fragment, needle) in [
+        ("[[clients]]\nname = \"\"\nkey = \"k1\"\n", "name"),
+        ("[[clients]]\nname = \"   \"\nkey = \"k1\"\n", "name"),
+        ("[[clients]]\nname = \"-\"\nkey = \"k1\"\n", "sentinel"),
+        ("[[clients]]\nname = \"geo\"\nkey = \"\"\n", "key"),
+        // Untrimmed: stored verbatim, so it would become a client_id matching
+        // no client_budgets / operators / response_cache.clients key.
+        ("[[clients]]\nname = \" geo\"\nkey = \"k1\"\n", "whitespace"),
+        ("[[clients]]\nname = \"geo \"\nkey = \"k1\"\n", "whitespace"),
+    ] {
+        let err = validate_clients(&cfg(fragment)).unwrap_err();
+        assert!(err.contains(needle), "expected '{needle}' in: {err}");
+    }
 }
 
 #[test]
 fn validate_clients_accepts_a_well_formed_table() {
-    let clients = vec![
-        mk_client("geo", "k1", &["claude-haiku-*"]),
-        mk_client("radar", "k2", &[]),
-    ];
-    assert!(validate_clients(&clients, None).is_ok());
+    assert!(validate_clients(&cfg(
+        "[[clients]]\nname = \"geo\"\nkey = \"k1\"\nmodels = [\"claude-haiku-*\"]\n\n[[clients]]\nname = \"radar\"\nkey = \"k2\"\n",
+    ))
+    .is_ok());
 }
 
-/// AC-6 — one client registry. A `[response_cache].clients` typo used to
-/// silently make the cache inert for that client; now it fails startup.
+/// One client registry, not five. Each of these config surfaces keys on a
+/// client name and each fails SILENTLY on a typo — a mistyped budget means
+/// UNLIMITED spend (`check_budget` returns Ok for an unknown client), a
+/// mistyped operator silently gates the caller it meant to exempt, a mistyped
+/// cache client silently disables the cache.
 #[test]
-fn validate_clients_rejects_response_cache_client_that_names_no_client() {
-    let clients = vec![mk_client("geo", "k1", &[])];
-    let rc = ResponseCacheConfig {
-        clients: vec!["geo-pipeline".to_string()],
-        backend: "redis".to_string(),
-        master_key: "00".repeat(32),
-        ttl_secs: None,
-        op_timeout_ms: None,
-        redis_url: Some("redis://localhost".to_string()),
-        api_key: None,
-    };
-    let err = validate_clients(&clients, Some(&rc)).unwrap_err();
-    assert!(err.contains("geo-pipeline"), "{err}");
-    assert!(err.contains("response_cache.clients"), "{err}");
+fn validate_clients_rejects_any_surface_naming_no_configured_client() {
+    // NOTE: top-level scalars/arrays must precede the first table header —
+    // a bare `operators = [...]` written after `[[clients]]` binds to that
+    // table instead and is silently dropped, making the test pass vacuously.
+    let base = "\n[[clients]]\nname = \"geo\"\nkey = \"k1\"\n";
+    for (fragment, surface) in [
+        (
+            format!("{base}\n[client_budgets]\ngeo-pipeline = 100\n"),
+            "client_budgets",
+        ),
+        (
+            format!("{base}\n[client_utilization_limits]\ngeo-pipeline = 0.5\n"),
+            "client_utilization_limits",
+        ),
+        (
+            format!("operators = [\"geo-pipeline\"]\n{base}"),
+            "operators",
+        ),
+        (
+            format!("{base}{RC_BLOCK}clients = [\"geo-pipeline\"]\n"),
+            "response_cache.clients",
+        ),
+    ] {
+        let err = validate_clients(&cfg(&fragment)).unwrap_err();
+        assert!(err.contains(surface), "expected '{surface}' in: {err}");
+        assert!(err.contains("geo-pipeline"), "must name the typo: {err}");
+    }
 }
 
 #[test]
-fn validate_clients_accepts_response_cache_client_that_names_a_client() {
-    let clients = vec![mk_client("geo", "k1", &[])];
-    let rc = ResponseCacheConfig {
-        clients: vec!["geo".to_string()],
-        backend: "redis".to_string(),
-        master_key: "00".repeat(32),
-        ttl_secs: None,
-        op_timeout_ms: None,
-        redis_url: Some("redis://localhost".to_string()),
-        api_key: None,
-    };
-    assert!(validate_clients(&clients, Some(&rc)).is_ok());
+fn validate_clients_accepts_every_surface_naming_a_configured_client() {
+    let fragment = format!(
+        "operators = [\"geo\"]\n\n[[clients]]\nname = \"geo\"\nkey = \"k1\"\n\n[client_budgets]\ngeo = 100\n\n[client_utilization_limits]\ngeo = 0.5\n{RC_BLOCK}clients = [\"geo\"]\n"
+    );
+    let parsed = cfg(&fragment);
+    // Guard against the vacuous-pass trap above: assert the fragment really
+    // populated all four surfaces before asserting validation accepts them.
+    assert_eq!(parsed.operators, vec!["geo".to_string()]);
+    assert!(parsed.client_budgets.contains_key("geo"));
+    assert!(parsed.client_utilization_limits.contains_key("geo"));
+    assert_eq!(
+        parsed.response_cache.as_ref().unwrap().clients,
+        vec!["geo".to_string()]
+    );
+    assert!(validate_clients(&parsed).is_ok());
 }
 
-/// On the legacy path there is no registry to check against, so the
-/// cross-check must not fire and break existing configs.
+/// On the legacy path there is no registry to check against, so none of the
+/// cross-checks may fire — existing configs must keep booting.
 #[test]
-fn validate_clients_skips_response_cache_crosscheck_without_a_client_table() {
-    let rc = ResponseCacheConfig {
-        clients: vec!["anything".to_string()],
-        backend: "redis".to_string(),
-        master_key: "00".repeat(32),
-        ttl_secs: None,
-        op_timeout_ms: None,
-        redis_url: Some("redis://localhost".to_string()),
-        api_key: None,
-    };
-    assert!(validate_clients(&[], Some(&rc)).is_ok());
+fn validate_clients_skips_all_crosschecks_without_a_client_table() {
+    let fragment = format!(
+        "operators = [\"anything\"]\n\n[client_budgets]\nanything = 100\n{RC_BLOCK}clients = [\"anything\"]\n"
+    );
+    assert!(validate_clients(&cfg(&fragment)).is_ok());
+}
+
+/// `passthrough` forwards the caller's auth headers upstream untouched. Under
+/// `[[clients]]` those headers carry the client's PROXY key, so the two modes
+/// together would transmit every client key to the upstream.
+#[test]
+fn validate_clients_rejects_passthrough_endpoint_alongside_clients() {
+    let err = validate_clients(&cfg(
+        "[[clients]]\nname = \"geo\"\nkey = \"k1\"\n\n[[endpoints]]\nname = \"managed\"\ntoken = \"passthrough\"\n",
+    ))
+    .unwrap_err();
+    assert!(err.contains("passthrough"), "{err}");
+    assert!(err.contains("managed"), "must name the endpoint: {err}");
+}
+
+/// …but passthrough on the legacy path is untouched.
+#[test]
+fn validate_clients_allows_passthrough_without_a_client_table() {
+    assert!(validate_clients(&cfg(
+        "[[endpoints]]\nname = \"managed\"\ntoken = \"passthrough\"\n",
+    ))
+    .is_ok());
 }
 
 // ── AC-4: the response-cache tenant follows the authenticated principal ──


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR introduces per-client authenticated identity via a new `[[clients]]` config table, replacing the legacy single shared `proxy_key` with a scheme where each caller has its own credential and the key itself determines identity.

## What Changed

### Per-client authentication (`[[clients]]`)
- Adds a `ClientConfig` struct (`name`, `key`, optional `models`) with a hand-written `Debug` impl that redacts the key to prevent credential leakage into logs.
- The matched client's `name` becomes the request's `client_id`, **overriding** the client-asserted `x-client-id` header and the `client_names` IP map entirely. This makes budgets, utilization ceilings, operator status, model allow-lists, and response-cache tenancy unforgeable — all five key on `client_id`.
- Keys are compared in **constant time** (`subtle::ConstantTimeEq`) against the whole table, closing a prefix/timing oracle. The legacy `proxy_key` comparison was also migrated to constant-time (behavior otherwise unchanged).
- A new `authenticate()` method centralizes credential checking across all four auth sites (`/v1/messages`, `/v1/chat/completions`, `/_stats`, `/metrics`), replacing four duplicated inline checks. On the OpenAI-compat surface it additionally accepts `Authorization: Bearer`; on the native surface it does not (to avoid conflicting with passthrough tokens).

### Per-client model allow-lists
- `clients[].models` restricts which models a client may request, using the same exact-match + `*`-suffix wildcard matcher as `endpoints[].models` (refactored into a shared `model_matches()` function).
- Enforced in `pre_request_gate` (covering both request surfaces) as a **403 policy denial** distinct from 429 capacity errors. Operators bypass it.
- **Fails closed**: a client with an allow-list is denied when the model cannot be read from the request body, preventing bypass via unparseable/nested-model bodies.
- Denials are counted as `anthropic_client_model_denied_total{client,model}`, with the caller-controlled `model` label truncated and cardinality-bounded via `_other` overflow.

### Mutual exclusivity & startup validation
- `proxy_key` and `[[clients]]` are **mutually exclusive** — configuring both fails startup (a flag-day migration, not a rolling cutover).
- New `validate_clients()` rejects at startup: empty/duplicate/`-`-sentinel/whitespace-padded names, empty/duplicate keys, and any `client_budgets`/`client_utilization_limits`/`operators`/`response_cache.clients` entry naming an unconfigured client (which would otherwise silently mean unlimited spend or an inert cache).
- Rejects `token = "passthrough"` endpoints alongside `[[clients]]`, since passthrough would forward client proxy keys upstream.

### Docs & tests
- Extensive updates to `README.md`, `CLAUDE.md`, and `config.toml.example` documenting the two auth modes, migration steps, security posture (default-open warnings), and the `/_stats`/`/metrics` credential requirement.
- ~860 lines of new tests covering key→identity resolution, spoofing rejection, bearer handling, allow-list semantics (including fail-closed), counter cardinality, all four auth sites, startup validation, and end-to-end enforcement on both surfaces.

## Known Limitations Noted
- `/_stats` and `/metrics` remain non-operator-gated (any valid credential can read them).
- Client ID spoofing persists on legacy/open configs only; `[[clients]]` is the fix.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-client API key and bearer-token authentication.
  * Added client-specific model allow-lists with clear `403` responses for denied models.
  * Extended authentication to proxy, OpenAI-compatible, statistics and metrics endpoints.
  * Added authenticated client identity handling, denial metrics and improved cache isolation.

* **Security**
  * Added constant-time credential verification and safer redacted diagnostics.
  * Added configuration validation for incompatible authentication settings and restricted passthrough access.

* **Documentation**
  * Updated setup guidance for client credentials, model restrictions, legacy keys, operator access and endpoint security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->