### PR TITLE
fix(LAB-1639): make the redis startup connect background + retrying

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2817,6 +2817,25 @@ fn start_coordination_redis(
         info!(%server, "redis reconnected for distributed state");
         Ok(())
     });
+    // Connection-level errors are otherwise INVISIBLE under a retry-forever
+    // policy: failed attempts broadcast errors, never a connect result, so
+    // neither wait_for_connect nor on_reconnect ever fires for them. A
+    // persistently wrong password (NOAUTH retries forever in fred) would be
+    // indistinguishable from a backend outage without this. Rate-limited to
+    // one line per 60s — the backoff ramp starts sub-second.
+    let last_error_log = AtomicU64::new(0);
+    client.on_error(move |error| {
+        let now = AppState::now_epoch();
+        let prev = last_error_log.load(Ordering::Relaxed);
+        if now.saturating_sub(prev) >= 60
+            && last_error_log
+                .compare_exchange(prev, now, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            warn!(%error, "redis connection error — reconnect policy retrying");
+        }
+        Ok(())
+    });
     let _connect_task = client.connect();
     Ok(client)
 }
@@ -3926,15 +3945,37 @@ impl AppState {
         let Some(client) = self.redis.clone() else {
             return;
         };
+        // Belt for the recorder task below: fred's wait_for_connect reads
+        // client state THEN subscribes, so a connect landing between those
+        // two ops is missed until the next reconnect — with a mid-run drop
+        // in between, the gate would wrongly read closed and skip writes
+        // LAB-932 buffers. This subscription fires on every successful
+        // connection (the first included), so the flag cannot lag reality
+        // past one broadcast.
+        let state = self.clone();
+        client.on_reconnect(move |_server| {
+            state.redis_ever_connected.store(true, Ordering::Relaxed);
+            Ok(())
+        });
         let state = self.clone();
         let waiter = client.clone();
         tokio::spawn(async move {
             // Resolves immediately when already connected. With a
             // retry-forever policy it otherwise resolves only on success:
             // failed attempts broadcast errors, not connect results.
-            if waiter.wait_for_connect().await.is_ok() {
-                state.redis_ever_connected.store(true, Ordering::Relaxed);
-                info!("redis connected for distributed state");
+            match waiter.wait_for_connect().await {
+                Ok(()) => {
+                    state.redis_ever_connected.store(true, Ordering::Relaxed);
+                    info!("redis connected for distributed state");
+                }
+                // Only broadcast when the connection task exits for good
+                // (non-retryable config/URL-class errors). Without this arm
+                // that exit would be silent and the startup WARN's "until
+                // the backend becomes reachable" a lie.
+                Err(e) => error!(
+                    error = %e,
+                    "redis connection task exited before first connect — coordination stays local-only"
+                ),
             }
         });
         let state = self.clone();
@@ -3944,7 +3985,7 @@ impl AppState {
             // above must not produce a false outage WARN.
             if !state.redis_ever_connected.load(Ordering::Relaxed) && !client.is_connected() {
                 warn!(
-                    "redis unreachable at startup — serving local-only until the backend becomes reachable"
+                    "redis unreachable at startup — running local-only until the backend becomes reachable"
                 );
             }
         });
@@ -12735,6 +12776,8 @@ async fn main() {
             ..Default::default()
         };
         let conn_config = ConnectionConfig {
+            // Keep connection_timeout in step with REDIS_STARTUP_GRACE: the
+            // startup WARN is timed to fire after one full connect budget.
             connection_timeout: Duration::from_secs(5),
             internal_command_timeout: Duration::from_secs(5),
             ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -745,6 +745,11 @@ struct AppState {
     /// fred clients are cheap to clone; every clone shares one multiplexed
     /// connection driven by a background task with a reconnect policy.
     redis: Option<RedisClient>,
+    /// Whether the coordination client has EVER connected. False from process
+    /// start until the first successful connect (set once by
+    /// `spawn_redis_connect_watcher`, never cleared). Gates coordination ops
+    /// off entirely while never-yet-connected — see `coordination_redis`.
+    redis_ever_connected: AtomicBool,
     /// Cached cluster info from Redis, updated by background sync task.
     cluster_info_cache: Mutex<Option<serde_json::Value>>,
     /// Monotonic request ID counter for log correlation.
@@ -2372,7 +2377,7 @@ impl AppState {
         }
 
         // Distributed probe lock: one pod per endpoint+model per interval.
-        if let Some(redis) = &self.redis {
+        if let Some(redis) = self.coordination_redis() {
             let lock_key = format!("alb:probe:{}:{}", ep.name, model);
             let lock_ttl = self.probe_interval_secs.max(1);
             // SET NX EX: OK reply when acquired, nil (None) when another
@@ -2775,6 +2780,46 @@ const BUDGET_TTL_SECS: i64 = 172_800;
 /// `default_command_timeout`), carried over from the old ConnectionManager's
 /// 2s response timeout.
 const REDIS_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How long after startup an unconnected coordination backend earns its one
+/// WARN (`spawn_redis_connect_watcher`). Matches the connection budget the
+/// old blocking `init()` gave the first attempt, so the log fires on the
+/// same timeline operators already know — it just no longer implies
+/// permanence.
+const REDIS_STARTUP_GRACE: Duration = Duration::from_secs(5);
+
+/// Build the coordination Redis client and spawn its connection task WITHOUT
+/// waiting for the first connect (LAB-1639). `Err` only for an unparseable
+/// URL — an unreachable backend is not an error here.
+///
+/// `fail_fast = false` routes the INITIAL connect through `policy` — the
+/// same retry loop that already handles mid-run drops — instead of fred's
+/// default single attempt. `connect()` (not `init()`) spawns that task and
+/// returns immediately: with a retry-forever policy, awaiting the first
+/// connect would block the caller for the whole backend outage, so a pod
+/// cold-starting during a Redis window would never bind its listener — a
+/// full LB outage instead of degraded local-only mode. The returned handle
+/// detaches on drop; the task keeps driving the connection (and reconnects)
+/// for the lifetime of the client.
+fn start_coordination_redis(
+    url: &str,
+    perf: PerformanceConfig,
+    conn_config: ConnectionConfig,
+    policy: ReconnectPolicy,
+) -> Result<RedisClient, fred::error::RedisError> {
+    let mut redis_config = RedisConfig::from_url(url)?;
+    redis_config.fail_fast = false;
+    let client = RedisClient::new(redis_config, Some(perf), Some(conn_config), Some(policy));
+    // Connection transitions are sparse, high-signal events; log them so a
+    // flapping backend is visible in operator logs. fred emits this on EVERY
+    // successful connection establishment, the first one included.
+    client.on_reconnect(|server| {
+        info!(%server, "redis reconnected for distributed state");
+        Ok(())
+    });
+    let _connect_task = client.connect();
+    Ok(client)
+}
 
 /// `SET key value EX ttl` — the one-line convenience the redis crate's
 /// `set_ex` provided; fred's five-argument `set` buries the common case in
@@ -3853,10 +3898,62 @@ impl AppState {
         effective_interval.saturating_mul(2).max(1)
     }
 
+    /// Redis handle for coordination reads/writes, or `None` while the
+    /// client has never yet connected (a process that started during a
+    /// backend outage — LAB-1639). Before the first connect fred BUFFERS
+    /// every command for `REDIS_COMMAND_TIMEOUT` (2s) and each failure would
+    /// WARN, so coordination ops skip outright: no stalls, no per-operation
+    /// log spam — the startup grace WARN is the one signal. After the first
+    /// connect this is permanently `Some`: mid-run drops keep the LAB-932
+    /// contract (bounded 2s buffered failures, request paths gated on
+    /// `is_connected`). The `is_connected()` arm only covers the moments
+    /// between an early first connect and the watcher task storing the flag.
+    fn coordination_redis(&self) -> Option<&RedisClient> {
+        let redis = self.redis.as_ref()?;
+        if self.redis_ever_connected.load(Ordering::Relaxed) || redis.is_connected() {
+            Some(redis)
+        } else {
+            None
+        }
+    }
+
+    /// Spawn the tasks that observe the coordination client's FIRST connect
+    /// (LAB-1639). Call once after construction; no-op without Redis.
+    /// One task records the connect — permanently opening the
+    /// `coordination_redis` gate — and one emits the single startup WARN if
+    /// the backend is still unreachable after `REDIS_STARTUP_GRACE`.
+    fn spawn_redis_connect_watcher(self: &Arc<Self>) {
+        let Some(client) = self.redis.clone() else {
+            return;
+        };
+        let state = self.clone();
+        let waiter = client.clone();
+        tokio::spawn(async move {
+            // Resolves immediately when already connected. With a
+            // retry-forever policy it otherwise resolves only on success:
+            // failed attempts broadcast errors, not connect results.
+            if waiter.wait_for_connect().await.is_ok() {
+                state.redis_ever_connected.store(true, Ordering::Relaxed);
+                info!("redis connected for distributed state");
+            }
+        });
+        let state = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(REDIS_STARTUP_GRACE).await;
+            // Double-check is_connected: a connect racing the recorder task
+            // above must not produce a false outage WARN.
+            if !state.redis_ever_connected.load(Ordering::Relaxed) && !client.is_connected() {
+                warn!(
+                    "redis unreachable at startup — serving local-only until the backend becomes reachable"
+                );
+            }
+        });
+    }
+
     /// Publish precomputed routing weights to Redis so non-probing pods
     /// can set their gauge atomics without recomputing.
     async fn publish_routing_weights(&self) {
-        let redis = match &self.redis {
+        let redis = match self.coordination_redis() {
             Some(r) => r,
             None => return,
         };
@@ -3907,7 +4004,7 @@ impl AppState {
     /// Broadcast a hard-limit recovery for an endpoint by name. The Redis
     /// sentinel key is derived from the name alone.
     async fn signal_hard_limit_recovery(&self, endpoint_name: &str) {
-        if let Some(redis) = &self.redis {
+        if let Some(redis) = self.coordination_redis() {
             let conn = redis.clone();
             let key = format!("alb:hard:{}", endpoint_name);
             let now_epoch = Self::now_epoch();
@@ -4488,7 +4585,7 @@ impl AppState {
         );
 
         // Fire-and-forget: publish rate info to Redis for cross-replica sync
-        if let Some(redis) = &self.redis {
+        if let Some(redis) = self.coordination_redis() {
             let rate_data = RedisRateInfo {
                 utilization: info.utilization,
                 utilization_5h: info.utilization_5h,
@@ -4618,7 +4715,7 @@ impl AppState {
         );
 
         // Propagate to Redis for cross-replica awareness
-        if let Some(redis) = &self.redis {
+        if let Some(redis) = self.coordination_redis() {
             let conn = redis.clone();
             let key = format!("alb:hard:{}", endpoint_name);
             let until_epoch = Self::now_epoch()
@@ -4707,7 +4804,7 @@ impl AppState {
     /// Sync shared state from Redis: hard limits + rate info.
     /// Called periodically by background task.
     async fn sync_from_redis(&self) {
-        let redis = match &self.redis {
+        let redis = match self.coordination_redis() {
             Some(r) => r,
             None => return,
         };
@@ -4958,7 +5055,7 @@ impl AppState {
     /// deployments keep accumulating locally; on an idle tick the TTL is still
     /// refreshed so the fleet-wide hash never expires under healthy traffic.
     async fn flush_transport_errors(&self) {
-        let redis = match &self.redis {
+        let redis = match self.coordination_redis() {
             Some(r) => r,
             None => return,
         };
@@ -5019,7 +5116,7 @@ impl AppState {
         }
     }
     async fn cluster_info(&self) -> Option<serde_json::Value> {
-        let redis = self.redis.as_ref()?;
+        let redis = self.coordination_redis()?;
         let mut redis_ok = true;
 
         // Count active replicas via SCAN (non-blocking, unlike KEYS). The
@@ -12622,49 +12719,30 @@ async fn main() {
 
     // Set up Redis connection for distributed state (if configured).
     // Timeout budgets carry over from the old ConnectionManager: 2s per
-    // command, 5s to establish a connection. `fail_fast` (fred's default)
-    // preserves the startup contract — an unreachable backend degrades to
-    // local-only rather than aborting or retrying forever. The reconnect
-    // policy is the one deliberate behaviour change (LAB-932 AC5): once the
-    // initial connect succeeds, a mid-run outage reconnects with capped
-    // exponential backoff instead of degrading permanently until restart.
+    // command, 5s to establish a connection. The startup contract (LAB-1639):
+    // the connect runs in the BACKGROUND under the retry-forever reconnect
+    // policy — startup never blocks on Redis and never aborts for an
+    // unreachable backend. A process that boots during a backend outage
+    // serves local-only (coordination ops gated off via
+    // `coordination_redis`) and attaches automatically when the backend
+    // becomes reachable; `None` here means a config error (unparseable URL),
+    // which stays local-only for the process lifetime. Mid-run outage
+    // behaviour is unchanged from LAB-932 AC5: once connected, drops
+    // reconnect with capped exponential backoff.
     let redis = if let Some(ref url) = config.redis_url {
-        match RedisConfig::from_url(url.as_str()) {
-            Ok(redis_config) => {
-                let perf = PerformanceConfig {
-                    default_command_timeout: REDIS_COMMAND_TIMEOUT,
-                    ..Default::default()
-                };
-                let conn_config = ConnectionConfig {
-                    connection_timeout: Duration::from_secs(5),
-                    internal_command_timeout: Duration::from_secs(5),
-                    ..Default::default()
-                };
-                // 0 = retry forever; delays 100ms → 30s, doubling.
-                let policy = ReconnectPolicy::new_exponential(0, 100, 30_000, 2);
-                let client =
-                    RedisClient::new(redis_config, Some(perf), Some(conn_config), Some(policy));
-                // Reconnect transitions are sparse, high-signal events; log
-                // them so a flapping backend is visible in operator logs.
-                client.on_reconnect(|server| {
-                    info!(%server, "redis reconnected for distributed state");
-                    Ok(())
-                });
-                // init() spawns the connection task and waits for the first
-                // connect. The returned handle detaches on drop; the task
-                // keeps driving the connection (and reconnects) for the
-                // lifetime of the client.
-                match client.init().await {
-                    Ok(_connect_handle) => {
-                        info!("redis connected for distributed state");
-                        Some(client)
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "redis connection failed — running in local-only mode");
-                        None
-                    }
-                }
-            }
+        let perf = PerformanceConfig {
+            default_command_timeout: REDIS_COMMAND_TIMEOUT,
+            ..Default::default()
+        };
+        let conn_config = ConnectionConfig {
+            connection_timeout: Duration::from_secs(5),
+            internal_command_timeout: Duration::from_secs(5),
+            ..Default::default()
+        };
+        // 0 = retry forever; delays 100ms → 30s, doubling.
+        let policy = ReconnectPolicy::new_exponential(0, 100, 30_000, 2);
+        match start_coordination_redis(url.as_str(), perf, conn_config, policy) {
+            Ok(client) => Some(client),
             Err(e) => {
                 warn!(error = %e, "invalid redis_url — running in local-only mode");
                 None
@@ -12755,6 +12833,7 @@ async fn main() {
         client_request_rates: Mutex::new(HashMap::new()),
         soft_limit: config.soft_limit.unwrap_or(0.90),
         redis,
+        redis_ever_connected: AtomicBool::new(false),
         cluster_info_cache: Mutex::new(None),
         next_req_id: AtomicU64::new(0),
         instance_id: {
@@ -12803,6 +12882,11 @@ async fn main() {
     if state.auto_cache {
         info!("auto-cache enabled");
     }
+
+    // Observe the coordination client's first connect: opens the
+    // `coordination_redis` gate and owns the startup connected/unreachable
+    // log lines (LAB-1639).
+    state.spawn_redis_connect_watcher();
 
     // Restore persisted state (cooldowns, utilization, request counts)
     state.load_state().await;
@@ -12907,7 +12991,7 @@ async fn main() {
             loop {
                 sync_state.sync_from_redis().await;
                 // Heartbeat: register this instance
-                if let Some(redis) = &sync_state.redis {
+                if let Some(redis) = sync_state.coordination_redis() {
                     let key = format!("alb:heartbeat:{instance_id}");
                     let _ = redis_set_ex(redis, &key, AppState::now_epoch().to_string(), 30).await;
                 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -398,6 +398,12 @@ fn test_state_base() -> AppState {
         client_request_rates: Mutex::new(HashMap::new()),
         soft_limit: 1.0,
         redis: None,
+        // true, not production's false: every fixture that overrides `redis`
+        // hands in a client that CONNECTED at creation (`fred_test_client`
+        // panics if it can't), so the ever-connected gate is open — exactly
+        // the post-first-connect state those tests exercise. The LAB-1639
+        // startup-outage test overrides this back to false.
+        redis_ever_connected: AtomicBool::new(true),
         cluster_info_cache: Mutex::new(None),
         next_req_id: AtomicU64::new(0),
         instance_id: 0,
@@ -18619,6 +18625,142 @@ mod redis_integration {
         assert_eq!(
             info["redis_connected"], true,
             "cluster_info must reflect the recovered backend"
+        );
+    }
+
+    /// LAB-1639: a process that STARTS while the backend is down must come
+    /// up serving local-only immediately — client construction must not
+    /// block on the unreachable backend — and must attach automatically when
+    /// the backend appears, without a restart. The startup analogue of the
+    /// mid-run death/recovery pair above. Under the pre-LAB-1639 contract
+    /// (fred's default `fail_fast = true` + a blocking `init()`) the single
+    /// refused connect at creation pinned the process local-only for its
+    /// entire lifetime.
+    #[tokio::test]
+    async fn backend_down_at_startup_serves_local_only_then_attaches() {
+        let Some(base) = test_redis_url() else {
+            return;
+        };
+        avoid_utc_midnight().await;
+        let target = base
+            .trim_start_matches("redis://")
+            .trim_end_matches('/')
+            .split('/')
+            .next()
+            .unwrap()
+            .to_string();
+        // Flush DB 14 through a DIRECT connection — the proxy is dead at
+        // client creation, so the usual flush-through-proxy path cannot run.
+        // The same client later verifies that post-attach writes landed.
+        let direct = connect_and_flush(&format!("{}/14", base.trim_end_matches('/'))).await;
+
+        // Reserve an address, then kill it BEFORE the client under test
+        // exists: nothing is listening when the connection task makes its
+        // first attempt — the exact boot-during-outage scenario.
+        let (proxy_addr, kill) = spawn_killable_proxy(target.clone()).await;
+        kill_proxy(kill).await;
+        let url = format!("redis://{proxy_addr}/14");
+
+        // The PRODUCTION constructor (fail_fast=false, background connect),
+        // with the harness's short budgets and fast constant reconnect.
+        let constructed = std::time::Instant::now();
+        let client = start_coordination_redis(
+            &url,
+            PerformanceConfig {
+                default_command_timeout: Duration::from_secs(1),
+                ..Default::default()
+            },
+            ConnectionConfig {
+                connection_timeout: Duration::from_secs(2),
+                internal_command_timeout: Duration::from_secs(2),
+                ..Default::default()
+            },
+            ReconnectPolicy::new_constant(0, 100),
+        )
+        .expect("a well-formed url must always yield a client");
+        assert!(
+            constructed.elapsed() < Duration::from_millis(500),
+            "client construction must not block on the unreachable backend"
+        );
+        assert!(
+            !client.is_connected(),
+            "never-yet-connected client must read disconnected"
+        );
+
+        let state = Arc::new(AppState {
+            client_budgets: [("startup-cli".to_string(), 100u64)].into(),
+            redis: Some(client.clone()),
+            // Production boots with the gate closed; test_state_base opens
+            // it for the connected-at-creation fixtures.
+            redis_ever_connected: AtomicBool::new(false),
+            ..test_state_base()
+        });
+        state.spawn_redis_connect_watcher();
+
+        // Never-yet-connected: the coordination gate is closed, so request
+        // paths and background ticks return at local speed — no buffered
+        // fred command burning its 1s timeout, no per-operation warnings.
+        assert!(
+            state.coordination_redis().is_none(),
+            "coordination gate must be closed before the first connect"
+        );
+        let ops = std::time::Instant::now();
+        assert!(state.check_budget("startup-cli").await.is_ok());
+        state.record_budget_usage("startup-cli", 50).await;
+        state.sync_from_redis().await;
+        state.publish_routing_weights().await;
+        assert!(
+            state.cluster_info().await.is_none(),
+            "cluster_info must skip (not stall) while never-yet-connected"
+        );
+        assert!(
+            ops.elapsed() < Duration::from_millis(500),
+            "local-only ops must not stall on the dead backend"
+        );
+
+        // Local budget accounting still enforces (50 + 60 > 100).
+        state.record_budget_usage("startup-cli", 60).await;
+        assert_eq!(
+            state.check_budget("startup-cli").await,
+            Err(0),
+            "local fallback must enforce the budget while unconnected"
+        );
+
+        // Backend appears (proxy revives at the SAME address): the
+        // retry-forever connection task must attach on its own.
+        let (revived_addr, _revived_kill) = spawn_killable_proxy_at(&proxy_addr, target).await;
+        assert_eq!(
+            revived_addr, proxy_addr,
+            "proxy must revive at its old address"
+        );
+
+        eventually("the first connect to open the coordination gate", || {
+            let s = state.clone();
+            async move { s.coordination_redis().is_some() }
+        })
+        .await;
+
+        // Coordination writes begin: a fresh INCRBY lands in the real
+        // backend, verified through the independent direct connection.
+        // 7, not 117 — the pre-attach 50 and 60 were local-only by design.
+        state.record_budget_usage("startup-cli", 7).await;
+        let today = AppState::now_epoch() / 86400;
+        let key = format!("alb:budget:startup-cli:{today}");
+        eventually("the post-attach INCRBY to land in the backend", || {
+            let mut c = direct.clone();
+            let key = key.clone();
+            async move { c.get::<_, Option<u64>>(&key).await.ok().flatten() == Some(7) }
+        })
+        .await;
+
+        // And the operator surface reflects the attach.
+        let info = state
+            .cluster_info()
+            .await
+            .expect("cluster_info after attach");
+        assert_eq!(
+            info["redis_connected"], true,
+            "cluster_info must reflect the attached backend"
         );
     }
 }


### PR DESCRIPTION
Fixes #128 / LAB-1639.

## Problem

Since the fred migration (#121), the coordination Redis handle was decided once at startup: fred's default `fail_fast: true` made `client.init().await` a **single** connect attempt, and on any error the process stored `redis: None` and ran local-only for its entire lifetime. The retry-forever `ReconnectPolicy` governed only post-init drops — for startup it was dead code. With Dragonfly at `replicas: 1` + `strategy: Recreate`, every Dragonfly change has a guaranteed window where a booting LB pod silently loses distributed state until someone restarts it.

## Change

- **`start_coordination_redis()`** (factored so the integration test drives the production constructor): sets `fail_fast = false` so the *initial* connect goes through the same retry-forever reconnect policy as mid-run drops, and uses `connect()` (non-blocking spawn) instead of a blocking `init()` — startup never waits on Redis, the listener always binds.
- **`redis_ever_connected` gate** (`coordination_redis()`): while never-yet-connected, all 9 background/spawned coordination call sites (probe lock, weight publish, hard-limit propagation + recovery sentinel, rate-info write, sync, transport-error flush, cluster_info, heartbeat) skip outright — no 2s buffered-command stalls, no per-operation WARN spam. Set once on first connect, never cleared: **post-first-connect behaviour is byte-identical to the LAB-932 contract** (mid-run drops buffer bounded 2s; request paths keep their existing `is_connected()` gates, which read `false` in the never-connected state — verified against vendored fred source: initial `ClientState` is `Disconnected`).
- **`spawn_redis_connect_watcher()`**: records the first connect (a `wait_for_connect` task plus an `on_reconnect` subscription that closes fred's read-state-then-subscribe gap), logs one INFO on attach, and one startup WARN after a 5s grace if still unreachable.
- **Observability hardening** (expert-panel findings): the `wait_for_connect` Err arm (permanent connection-task exit on non-retryable config-class errors) now logs `error!`; a rate-limited (1/60s) `on_error` subscriber makes persistent connect errors — e.g. NOAUTH from a rotated password, which fred retries forever — diagnosable instead of invisible.

## Log-line changes (operator note)

- Boot-during-outage: `"redis connection failed — running in local-only mode"` → `"redis unreachable at startup — running local-only until the backend becomes reachable"` (fires after the 5s grace; keeps the `running` + `local-only` tokens for existing greps). The invalid-URL WARN is unchanged.
- New: `"redis connection error — reconnect policy retrying"` (≤1/60s while a backend is unreachable/misconfigured), `"redis connection task exited before first connect — coordination stays local-only"` (permanent-exit path).
- `redis_connected` in `/_stats` and `anthropic_cluster_redis_connected` flip to 1 on attach via the existing sync tick — no metric changes.

## Tests

- New `backend_down_at_startup_serves_local_only_then_attaches` (LAB-931 killable-proxy harness, DB 14): backend dead at client creation → construction returns in <500ms, gate closed, request-path + background ops complete at local speed, local budget still enforced → proxy revives at the same address → gate opens on its own, a fresh INCRBY lands in the real backend (verified through the independent redis-crate oracle), `cluster_info` reports `redis_connected: true`.
- `backend_death_mid_run_degrades_to_local_only` and `backend_recovery_mid_run_resumes_coordination` pass **unmodified** (test fixture defaults the new flag to `true`, mirroring their connected-at-creation clients).
- Full suite: 612 + 18 + 12 pass locally against redis-server with `ALB_TEST_REDIS_URL` set; `cargo fmt --check` and `clippy -Dwarnings` clean.

## Expert panel (workspace gate, high stakes)

bug-hunter 3 MAJ (permanent-exit silence, auth-error invisibility, flag TOCTOU) — all fixed in 88d958c. security: no findings (no URL/credential leakage in new log lines; never-connected local-only window is strictly tighter than the permanent local-only it replaces). craftsman 3 MIN — fixed (Err-arm logging, WARN token continuity, grace/timeout cross-reference); 2 cuts rejected: collapsing the two watcher tasks re-introduces the drop/re-subscribe race catchphrase verified against fred source, and the named `_connect_task` binding is the idiomatic deliberate-discard signal. catchphrase: no cuts.

## Out of scope

Netpol/egress fix (LAB-1625, 27b-io/lab#40), prod rollout verification, routing math, post-init reconnect policy.
