### PR TITLE
Fix 400s on all Claude Code traffic: allow its full beta flag set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2185,6 +2185,25 @@ const DEFAULT_CLIENT_BETA_ALLOWLIST: &[&str] = &[
     "fine-grained-tool-streaming-*",
     "prompt-caching-*",
     "context-1m*",
+    // The rest of what Claude Code 2.1.x sends on every request (inventory
+    // taken from anthropic_beta_flag_dropped_total on the lab fleet,
+    // 2026-08-01). The first cut of this list under-enumerated them, which
+    // 400'd all primary traffic: several of these flags have a BODY-side
+    // counterpart the LB forwards verbatim (context-management →
+    // `context_management`, structured-outputs → `output_format`,
+    // extended-cache-ttl → `cache_control.ttl`), so stripping only the
+    // header leaves an incoherent request that upstream rejects outright
+    // rather than degrading to the non-beta behaviour.
+    "context-management-*",
+    "structured-outputs-*",
+    "extended-cache-ttl-*",
+    "effort-*",
+    "thinking-token-count-*",
+    "mid-conversation-system-*",
+    "advisor-tool-*",
+    "fallback-credit-*",
+    "redact-thinking-*",
+    "afk-mode-*",
 ];
 
 /// Cardinality bound for `beta_flags_dropped` — flag names are

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16366,10 +16366,12 @@ fn oauth_beta_filter_keeps_claude_code_flag_set() {
             // mis-stripping and surfacing as a baffling allowlist miss below.
             let parts: Vec<&str> = flag.rsplitn(4, '-').collect();
             assert_eq!(parts.len(), 4, "flag lacks a -YYYY-MM-DD suffix: {flag}");
+            // rsplitn yields the components reversed: day, month, year.
             assert!(
                 parts[..3]
                     .iter()
-                    .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit())),
+                    .zip([2usize, 2, 4])
+                    .all(|(p, w)| p.len() == w && p.bytes().all(|b| b.is_ascii_digit())),
                 "flag suffix is not numeric YYYY-MM-DD: {flag}"
             );
             let family = parts[3];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16287,6 +16287,54 @@ fn oauth_beta_filter_keeps_default_allowed_flags() {
     );
 }
 
+/// Regression (2026-08-01 incident): the full `anthropic-beta` set Claude
+/// Code 2.1.220 sends must survive the default allow-list. The first cut of
+/// `DEFAULT_CLIENT_BETA_ALLOWLIST` listed only six entries and dropped these
+/// ten, which 400'd every Claude Code request through the proxy —
+/// `context-management` in particular has a body-side `context_management`
+/// object that the LB forwards verbatim, so dropping the header alone is a
+/// hard upstream rejection, not a silent feature downgrade.
+///
+/// This inventory came off `anthropic_beta_flag_dropped_total` on the live
+/// fleet. Date suffixes are deliberately concrete: the allow-list wildcards
+/// them, so a Claude Code date bump keeps passing while a genuinely new flag
+/// family still shows up as a drop.
+#[test]
+fn oauth_beta_filter_keeps_claude_code_flag_set() {
+    let claude_code_flags = [
+        "thinking-token-count-2026-05-13",
+        "context-management-2025-06-27",
+        "mid-conversation-system-2026-04-07",
+        "advisor-tool-2026-03-01",
+        "effort-2025-11-24",
+        "fallback-credit-2026-06-01",
+        "extended-cache-ttl-2025-04-11",
+        "redact-thinking-2026-02-12",
+        "afk-mode-2026-01-31",
+        "structured-outputs-2025-12-15",
+    ];
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_str(&claude_code_flags.join(",")).unwrap(),
+    );
+    let dropped = inject_account_auth(&mut headers, "sk-ant-oat01-test", false, &default_betas());
+    assert!(
+        dropped.is_empty(),
+        "no Claude Code flag may be dropped by the default allow-list: {dropped:?}"
+    );
+    let sent = headers.get("anthropic-beta").unwrap().to_str().unwrap();
+    for flag in claude_code_flags {
+        assert!(
+            sent.contains(flag),
+            "Claude Code flag not forwarded: {flag}"
+        );
+    }
+    for flag in OAUTH_BETA_FLAGS {
+        assert!(sent.contains(flag), "required OAuth flag missing: {flag}");
+    }
+}
+
 /// AC-13: passthrough endpoints return early — caller headers untouched,
 /// nothing dropped.
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16313,26 +16313,42 @@ fn oauth_beta_filter_keeps_claude_code_flag_set() {
         "afk-mode-2026-01-31",
         "structured-outputs-2025-12-15",
     ];
+    // Negative control: the point of the allow-list is that it still rejects.
+    // Without this, widening the default to "*" would keep the test green.
+    let unlisted = "evil-feature-2026-01-01";
     let mut headers = axum::http::HeaderMap::new();
     headers.insert(
         "anthropic-beta",
-        HeaderValue::from_str(&claude_code_flags.join(",")).unwrap(),
+        HeaderValue::from_str(&format!("{},{unlisted}", claude_code_flags.join(","))).unwrap(),
     );
     let dropped = inject_account_auth(&mut headers, "sk-ant-oat01-test", false, &default_betas());
-    assert!(
-        dropped.is_empty(),
-        "no Claude Code flag may be dropped by the default allow-list: {dropped:?}"
+    assert_eq!(
+        dropped,
+        vec![unlisted.to_string()],
+        "only the unlisted flag may be dropped"
     );
+    // Exact token membership, not substring: `sent.contains(flag)` also passes
+    // on a mangled or embedded token (e.g. "no-effort-2025-11-24" contains
+    // "effort-2025-11-24"), so it cannot tell a forwarded flag from a
+    // corrupted one.
     let sent = headers.get("anthropic-beta").unwrap().to_str().unwrap();
+    let tokens: Vec<&str> = sent.split(',').map(str::trim).collect();
     for flag in claude_code_flags {
         assert!(
-            sent.contains(flag),
-            "Claude Code flag not forwarded: {flag}"
+            tokens.contains(&flag),
+            "Claude Code flag not forwarded as an exact token: {flag} (sent: {sent})"
         );
     }
     for flag in OAUTH_BETA_FLAGS {
-        assert!(sent.contains(flag), "required OAuth flag missing: {flag}");
+        assert!(
+            tokens.contains(flag),
+            "required OAuth flag missing: {flag} (sent: {sent})"
+        );
     }
+    assert!(
+        !tokens.contains(&unlisted),
+        "dropped flag must not be forwarded: {sent}"
+    );
 }
 
 /// AC-13: passthrough endpoints return early — caller headers untouched,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16349,6 +16349,38 @@ fn oauth_beta_filter_keeps_claude_code_flag_set() {
         !tokens.contains(&unlisted),
         "dropped flag must not be forwarded: {sent}"
     );
+
+    // A Claude Code date bump must keep passing — that is the entire reason
+    // these entries are wildcarded. Nothing above catches a de-wildcarded
+    // entry (`"context-management-*"` narrowed back to the concrete
+    // `"context-management-2025-06-27"` satisfies every assertion so far),
+    // and that edit re-breaks all primary traffic on Claude Code's next
+    // release. Rebuild each family with a different date, through the real
+    // filter path.
+    let bumped: Vec<String> = claude_code_flags
+        .iter()
+        .map(|flag| {
+            // Strip the trailing `-YYYY-MM-DD`, keeping the family.
+            let family = flag.rsplitn(4, '-').last().unwrap();
+            assert_ne!(family, *flag, "date-suffix strip failed for {flag}");
+            format!("{family}-2099-12-31")
+        })
+        .collect();
+    let mut bumped_headers = axum::http::HeaderMap::new();
+    bumped_headers.insert(
+        "anthropic-beta",
+        HeaderValue::from_str(&bumped.join(",")).unwrap(),
+    );
+    let bumped_dropped = inject_account_auth(
+        &mut bumped_headers,
+        "sk-ant-oat01-test",
+        false,
+        &default_betas(),
+    );
+    assert!(
+        bumped_dropped.is_empty(),
+        "a Claude Code date bump must stay allowed (suffix wildcard lost?): {bumped_dropped:?}"
+    );
 }
 
 /// AC-13: passthrough endpoints return early — caller headers untouched,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16360,8 +16360,20 @@ fn oauth_beta_filter_keeps_claude_code_flag_set() {
     let bumped: Vec<String> = claude_code_flags
         .iter()
         .map(|flag| {
-            // Strip the trailing `-YYYY-MM-DD`, keeping the family.
-            let family = flag.rsplitn(4, '-').last().unwrap();
+            // Strip the trailing `-YYYY-MM-DD`, keeping the family. Validate
+            // the suffix shape first so a malformed inventory entry (e.g. a
+            // compact `-YYYYMMDD` date) fails naming the entry, instead of
+            // mis-stripping and surfacing as a baffling allowlist miss below.
+            let parts: Vec<&str> = flag.rsplitn(4, '-').collect();
+            assert_eq!(parts.len(), 4, "flag lacks a -YYYY-MM-DD suffix: {flag}");
+            assert!(
+                parts[..3]
+                    .iter()
+                    .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit())),
+                "flag suffix is not numeric YYYY-MM-DD: {flag}"
+            );
+            let family = parts[3];
+            assert_ne!(family, "", "empty family for {flag}");
             assert_ne!(family, *flag, "date-suffix strip failed for {flag}");
             format!("{family}-2099-12-31")
         })
@@ -16381,6 +16393,21 @@ fn oauth_beta_filter_keeps_claude_code_flag_set() {
         bumped_dropped.is_empty(),
         "a Claude Code date bump must stay allowed (suffix wildcard lost?): {bumped_dropped:?}"
     );
+    // `dropped` and the outbound header are separate outputs — an allowed
+    // flag silently discarded (neither forwarded nor reported) passes the
+    // assertion above. Check the header too, exact-token like the main set.
+    let bumped_sent = bumped_headers
+        .get("anthropic-beta")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    let bumped_tokens: Vec<&str> = bumped_sent.split(',').map(str::trim).collect();
+    for flag in &bumped {
+        assert!(
+            bumped_tokens.contains(&flag.as_str()),
+            "bumped flag not forwarded as an exact token: {flag} (sent: {bumped_sent})"
+        );
+    }
 }
 
 /// AC-13: passthrough endpoints return early — caller headers untouched,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR fixes a critical bug where **all Claude Code traffic was receiving HTTP 400 errors** when routed through the load balancer.

## Problem

The `DEFAULT_CLIENT_BETA_ALLOWLIST` only contained six beta flag entries, which caused it to drop ten additional `anthropic-beta` flags that Claude Code 2.1.x sends on every request. This was not a silent feature downgrade — it caused hard upstream rejections (400s) on **all primary traffic**.

The root cause is that several of these dropped flags have a body-side counterpart that the load balancer forwards verbatim:
- `context-management` → `context_management` object
- `structured-outputs` → `output_format`
- `extended-cache-ttl` → `cache_control.ttl`

Stripping only the header (while still forwarding the body-side data) left an incoherent request that upstream rejected outright.

## Changes

**`src/main.rs`** — Added ten previously-missing beta flag families to the default allow-list (using wildcards to tolerate date suffix bumps):
- `context-management-*`
- `structured-outputs-*`
- `extended-cache-ttl-*`
- `effort-*`
- `thinking-token-count-*`
- `mid-conversation-system-*`
- `advisor-tool-*`
- `fallback-credit-*`
- `redact-thinking-*`
- `afk-mode-*`

The inventory was derived from the `anthropic_beta_flag_dropped_total` metric on the live fleet.

**`src/tests.rs`** — Added a regression test (`oauth_beta_filter_keeps_claude_code_flag_set`) that verifies the complete Claude Code 2.1.220 beta flag set survives the default allow-list, none are dropped, all are forwarded, and required OAuth flags remain present. Concrete date suffixes are used intentionally so that date bumps continue to pass while genuinely new flag families still surface as drops.

## Impact

Restores Claude Code request compatibility through the proxy, eliminating the 400 errors affecting all Claude Code traffic.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Claude Code 2.1.x beta capabilities, including context management, structured outputs, extended caching, effort controls and enhanced thinking features.
  * Added support for advisor tools, fallback credits, redacted thinking, mid-conversation system prompts and AFK mode.
  * Added support for date-suffixed variants of supported beta flags.

* **Bug Fixes**
  * Ensured supported beta flags are forwarded correctly while unrecognised flags continue to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->