### PR TITLE
LAB-932: migrate coordination layer from the redis crate to fred

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Request → IP allowlist check → proxy_key auth → pre_request_gate(operator 
 | Section | What it does |
 |---------|-------------|
 | **Config** (`Config`, `EndpointConfig`) | TOML deserialization structs |
-| **Runtime state** (`AppState`, `Endpoint`, `RateLimitInfo`) | Shared via `Arc<AppState>`, per-endpoint `RwLock<RateLimitInfo>`, atomic counters, optional Redis `ConnectionManager` |
+| **Runtime state** (`AppState`, `Endpoint`, `RateLimitInfo`) | Shared via `Arc<AppState>`, per-endpoint `RwLock<RateLimitInfo>`, atomic counters, optional fred `RedisClient` (auto-reconnecting) |
 | **Persistence** (`PersistedState`) | JSON state file at `<config_path>.state.json`, saved after every request and on shutdown. Redis for cross-replica state when configured. |
 | **Token usage** (`TokenUsage`, `record_usage`) | Extracts token counts from responses (streaming SSE + non-streaming JSON), tracks per-endpoint and per-client |
 | **Auto-cache** (`inject_cache_breakpoints`) | Injects up to 3 prompt cache breakpoints (last tool, system, last user message) unless cache_control already present |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "blake2",
  "bytes",
  "cachekit-rs",
+ "fred",
  "http-body-util",
  "hyper",
  "ipnet",
@@ -457,16 +458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,9 +662,12 @@ dependencies = [
  "parking_lot",
  "rand 0.8.7",
  "redis-protocol",
+ "rustls",
+ "rustls-native-certs",
  "semver",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "url",
@@ -1303,10 +1297,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.1.6",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1406,12 +1400,6 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -1668,13 +1656,10 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-native-certs",
  "ryu",
  "sha1_smol",
  "socket2 0.6.2",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "url",
  "xxhash-rust",
@@ -1825,6 +1810,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1835,14 +1821,24 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1900,20 +1896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2171,7 +2154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,12 @@ bytes = "1"
 http-body-util = "0.1"
 ipnet = "2.11.0"
 tokio-stream = "0.1"
-redis = { version = "1.0.3", features = ["tokio-comp", "connection-manager", "tls-rustls", "tokio-rustls-comp"] }
+# LAB-932: the coordination layer's Redis client. fred was already compiled in
+# via cachekit-rs's "redis" feature — this direct dep adds zero marginal weight
+# and lets the coordination layer share the fleet-standard client. Defaults
+# (i-std) cover keys/hashes/scan; i-scripts adds the Lua CAS; enable-rustls-ring
+# keeps rediss:// support on the ring TLS stack already in the tree.
+fred = { version = "9.4", features = ["i-scripts", "enable-rustls-ring"] }
 # LAB-933 response cache. NOTE: the crate is `cachekit-rs` (lib name `cachekit`,
 # github.com/cachekit-io/cachekit-rs) — the crate published as plain `cachekit`
 # on crates.io is an UNRELATED eviction-primitives library. Do not "fix" this.
@@ -37,3 +42,8 @@ serde_bytes = "0.11"
 [dev-dependencies]
 tempfile = "3.25.0"
 async-trait = "0.1"
+# Test-only, deliberately NOT the production client: the redis_integration
+# fixtures and assertions verify the fred-backed coordination layer through an
+# independent second client, so a systematic encoding/semantics bug in our fred
+# usage cannot self-certify. Never compiled into the release binary.
+redis = { version = "1.0.3", features = ["tokio-comp", "connection-manager"] }

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -106,7 +106,7 @@ kill "$(cat /tmp/alb-test-redis.pid)"
 > (test job) and `.github/workflows/release.yml` (validate job). Neither
 > can ever skip the suite silently.
 
-Each test owns a dedicated logical DB (`SELECT 1`–`12`) because all `alb:*`
+Each test owns a dedicated logical DB (`SELECT 1`–`13`, one per test) because all `alb:*`
 coordination keys are hardcoded in production code and cannot be prefixed
 per-test. Failure-path tests route the connection through an in-test
 killable TCP proxy to simulate the backend dying mid-run.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,14 @@ use axum::{
     routing::any,
     Router,
 };
+use fred::{
+    clients::RedisClient,
+    interfaces::{ClientLike, EventInterface, HashesInterface, KeysInterface, LuaInterface},
+    types::{
+        ConnectionConfig, Expiration, PerformanceConfig, ReconnectPolicy, RedisConfig, RedisValue,
+        SetOptions,
+    },
+};
 use ipnet::IpNet;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -602,8 +610,10 @@ struct AppState {
     /// Utilization soft ceiling. Accounts above this are excluded from routing
     /// unless all candidates exceed it. Default: 0.90.
     soft_limit: f64,
-    /// Redis connection for distributed state. None = local-only (single instance).
-    redis: Option<redis::aio::ConnectionManager>,
+    /// Redis client for distributed state. None = local-only (single instance).
+    /// fred clients are cheap to clone; every clone shares one multiplexed
+    /// connection driven by a background task with a reconnect policy.
+    redis: Option<RedisClient>,
     /// Cached cluster info from Redis, updated by background sync task.
     cluster_info_cache: Mutex<Option<serde_json::Value>>,
     /// Monotonic request ID counter for log correlation.
@@ -1718,20 +1728,22 @@ impl AppState {
 
         // Distributed probe lock: one pod per endpoint+model per interval.
         if let Some(redis) = &self.redis {
-            let mut conn = redis.clone();
             let lock_key = format!("alb:probe:{}:{}", ep.name, model);
             let lock_ttl = self.probe_interval_secs.max(1);
-            let acquired: redis::RedisResult<bool> = redis::cmd("SET")
-                .arg(&lock_key)
-                .arg(1u8)
-                .arg("NX")
-                .arg("EX")
-                .arg(lock_ttl)
-                .query_async(&mut conn)
+            // SET NX EX: OK reply when acquired, nil (None) when another
+            // replica already holds the lock.
+            let acquired: Result<Option<String>, fred::error::RedisError> = redis
+                .set(
+                    lock_key.as_str(),
+                    1,
+                    Some(Expiration::EX(lock_ttl as i64)),
+                    Some(SetOptions::NX),
+                    false,
+                )
                 .await;
             match acquired {
-                Ok(true) => {} // Lock acquired, proceed with probe
-                Ok(false) => {
+                Ok(Some(_)) => {} // Lock acquired, proceed with probe
+                Ok(None) => {
                     trace!(
                         endpoint = ep.name,
                         probe_model = model,
@@ -2105,6 +2117,25 @@ const TRANSPORT_ERRORS_TTL_SECS: u64 = 172_800;
 /// 48h: a daily counter only needs to survive its own day plus enough slack
 /// for stats/aggregation to read yesterday; after two days it is garbage.
 const BUDGET_TTL_SECS: i64 = 172_800;
+
+/// Per-command budget for the coordination client (fred's
+/// `default_command_timeout`), carried over from the old ConnectionManager's
+/// 2s response timeout.
+const REDIS_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// `SET key value EX ttl` — the one-line convenience the redis crate's
+/// `set_ex` provided; fred's five-argument `set` buries the common case in
+/// `None, false` noise at every call site.
+async fn redis_set_ex(
+    client: &RedisClient,
+    key: &str,
+    value: String,
+    ttl_secs: i64,
+) -> Result<(), fred::error::RedisError> {
+    client
+        .set(key, value, Some(Expiration::EX(ttl_secs)), None, false)
+        .await
+}
 
 /// Maximum request body size (25 MiB). Kept deliberately below Anthropic's own
 /// 32 MB Messages API request limit so multi-image/PDF payloads upstream would
@@ -3114,7 +3145,6 @@ impl AppState {
             Some(r) => r,
             None => return,
         };
-        use redis::AsyncCommands;
         let ttl = Self::routing_weight_publish_ttl(self.probe_interval_secs);
         let publish = |name: &str, weight: &AtomicU64, share: &AtomicU64, gate: &AtomicU64| {
             let w = f64::from_bits(weight.load(Ordering::Relaxed));
@@ -3122,10 +3152,9 @@ impl AppState {
             let g = f64::from_bits(gate.load(Ordering::Relaxed));
             let key = format!("alb:weight:{}", name);
             let val = format!("{w},{s},{g}");
-            let mut conn = redis.clone();
+            let conn = redis.clone();
             tokio::spawn(async move {
-                let result: redis::RedisResult<()> = conn.set_ex(&key, val, ttl).await;
-                if let Err(e) = result {
+                if let Err(e) = redis_set_ex(&conn, &key, val, ttl as i64).await {
                     tracing::warn!(error = %e, "redis routing weight publish failed");
                 }
             });
@@ -3164,14 +3193,13 @@ impl AppState {
     /// sentinel key is derived from the name alone.
     async fn signal_hard_limit_recovery(&self, endpoint_name: &str) {
         if let Some(redis) = &self.redis {
-            let mut conn = redis.clone();
+            let conn = redis.clone();
             let key = format!("alb:hard:{}", endpoint_name);
             let now_epoch = Self::now_epoch();
             // Lua CAS: only write the sentinel if the current value is absent,
             // already the sentinel, or an expired hard-limit (epoch <= now).
             // Rejects a concurrent mark_hard_limited write with epoch > now.
-            let script = redis::Script::new(
-                r#"
+            const RECOVERY_CAS_SCRIPT: &str = r#"
                 local current = redis.call('GET', KEYS[1])
                 if current == false then
                     return redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
@@ -3181,15 +3209,21 @@ impl AppState {
                     return redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
                 end
                 return 0
-                "#,
-            );
+                "#;
             tokio::spawn(async move {
-                let result: redis::RedisResult<redis::Value> = script
-                    .key(&key)
-                    .arg(HARD_LIMIT_CLEARED_SENTINEL)
-                    .arg(HARD_LIMIT_SENTINEL_TTL_SECS)
-                    .arg(now_epoch)
-                    .invoke_async(&mut conn)
+                // Args travel as decimal strings — byte-identical to the wire
+                // encoding the redis crate used, so the stored sentinel still
+                // parses as u64 on the sync_from_redis read side.
+                let result: Result<RedisValue, fred::error::RedisError> = conn
+                    .eval(
+                        RECOVERY_CAS_SCRIPT,
+                        vec![key],
+                        vec![
+                            HARD_LIMIT_CLEARED_SENTINEL.to_string(),
+                            HARD_LIMIT_SENTINEL_TTL_SECS.to_string(),
+                            now_epoch.to_string(),
+                        ],
+                    )
                     .await;
                 if let Err(e) = result {
                     tracing::warn!(error = %e, "redis sentinel write failed for hard-limit clear");
@@ -3771,13 +3805,11 @@ impl AppState {
                 .map(|r| r.saturating_sub(now_epoch).max(60))
                 .unwrap_or(3600); // default 1h if no reset known
 
-            let mut conn = redis.clone();
+            let conn = redis.clone();
             let key = format!("alb:rate:{}", endpoint_name);
             tokio::spawn(async move {
                 if let Ok(json) = serde_json::to_string(&rate_data) {
-                    use redis::AsyncCommands;
-                    let result: redis::RedisResult<()> = conn.set_ex(&key, json, ttl).await;
-                    if let Err(e) = result {
+                    if let Err(e) = redis_set_ex(&conn, &key, json, ttl as i64).await {
                         tracing::warn!(error = %e, "redis rate info write failed");
                     }
                 }
@@ -3872,17 +3904,16 @@ impl AppState {
 
         // Propagate to Redis for cross-replica awareness
         if let Some(redis) = &self.redis {
-            let mut conn = redis.clone();
+            let conn = redis.clone();
             let key = format!("alb:hard:{}", endpoint_name);
             let until_epoch = Self::now_epoch()
                 + cooldown.as_secs()
                 + if cooldown.subsec_nanos() > 0 { 1 } else { 0 };
             let ttl = cooldown.as_secs().max(1);
             tokio::spawn(async move {
-                use redis::AsyncCommands;
-                let result: redis::RedisResult<()> = conn.set_ex(&key, until_epoch, ttl).await;
-                if let Err(e) = result {
-                    tracing::warn!(error = %e, "redis SETEX failed for hard-limit propagation");
+                if let Err(e) = redis_set_ex(&conn, &key, until_epoch.to_string(), ttl as i64).await
+                {
+                    tracing::warn!(error = %e, "redis SET EX failed for hard-limit propagation");
                 }
             });
         }
@@ -3965,8 +3996,6 @@ impl AppState {
             Some(r) => r,
             None => return,
         };
-        use redis::AsyncCommands;
-        let mut conn = redis.clone();
         let now_epoch = Self::now_epoch();
         let now_instant = Instant::now();
 
@@ -3999,7 +4028,7 @@ impl AppState {
             .map(|t| format!("alb:hard:{}", t.name))
             .collect();
 
-        if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&hard_keys).await {
+        if let Ok(values) = redis.mget::<Vec<Option<String>>, _>(hard_keys).await {
             for (i, remote) in values.into_iter().enumerate() {
                 let remote = remote.and_then(|value| value.parse::<u64>().ok());
                 match classify_hard_limit_sync(remote, now_epoch, now_instant) {
@@ -4041,7 +4070,7 @@ impl AppState {
             .map(|t| format!("alb:rate:{}", t.name))
             .collect();
 
-        if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&rate_keys).await {
+        if let Ok(values) = redis.mget::<Vec<Option<String>>, _>(rate_keys).await {
             for (i, val) in values.iter().enumerate() {
                 if let Some(json) = val {
                     if let Ok(remote) = serde_json::from_str::<RedisRateInfo>(json) {
@@ -4089,7 +4118,7 @@ impl AppState {
             .iter()
             .map(|t| format!("alb:weight:{}", t.name))
             .collect();
-        if let Ok(values) = conn.mget::<_, Vec<Option<String>>>(&weight_keys).await {
+        if let Ok(values) = redis.mget::<Vec<Option<String>>, _>(weight_keys).await {
             for (i, val) in values.iter().enumerate() {
                 if let Some(csv) = val {
                     let mut parts = csv.splitn(3, ',');
@@ -4165,11 +4194,8 @@ impl AppState {
             // window; skipping this would wipe the fleet-wide counter after
             // 48h of perfectly healthy, error-free traffic. EXPIRE on a
             // not-yet-existing key is a no-op, so this is safe pre-first-error.
-            let mut conn = redis.clone();
-            let result: redis::RedisResult<()> = redis::cmd("EXPIRE")
-                .arg(TRANSPORT_ERRORS_KEY)
-                .arg(TRANSPORT_ERRORS_TTL_SECS)
-                .query_async(&mut conn)
+            let result: Result<(), fred::error::RedisError> = redis
+                .expire(TRANSPORT_ERRORS_KEY, TRANSPORT_ERRORS_TTL_SECS as i64)
                 .await;
             if let Err(e) = result {
                 warn!(error = %e, "redis EXPIRE failed for transport-errors TTL refresh");
@@ -4177,23 +4203,20 @@ impl AppState {
             return;
         }
 
-        // One round-trip: HINCRBY every kind, then refresh the TTL. Low-level
-        // cmd/arg form so this does not depend on generated fluent pipe methods.
-        let mut conn = redis.clone();
-        let mut pipe = redis::pipe();
+        // One round-trip: HINCRBY every kind, then refresh the TTL. fred
+        // pipeline commands resolve immediately when queued; `all()` sends the
+        // batch and surfaces the first error, matching the old atomic
+        // success-or-requeue contract.
+        let pipe = redis.pipeline();
         for (kind, n) in &deltas {
-            pipe.cmd("HINCRBY")
-                .arg(TRANSPORT_ERRORS_KEY)
-                .arg(*kind)
-                .arg(*n)
-                .ignore();
+            let _: Result<(), fred::error::RedisError> =
+                pipe.hincrby(TRANSPORT_ERRORS_KEY, *kind, *n as i64).await;
         }
-        pipe.cmd("EXPIRE")
-            .arg(TRANSPORT_ERRORS_KEY)
-            .arg(TRANSPORT_ERRORS_TTL_SECS)
-            .ignore();
+        let _: Result<(), fred::error::RedisError> = pipe
+            .expire(TRANSPORT_ERRORS_KEY, TRANSPORT_ERRORS_TTL_SECS as i64)
+            .await;
 
-        let result: redis::RedisResult<()> = pipe.query_async(&mut conn).await;
+        let result: Result<Vec<RedisValue>, fred::error::RedisError> = pipe.all().await;
         if let Err(e) = result {
             // Redis is unreachable (or the pipeline reply was lost) — return the
             // drained deltas to the local accumulator so error signal is not
@@ -4215,27 +4238,41 @@ impl AppState {
     }
     async fn cluster_info(&self) -> Option<serde_json::Value> {
         let redis = self.redis.as_ref()?;
-        use redis::AsyncCommands;
-        let mut conn = redis.clone();
         let mut redis_ok = true;
 
-        // Count active replicas via SCAN (non-blocking, unlike KEYS)
+        // Count active replicas via SCAN (non-blocking, unlike KEYS). The
+        // cursor is driven manually as a plain command per page — NOT via
+        // fred's scan stream. The stream's pages arrive over a channel that
+        // `default_command_timeout` does not cover, and abandoning the stream
+        // does not stop the scan: `ScanResult`'s Drop impl auto-requests the
+        // next page with nobody listening, so every abandoned scan keeps
+        // walking the keyspace against a backend that is already slow. A
+        // manual cursor loop keeps each page under the ordinary 2s command
+        // budget and genuinely ends the scan when this function returns.
         let mut replicas = 0u64;
-        let mut cursor: u64 = 0;
+        let mut cursor = String::from("0");
         loop {
-            let result: redis::RedisResult<(u64, Vec<String>)> = redis::cmd("SCAN")
-                .arg(cursor)
-                .arg("MATCH")
-                .arg("alb:heartbeat:*")
-                .arg("COUNT")
-                .arg(100)
-                .query_async(&mut conn)
+            let result: Result<(String, Vec<String>), fred::error::RedisError> = redis
+                .custom(
+                    fred::types::CustomCommand::new_static(
+                        "SCAN",
+                        fred::types::ClusterHash::FirstKey,
+                        false,
+                    ),
+                    vec![
+                        cursor,
+                        "MATCH".to_string(),
+                        "alb:heartbeat:*".to_string(),
+                        "COUNT".to_string(),
+                        "100".to_string(),
+                    ],
+                )
                 .await;
             match result {
                 Ok((next_cursor, keys)) => {
                     replicas += keys.len() as u64;
                     cursor = next_cursor;
-                    if cursor == 0 {
+                    if cursor == "0" {
                         break;
                     }
                 }
@@ -4256,7 +4293,7 @@ impl AppState {
                 .iter()
                 .map(|id| format!("alb:budget:{id}:{today}"))
                 .collect();
-            match conn.mget::<_, Vec<Option<u64>>>(&budget_keys).await {
+            match redis.mget::<Vec<Option<u64>>, _>(budget_keys).await {
                 Ok(values) => {
                     for (i, client_id) in client_ids.iter().enumerate() {
                         let used = values.get(i).copied().flatten().unwrap_or(0);
@@ -4280,8 +4317,8 @@ impl AppState {
         // handler to fall back to this replica's local accumulator.
         let mut transport_errors: Option<serde_json::Map<String, serde_json::Value>> = None;
         if redis_ok {
-            match conn
-                .hgetall::<_, HashMap<String, u64>>(TRANSPORT_ERRORS_KEY)
+            match redis
+                .hgetall::<HashMap<String, u64>, _>(TRANSPORT_ERRORS_KEY)
                 .await
             {
                 Ok(map) => {
@@ -5176,17 +5213,24 @@ impl AppState {
         };
         let today = Self::now_epoch() / 86400;
 
-        // Try Redis first for cross-replica budget enforcement
+        // Try Redis first for cross-replica budget enforcement. The
+        // is_connected gate matters on this request-path call: while fred is
+        // reconnecting it BUFFERS commands until default_command_timeout
+        // instead of erroring, so without the gate a sustained outage would
+        // add ~2s to every budgeted request. Known-down transport skips
+        // straight to local enforcement at the old client's speed.
         if let Some(redis) = &self.redis {
-            use redis::AsyncCommands;
-            let key = format!("alb:budget:{client_id}:{today}");
-            let mut conn = redis.clone();
-            match conn.get::<_, Option<u64>>(&key).await {
-                Ok(Some(used)) if used >= limit => return Err(0),
-                Ok(_) => return Ok(()),
-                Err(e) => {
-                    warn!(error = %e, "redis budget check failed, falling back to local");
+            if redis.is_connected() {
+                let key = format!("alb:budget:{client_id}:{today}");
+                match redis.get::<Option<u64>, _>(key.as_str()).await {
+                    Ok(Some(used)) if used >= limit => return Err(0),
+                    Ok(_) => return Ok(()),
+                    Err(e) => {
+                        warn!(error = %e, "redis budget check failed, falling back to local");
+                    }
                 }
+            } else {
+                trace!("redis disconnected, budget check falling back to local");
             }
         }
 
@@ -5219,16 +5263,26 @@ impl AppState {
             entry.1 += tokens;
         }
 
-        // Await Redis INCRBY (not fire-and-forget) so check_budget always sees latest counter
+        // Await Redis INCRBY (not fire-and-forget) so check_budget always sees
+        // latest counter. Same is_connected rationale as check_budget: this
+        // runs on the request path, and a reconnecting fred client would
+        // buffer the INCRBY (and the follow-up DEL on its error branch) for
+        // 2s each instead of failing fast. Skipping while down is equivalent
+        // to the old attempt-and-fail: local state above is already updated,
+        // and the DEL that failure would trigger could not reach the backend
+        // either.
         if let Some(redis) = &self.redis {
-            use redis::AsyncCommands;
-            let mut conn = redis.clone();
+            if !redis.is_connected() {
+                trace!("redis disconnected, budget INCRBY skipped (local state updated)");
+                return;
+            }
             let key = format!("alb:budget:{client_id}:{today}");
-            let result: redis::RedisResult<u64> = conn.incr(&key, tokens).await;
+            let result: Result<u64, fred::error::RedisError> =
+                redis.incr_by(key.as_str(), tokens as i64).await;
             match result {
                 Ok(_) => {
-                    let expire_result: redis::RedisResult<bool> =
-                        conn.expire(&key, BUDGET_TTL_SECS).await;
+                    let expire_result: Result<bool, fred::error::RedisError> =
+                        redis.expire(key.as_str(), BUDGET_TTL_SECS).await;
                     if let Err(e) = expire_result {
                         tracing::warn!(error = %e, "redis EXPIRE failed for budget key");
                     }
@@ -5236,7 +5290,7 @@ impl AppState {
                 Err(e) => {
                     // Delete stale key so check_budget falls through to local state
                     tracing::warn!(error = %e, "redis INCRBY failed, deleting stale budget key");
-                    let _: redis::RedisResult<()> = conn.del(&key).await;
+                    let _: Result<(), fred::error::RedisError> = redis.del(key.as_str()).await;
                 }
             }
         }
@@ -11304,17 +11358,44 @@ async fn main() {
         None
     };
 
-    // Set up Redis connection for distributed state (if configured)
+    // Set up Redis connection for distributed state (if configured).
+    // Timeout budgets carry over from the old ConnectionManager: 2s per
+    // command, 5s to establish a connection. `fail_fast` (fred's default)
+    // preserves the startup contract — an unreachable backend degrades to
+    // local-only rather than aborting or retrying forever. The reconnect
+    // policy is the one deliberate behaviour change (LAB-932 AC5): once the
+    // initial connect succeeds, a mid-run outage reconnects with capped
+    // exponential backoff instead of degrading permanently until restart.
     let redis = if let Some(ref url) = config.redis_url {
-        match redis::Client::open(url.as_str()) {
-            Ok(client) => {
-                let mgr_config = redis::aio::ConnectionManagerConfig::new()
-                    .set_response_timeout(Some(Duration::from_secs(2)))
-                    .set_connection_timeout(Some(Duration::from_secs(5)));
-                match client.get_connection_manager_with_config(mgr_config).await {
-                    Ok(mgr) => {
+        match RedisConfig::from_url(url.as_str()) {
+            Ok(redis_config) => {
+                let perf = PerformanceConfig {
+                    default_command_timeout: REDIS_COMMAND_TIMEOUT,
+                    ..Default::default()
+                };
+                let conn_config = ConnectionConfig {
+                    connection_timeout: Duration::from_secs(5),
+                    internal_command_timeout: Duration::from_secs(5),
+                    ..Default::default()
+                };
+                // 0 = retry forever; delays 100ms → 30s, doubling.
+                let policy = ReconnectPolicy::new_exponential(0, 100, 30_000, 2);
+                let client =
+                    RedisClient::new(redis_config, Some(perf), Some(conn_config), Some(policy));
+                // Reconnect transitions are sparse, high-signal events; log
+                // them so a flapping backend is visible in operator logs.
+                client.on_reconnect(|server| {
+                    info!(%server, "redis reconnected for distributed state");
+                    Ok(())
+                });
+                // init() spawns the connection task and waits for the first
+                // connect. The returned handle detaches on drop; the task
+                // keeps driving the connection (and reconnects) for the
+                // lifetime of the client.
+                match client.init().await {
+                    Ok(_connect_handle) => {
                         info!("redis connected for distributed state");
-                        Some(mgr)
+                        Some(client)
                     }
                     Err(e) => {
                         warn!(error = %e, "redis connection failed — running in local-only mode");
@@ -11540,11 +11621,8 @@ async fn main() {
                 sync_state.sync_from_redis().await;
                 // Heartbeat: register this instance
                 if let Some(redis) = &sync_state.redis {
-                    use redis::AsyncCommands;
-                    let mut conn = redis.clone();
                     let key = format!("alb:heartbeat:{instance_id}");
-                    let _: redis::RedisResult<()> =
-                        conn.set_ex(&key, AppState::now_epoch(), 30u64).await;
+                    let _ = redis_set_ex(redis, &key, AppState::now_epoch().to_string(), 30).await;
                 }
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16043,12 +16043,22 @@ mod redis_integration {
     /// flushing it. Returns None (with a SKIP notice) when the env var is
     /// unset; panics when it is set but the backend is unreachable.
     /// `db` must be unique per test — logical DBs are the isolation unit.
-    async fn redis_test_conn(db: u8) -> Option<redis::aio::ConnectionManager> {
+    ///
+    /// Returns a PAIR of clients on the same DB: the `redis`-crate connection
+    /// is the test's independent fixture/assertion client (deliberately NOT
+    /// the client under test), and the fred client is what goes into
+    /// `AppState.redis` — the production coordination path being verified.
+    async fn redis_test_conn(db: u8) -> Option<(redis::aio::ConnectionManager, RedisClient)> {
         let base = test_redis_url()?;
-        Some(connect_and_flush(&format!("{}/{db}", base.trim_end_matches('/'))).await)
+        let url = format!("{}/{db}", base.trim_end_matches('/'));
+        let conn = connect_and_flush(&url).await;
+        let fred = fred_test_client(&url).await;
+        Some((conn, fred))
     }
 
-    async fn connect_and_flush(url: &str) -> redis::aio::ConnectionManager {
+    /// Independent (redis-crate) connection WITHOUT flushing — for asserting
+    /// on state that must survive, e.g. after a backend recovery.
+    async fn connect(url: &str) -> redis::aio::ConnectionManager {
         let client = redis::Client::open(url)
             .unwrap_or_else(|e| panic!("{TEST_REDIS_ENV}: invalid url {url}: {e}"));
         // Short timeouts + a single retry: the failure-path tests kill the
@@ -16058,15 +16068,43 @@ mod redis_integration {
             .set_response_timeout(Some(Duration::from_secs(1)))
             .set_connection_timeout(Some(Duration::from_secs(2)))
             .set_number_of_retries(1);
-        let mut conn = client
+        client
             .get_connection_manager_with_config(cfg)
             .await
             .unwrap_or_else(|e| {
                 panic!("{TEST_REDIS_ENV} set but backend unreachable at {url}: {e}")
-            });
+            })
+    }
+
+    async fn connect_and_flush(url: &str) -> redis::aio::ConnectionManager {
+        let mut conn = connect(url).await;
         let flushed: redis::RedisResult<()> = redis::cmd("FLUSHDB").query_async(&mut conn).await;
         flushed.unwrap_or_else(|e| panic!("FLUSHDB failed on {url}: {e}"));
         conn
+    }
+
+    /// The client under test: a fred client configured like `connect` (short
+    /// budgets so failure-path tests observe errors in milliseconds) plus a
+    /// fast constant reconnect policy so the recovery test can watch
+    /// coordination resume without production-scale backoff.
+    async fn fred_test_client(url: &str) -> RedisClient {
+        let config = RedisConfig::from_url(url)
+            .unwrap_or_else(|e| panic!("{TEST_REDIS_ENV}: invalid url {url}: {e}"));
+        let perf = PerformanceConfig {
+            default_command_timeout: Duration::from_secs(1),
+            ..Default::default()
+        };
+        let conn_config = ConnectionConfig {
+            connection_timeout: Duration::from_secs(2),
+            internal_command_timeout: Duration::from_secs(2),
+            ..Default::default()
+        };
+        let policy = ReconnectPolicy::new_constant(0, 100);
+        let client = RedisClient::new(config, Some(perf), Some(conn_config), Some(policy));
+        let _connect_handle = client.init().await.unwrap_or_else(|e| {
+            panic!("{TEST_REDIS_ENV} set but backend unreachable at {url}: {e}")
+        });
+        client
     }
 
     /// TCP forwarder in front of the real backend that can be killed
@@ -16074,7 +16112,17 @@ mod redis_integration {
     /// Killing aborts every live relay and drops the listener, so both
     /// in-flight commands and subsequent reconnect attempts fail.
     async fn spawn_killable_proxy(target: String) -> (String, tokio::sync::oneshot::Sender<()>) {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        spawn_killable_proxy_at("127.0.0.1:0", target).await
+    }
+
+    /// Same as `spawn_killable_proxy`, but at a caller-chosen address — used
+    /// to REVIVE a killed proxy at its old address so a reconnect policy can
+    /// find the backend again.
+    async fn spawn_killable_proxy_at(
+        bind: &str,
+        target: String,
+    ) -> (String, tokio::sync::oneshot::Sender<()>) {
+        let listener = tokio::net::TcpListener::bind(bind).await.unwrap();
         let addr = listener.local_addr().unwrap();
         let (kill_tx, mut kill_rx) = tokio::sync::oneshot::channel::<()>();
         tokio::spawn(async move {
@@ -16105,14 +16153,10 @@ mod redis_integration {
         (format!("127.0.0.1:{}", addr.port()), kill_tx)
     }
 
-    /// Connection to the test backend routed through a killable proxy.
-    /// Same skip/panic contract as `redis_test_conn`.
-    async fn proxied_conn(
-        db: u8,
-    ) -> Option<(
-        redis::aio::ConnectionManager,
-        tokio::sync::oneshot::Sender<()>,
-    )> {
+    /// fred client (the client under test) routed through a killable proxy.
+    /// Same skip/panic contract as `redis_test_conn`. The DB is flushed via
+    /// the independent redis-crate client before the fred client connects.
+    async fn proxied_conn(db: u8) -> Option<(RedisClient, tokio::sync::oneshot::Sender<()>)> {
         let base = test_redis_url()?;
         let target = base
             .trim_start_matches("redis://")
@@ -16122,8 +16166,10 @@ mod redis_integration {
             .unwrap()
             .to_string();
         let (proxy_addr, kill) = spawn_killable_proxy(target).await;
-        let conn = connect_and_flush(&format!("redis://{proxy_addr}/{db}")).await;
-        Some((conn, kill))
+        let url = format!("redis://{proxy_addr}/{db}");
+        drop(connect_and_flush(&url).await);
+        let fred = fred_test_client(&url).await;
+        Some((fred, kill))
     }
 
     async fn kill_proxy(kill: tokio::sync::oneshot::Sender<()>) {
@@ -16143,13 +16189,10 @@ mod redis_integration {
         }
     }
 
-    fn state_with_redis(
-        endpoints: Vec<Endpoint>,
-        conn: redis::aio::ConnectionManager,
-    ) -> Arc<AppState> {
+    fn state_with_redis(endpoints: Vec<Endpoint>, client: RedisClient) -> Arc<AppState> {
         Arc::new(AppState {
             endpoints,
-            redis: Some(conn),
+            redis: Some(client),
             ..test_state_base()
         })
     }
@@ -16219,7 +16262,7 @@ mod redis_integration {
     /// nothing. Pairs with the pure `classify_hard_limit_*` unit tests.
     #[tokio::test]
     async fn sync_from_redis_merges_hard_limits_with_real_backend() {
-        let Some(mut conn) = redis_test_conn(1).await else {
+        let Some((mut conn, fred)) = redis_test_conn(1).await else {
             return;
         };
         let state = state_with_redis(
@@ -16230,7 +16273,7 @@ mod redis_integration {
                 make_endpoint("hl-remote-newer", Protocol::Anthropic),
                 make_endpoint("hl-absent", Protocol::Anthropic),
             ],
-            conn.clone(),
+            fred,
         );
 
         let now_epoch = AppState::now_epoch();
@@ -16332,7 +16375,7 @@ mod redis_integration {
     /// both directions, plus the absent-key case, against real MGET replies.
     #[tokio::test]
     async fn sync_from_redis_rate_info_most_recent_wins_both_directions() {
-        let Some(mut conn) = redis_test_conn(2).await else {
+        let Some((mut conn, fred)) = redis_test_conn(2).await else {
             return;
         };
         let state = state_with_redis(
@@ -16341,7 +16384,7 @@ mod redis_integration {
                 make_endpoint("ri-remote-older", Protocol::Anthropic),
                 make_endpoint("ri-absent", Protocol::Anthropic),
             ],
-            conn.clone(),
+            fred,
         );
         let now_epoch = AppState::now_epoch();
 
@@ -16395,7 +16438,7 @@ mod redis_integration {
     /// malformed and absent values touch nothing.
     #[tokio::test]
     async fn sync_from_redis_applies_published_routing_weights() {
-        let Some(mut conn) = redis_test_conn(3).await else {
+        let Some((mut conn, fred)) = redis_test_conn(3).await else {
             return;
         };
         let state = state_with_redis(
@@ -16405,7 +16448,7 @@ mod redis_integration {
                 make_endpoint("w-bad", Protocol::Anthropic),
                 make_endpoint("w-absent", Protocol::Anthropic),
             ],
-            conn.clone(),
+            fred,
         );
         for ep in &state.endpoints {
             ep.last_routing_weight
@@ -16452,10 +16495,10 @@ mod redis_integration {
     /// covered by the pure `classify_hard_limit_*` tests.
     #[tokio::test]
     async fn recovery_sentinel_cas_clears_stale_but_not_live_hard_limits() {
-        let Some(mut conn) = redis_test_conn(4).await else {
+        let Some((mut conn, fred)) = redis_test_conn(4).await else {
             return;
         };
-        let state = state_with_redis(vec![], conn.clone());
+        let state = state_with_redis(vec![], fred);
         let key = "alb:hard:cas-ep";
 
         // Absent key → sentinel written, with the sentinel TTL.
@@ -16509,19 +16552,19 @@ mod redis_integration {
     /// yesterday's spend invisible today.
     #[tokio::test]
     async fn budget_incrby_accumulates_across_replicas_with_expiry() {
-        let Some(mut conn) = redis_test_conn(5).await else {
+        let Some((mut conn, fred)) = redis_test_conn(5).await else {
             return;
         };
         avoid_utc_midnight().await;
         let budgets: HashMap<String, u64> = [("budget-cli".to_string(), 1000u64)].into();
         let replica_a = Arc::new(AppState {
             client_budgets: budgets.clone(),
-            redis: Some(conn.clone()),
+            redis: Some(fred.clone()),
             ..test_state_base()
         });
         let replica_b = Arc::new(AppState {
             client_budgets: budgets,
-            redis: Some(conn.clone()),
+            redis: Some(fred.clone()),
             ..test_state_base()
         });
 
@@ -16549,7 +16592,7 @@ mod redis_integration {
         // local usage of its own sees the shared counter and refuses.
         let enforcing = Arc::new(AppState {
             client_budgets: [("budget-cli".to_string(), 300u64)].into(),
-            redis: Some(conn.clone()),
+            redis: Some(fred.clone()),
             ..test_state_base()
         });
         assert_eq!(
@@ -16570,7 +16613,7 @@ mod redis_integration {
             .unwrap();
         let roll = Arc::new(AppState {
             client_budgets: [("roll-cli".to_string(), 100u64)].into(),
-            redis: Some(conn.clone()),
+            redis: Some(fred.clone()),
             ..test_state_base()
         });
         assert!(
@@ -16585,13 +16628,13 @@ mod redis_integration {
     /// errors.
     #[tokio::test]
     async fn budget_incrby_failure_deletes_key_and_local_fallback_enforces() {
-        let Some(mut conn) = redis_test_conn(6).await else {
+        let Some((mut conn, fred)) = redis_test_conn(6).await else {
             return;
         };
         avoid_utc_midnight().await;
         let state = Arc::new(AppState {
             client_budgets: [("poison-cli".to_string(), 100u64)].into(),
-            redis: Some(conn.clone()),
+            redis: Some(fred),
             ..test_state_base()
         });
         let today = AppState::now_epoch() / 86400;
@@ -16649,7 +16692,7 @@ mod redis_integration {
     /// undercounts. Budget MGET aggregation is asserted in the same pass.
     #[tokio::test]
     async fn cluster_info_counts_heartbeats_across_multiple_scan_pages() {
-        let Some(mut conn) = redis_test_conn(7).await else {
+        let Some((mut conn, fred)) = redis_test_conn(7).await else {
             return;
         };
         avoid_utc_midnight().await;
@@ -16670,7 +16713,7 @@ mod redis_integration {
 
         let state = Arc::new(AppState {
             client_budgets: [("scan-cli".to_string(), 1000u64)].into(),
-            redis: Some(conn.clone()),
+            redis: Some(fred),
             ..test_state_base()
         });
         let info = state.cluster_info().await.expect("cluster_info with redis");
@@ -16688,11 +16731,11 @@ mod redis_integration {
     /// the idle tick refresh the TTL.
     #[tokio::test]
     async fn flush_transport_errors_hincrby_accumulates_across_replicas() {
-        let Some(mut conn) = redis_test_conn(8).await else {
+        let Some((mut conn, fred)) = redis_test_conn(8).await else {
             return;
         };
-        let replica_a = state_with_redis(vec![], conn.clone());
-        let replica_b = state_with_redis(vec![], conn.clone());
+        let replica_a = state_with_redis(vec![], fred.clone());
+        let replica_b = state_with_redis(vec![], fred.clone());
         {
             let mut m = replica_a.lock_transport_errors();
             m.insert("connect", 3);
@@ -16748,10 +16791,10 @@ mod redis_integration {
     /// signal.
     #[tokio::test]
     async fn flush_transport_errors_requeues_deltas_when_redis_dies() {
-        let Some((conn, kill)) = proxied_conn(9).await else {
+        let Some((fred, kill)) = proxied_conn(9).await else {
             return;
         };
-        let state = state_with_redis(vec![], conn);
+        let state = state_with_redis(vec![], fred);
         {
             let mut m = state.lock_transport_errors();
             m.insert("reset", 4);
@@ -16770,22 +16813,22 @@ mod redis_integration {
     /// is held, and a different model probes under its own lock.
     #[tokio::test]
     async fn probe_lock_grants_one_replica_per_endpoint_model() {
-        let Some(mut conn) = redis_test_conn(10).await else {
+        let Some((mut conn, fred)) = redis_test_conn(10).await else {
             return;
         };
         let (mock_url, hits) = spawn_counting_upstream().await;
         let dir = tempfile::tempdir().unwrap();
 
-        let mk_replica = |file: &str, conn: redis::aio::ConnectionManager| {
+        let mk_replica = |file: &str, client: RedisClient| {
             Arc::new(AppState {
                 endpoints: vec![mk_endpoint_at("probe-ep", "sk-test", &mock_url)],
-                redis: Some(conn),
+                redis: Some(client),
                 state_path: dir.path().join(file),
                 ..test_state_base()
             })
         };
-        let replica_a = mk_replica("a.json", conn.clone());
-        let replica_b = mk_replica("b.json", conn.clone());
+        let replica_a = mk_replica("a.json", fred.clone());
+        let replica_b = mk_replica("b.json", fred.clone());
 
         replica_a.probe_endpoint(0, "claude-sonnet-4-5").await;
         assert_eq!(
@@ -16819,14 +16862,14 @@ mod redis_integration {
     /// probe proceeds anyway (a dead coordinator must not stop probing).
     #[tokio::test]
     async fn probe_lock_fails_open_when_redis_is_down() {
-        let Some((conn, kill)) = proxied_conn(11).await else {
+        let Some((fred, kill)) = proxied_conn(11).await else {
             return;
         };
         let (mock_url, hits) = spawn_counting_upstream().await;
         let dir = tempfile::tempdir().unwrap();
         let state = Arc::new(AppState {
             endpoints: vec![mk_endpoint_at("failopen-ep", "sk-test", &mock_url)],
-            redis: Some(conn),
+            redis: Some(fred),
             state_path: dir.path().join("s.json"),
             ..test_state_base()
         });
@@ -16834,8 +16877,8 @@ mod redis_integration {
         // Prove the backend is actually dead before probing — otherwise a
         // silently-regressed kill_proxy would make hits==1 pass via the
         // lock-acquired path instead of the fail-open path.
-        let mut dead = state.redis.clone().unwrap();
-        let ping: redis::RedisResult<String> = redis::cmd("PING").query_async(&mut dead).await;
+        let dead = state.redis.clone().unwrap();
+        let ping: Result<String, fred::error::RedisError> = dead.ping().await;
         assert!(ping.is_err(), "proxy kill must sever the redis connection");
         state.probe_endpoint(0, "claude-sonnet-4-5").await;
         assert_eq!(
@@ -16851,14 +16894,14 @@ mod redis_integration {
     /// cold-start absence case; this covers loss of an established backend.
     #[tokio::test]
     async fn backend_death_mid_run_degrades_to_local_only() {
-        let Some((conn, kill)) = proxied_conn(12).await else {
+        let Some((fred, kill)) = proxied_conn(12).await else {
             return;
         };
         avoid_utc_midnight().await;
         let state = Arc::new(AppState {
             endpoints: vec![make_endpoint("degrade-ep", Protocol::Anthropic)],
             client_budgets: [("degrade-cli".to_string(), 100u64)].into(),
-            redis: Some(conn),
+            redis: Some(fred),
             ..test_state_base()
         });
 
@@ -16893,6 +16936,95 @@ mod redis_integration {
         assert_eq!(
             info["redis_connected"], false,
             "cluster_info must surface the outage"
+        );
+    }
+
+    /// AC5 (LAB-932) — the one deliberate behaviour change of the fred
+    /// migration: after a backend outage degrades coordination to local-only,
+    /// the backend coming BACK must restore cross-replica coordination
+    /// without a process restart. The sibling test above proves graceful
+    /// degradation; this proves recovery. Under the old `redis`-crate client
+    /// the second half of this test would hang degraded forever.
+    #[tokio::test]
+    async fn backend_recovery_mid_run_resumes_coordination() {
+        let Some(base) = test_redis_url() else {
+            return;
+        };
+        avoid_utc_midnight().await;
+        let target = base
+            .trim_start_matches("redis://")
+            .trim_end_matches('/')
+            .split('/')
+            .next()
+            .unwrap()
+            .to_string();
+        let (proxy_addr, kill) = spawn_killable_proxy(target.clone()).await;
+        let url = format!("redis://{proxy_addr}/13");
+        drop(connect_and_flush(&url).await);
+        let fred = fred_test_client(&url).await;
+        // Independent assertion client, connected DIRECTLY to the backend
+        // (not through the killable proxy, and without flushing) so it can
+        // verify post-recovery writes actually landed.
+        let direct = connect(&format!("{}/13", base.trim_end_matches('/'))).await;
+
+        let state = Arc::new(AppState {
+            client_budgets: [("recover-cli".to_string(), 100u64)].into(),
+            redis: Some(fred),
+            ..test_state_base()
+        });
+
+        // Healthy first: the shared counter works through the proxy.
+        state.record_budget_usage("recover-cli", 50).await;
+        assert!(state.check_budget("recover-cli").await.is_ok());
+
+        kill_proxy(kill).await;
+
+        // Dead: INCRBY and its follow-up DEL both fail; the local accumulator
+        // (50+60=110) enforces the 100 budget.
+        state.record_budget_usage("recover-cli", 60).await;
+        assert_eq!(
+            state.check_budget("recover-cli").await,
+            Err(0),
+            "local fallback must enforce the budget while the backend is dead"
+        );
+
+        // Revive the backend at the SAME address. fred's reconnect policy
+        // must re-establish the connection on its own.
+        let (revived_addr, _revived_kill) = spawn_killable_proxy_at(&proxy_addr, target).await;
+        assert_eq!(
+            revived_addr, proxy_addr,
+            "proxy must revive at its old address"
+        );
+
+        // Coordination resumes: the shared counter (still 50 — the
+        // dead-window INCRBY failed, and so did its delete-on-failure)
+        // becomes authoritative again, flipping check_budget from the local
+        // Err(0) back to Ok.
+        eventually("coordination to resume after backend recovery", || {
+            let s = state.clone();
+            async move { s.check_budget("recover-cli").await.is_ok() }
+        })
+        .await;
+
+        // And writes flow again, verified through the independent direct
+        // connection: a fresh INCRBY lands in the real backend.
+        state.record_budget_usage("recover-cli", 7).await;
+        let today = AppState::now_epoch() / 86400;
+        let key = format!("alb:budget:recover-cli:{today}");
+        eventually("post-recovery INCRBY to land in the backend", || {
+            let mut c = direct.clone();
+            let key = key.clone();
+            async move { c.get::<_, Option<u64>>(&key).await.ok().flatten() == Some(57) }
+        })
+        .await;
+
+        let info = state
+            .cluster_info()
+            .await
+            .expect("cluster_info after recovery");
+        assert_eq!(
+            info["redis_connected"], true,
+            "cluster_info must reflect the recovered backend"
         );
     }
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Migrates the distributed coordination layer from the `redis` crate to `fred` as the production Redis client (LAB-932).

## What Changed

**Production client swap** (`src/main.rs`)
- Replaces `redis::aio::ConnectionManager` with fred's `RedisClient` in `AppState`. fred clients are cheap to clone and share a single multiplexed connection driven by a background task.
- Rewrites all coordination operations against the fred API: probe locks (`SET NX EX`), routing-weight publishing, hard-limit propagation, the Lua CAS recovery sentinel (`eval`), rate-info writes, budget `INCRBY`/`EXPIRE`/`DEL`, transport-error `HINCRBY` pipelines, heartbeat `SET EX`, and cluster-info `MGET`/`HGETALL`.
- Preserves wire-level compatibility: Lua script args are sent as decimal strings so stored sentinels still parse as `u64` on the read side.
- Adds a `redis_set_ex` helper to keep the common `SET key value EX ttl` call sites clean.
- Carries over the old timeout budgets: 2s per-command, 5s connection timeout.

**Behavior change — automatic reconnection (AC5)**
- The deliberate new behavior: after the initial connect succeeds, a mid-run backend outage now reconnects with capped exponential backoff (100ms → 30s) instead of degrading permanently until process restart. Previously an established connection loss meant local-only mode until a restart.
- Reconnect transitions are logged as high-signal operator events.

**Request-path fast-fail via `is_connected` gate**
- `check_budget` and `record_budget_usage` now gate Redis calls on `is_connected()`. Because fred buffers commands (rather than erroring) while reconnecting, this prevents a sustained outage from adding ~2s latency to every budgeted request — a known-down transport skips straight to local enforcement.

**SCAN handling**
- `cluster_info` drives the SCAN cursor manually per-page instead of using fred's scan stream, so each page stays within the 2s command budget and the scan genuinely stops when the function returns (avoiding the stream's Drop behavior that keeps walking the keyspace).

**Dependencies** (`Cargo.toml`)
- Adds `fred` (9.4) as a direct dependency, already compiled in via `cachekit-rs`, so it adds no marginal weight and shares the fleet-standard client.
- Keeps the `redis` crate as a **test-only** dev-dependency — used as an independent second client in integration tests so a systematic bug in the fred usage cannot self-certify.

**Tests** (`src/tests.rs`)
- Test fixtures now return a *pair*: a `redis`-crate client (independent fixture/assertion) plus the fred client under test (into `AppState.redis`).
- Adds a fast-reconnect fred test client and a `spawn_killable_proxy_at` helper to revive a killed proxy at its old address.
- Adds new test `backend_recovery_mid_run_resumes_coordination` verifying AC5: coordination degrades to local-only when the backend dies, then automatically resumes cross-replica coordination when the backend returns — without a restart. Uses logical DB 13.

**Docs**
- Updates `CLAUDE.md` and `TESTING_GUIDE.md` to reflect the fred client and the added test DB range.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved reliability of distributed coordination with automatic Redis reconnection and recovery after temporary outages.
  * Added clearer timeout handling and more efficient coordination operations.
  * Strengthened secure Redis connectivity with Rustls support.

* **Bug Fixes**
  * Coordination now resumes more reliably when Redis becomes unavailable and returns.
  * Improved synchronisation for budgets, rate limits, routing, health checks and cluster status.

* **Documentation**
  * Updated runtime and integration testing documentation to reflect the latest Redis setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->