### PR TITLE
perf(LAB-716): build OpenAI-path request bodies once per request, not per retry attempt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6732,6 +6732,14 @@ enum ForwardOutcome {
     },
 }
 
+/// Non-transient rotation: skip this endpoint and try the next candidate.
+/// Pre-dates the `ForwardOutcome` return type as a bare `None`.
+const ROTATE: ForwardOutcome = ForwardOutcome::Retry {
+    saw_529: false,
+    push_skip: true,
+    transient: false,
+};
+
 /// True when an upstream error body says this ACCOUNT cannot serve the
 /// requested model — distinct from a malformed request (LAB-941). Matched
 /// conservatively against observed wire formats:
@@ -7954,82 +7962,87 @@ async fn proxy_handler(
             // `forward_anthropic` (Anthropic) or `try_fallback_upstream`
             // (OpenAI). Both return a `ForwardOutcome` so the shared
             // round-gated policy in `apply_round_outcome` covers both.
-            let (outcome, picked_idx): (ForwardOutcome, EndpointIdx) =
-                match state.pick_endpoint(affinity, &model, &skip).await {
-                    Some(i) => {
-                        let ep = &state.endpoints[i];
-                        match ep.protocol {
-                            Protocol::Anthropic => {
-                                let out = forward_anthropic(
-                                    &state,
-                                    &parts,
-                                    &body_bytes,
-                                    &oauth_body_bytes,
-                                    ep,
-                                    i,
-                                    &req_id,
-                                    &client_id,
-                                    &client_ver,
-                                    &client_ip,
-                                    &agent_id,
-                                    &session_id,
-                                    &model,
-                                    affinity,
-                                    request_start,
-                                )
-                                .await;
-                                (out, i)
-                            }
-                            Protocol::OpenAI => {
-                                let out = match openai_fallback_body
-                                    .get_or_insert_with(|| build_openai_fallback_body(&body_bytes))
-                                {
-                                    FallbackBody::Ready { body, is_streaming } => {
-                                        try_fallback_upstream(
-                                            &state,
-                                            body,
-                                            &req_id,
-                                            &client_id,
-                                            &client_ip,
-                                            &agent_id,
-                                            &session_id,
-                                            &model,
-                                            i,
-                                            request_start,
-                                            true,
-                                            *is_streaming,
-                                        )
-                                        .await
-                                    }
-                                    FallbackBody::Unparseable => ForwardOutcome::Retry {
-                                        saw_529: false,
-                                        push_skip: true,
-                                        transient: false,
-                                    },
-                                    FallbackBody::Untranslatable(msg) => {
-                                        warn!(
+            let (outcome, picked_idx): (ForwardOutcome, EndpointIdx) = match state
+                .pick_endpoint(affinity, &model, &skip)
+                .await
+            {
+                Some(i) => {
+                    let ep = &state.endpoints[i];
+                    match ep.protocol {
+                        Protocol::Anthropic => {
+                            let out = forward_anthropic(
+                                &state,
+                                &parts,
+                                &body_bytes,
+                                &oauth_body_bytes,
+                                ep,
+                                i,
+                                &req_id,
+                                &client_id,
+                                &client_ver,
+                                &client_ip,
+                                &agent_id,
+                                &session_id,
+                                &model,
+                                affinity,
+                                request_start,
+                            )
+                            .await;
+                            (out, i)
+                        }
+                        Protocol::OpenAI => {
+                            let out = match openai_fallback_body
+                                .get_or_insert_with(|| build_openai_fallback_body(&body_bytes))
+                            {
+                                FallbackBody::Ready { body, is_streaming } => {
+                                    try_fallback_upstream(
+                                        &state,
+                                        body,
+                                        &req_id,
+                                        &client_id,
+                                        &client_ip,
+                                        &agent_id,
+                                        &session_id,
+                                        &model,
+                                        i,
+                                        request_start,
+                                        true,
+                                        *is_streaming,
+                                    )
+                                    .await
+                                }
+                                FallbackBody::Unparseable => {
+                                    warn!(
                                             req_id,
                                             upstream = ep.name,
-                                            error = %msg,
-                                            "fallback: request not representable in OpenAI format"
+                                            "fallback: request JSON unparseable, skipping OpenAI endpoint"
                                         );
-                                        // Terminal, not a retry: the request itself
-                                        // is the problem, so rotating would fail the
-                                        // same way on every endpoint.
-                                        ForwardOutcome::Done(untranslatable_request_response(msg))
-                                    }
-                                };
-                                (out, i)
-                            }
+                                    ROTATE
+                                }
+                                FallbackBody::Untranslatable(msg) => {
+                                    warn!(
+                                        req_id,
+                                        upstream = ep.name,
+                                        error = %msg,
+                                        "fallback: request not representable in OpenAI format"
+                                    );
+                                    // Terminal, not a retry: the request itself
+                                    // is the problem, so rotating would fail the
+                                    // same way on every endpoint.
+                                    ForwardOutcome::Done(untranslatable_request_response(msg))
+                                }
+                            };
+                            (out, i)
                         }
                     }
-                    // Candidates exhausted mid-round (all skipped / hard-limited /
-                    // model-filtered). Break to the round-end logic rather than
-                    // returning here, so a transient-only round still reaches the
-                    // transient-aware exhaustion status instead of short-circuiting
-                    // to a premature 429.
-                    None => break,
-                };
+                }
+                // Candidates exhausted mid-round (all skipped / hard-limited /
+                // model-filtered). Break to the round-end logic rather than
+                // returning here, so a transient-only round still reaches the
+                // transient-aware exhaustion status instead of short-circuiting
+                // to a premature 429.
+                None => break,
+            };
 
             match apply_round_outcome(
                 retry_round,
@@ -8089,9 +8102,7 @@ async fn proxy_handler(
 
 /// Anthropic→OpenAI request body for `try_fallback_upstream`, built lazily by
 /// `proxy_handler` on the first OpenAI-endpoint attempt of a request and
-/// memoized across rotations/retries (LAB-716) — previously the parse +
-/// translate + serialize ran inside the retry loop, once per attempt, peaking
-/// exactly when the pool was retrying hardest.
+/// memoized across rotations/retries (LAB-716).
 enum FallbackBody {
     /// Translated + serialized once; `is_streaming` read from the same parse.
     Ready {
@@ -8125,14 +8136,20 @@ fn build_openai_fallback_body(body_bytes: &[u8]) -> FallbackBody {
             body: b.into(),
             is_streaming,
         },
-        Err(_) => FallbackBody::Unparseable,
+        Err(e) => {
+            // Can't happen for a Value built from parsed JSON (string keys
+            // only) — but don't rotate invisibly if it somehow does.
+            warn!(error = %e, "fallback: translated body failed to serialize");
+            FallbackBody::Unparseable
+        }
     }
 }
 
-/// Forward a request to a `Protocol::OpenAI` endpoint. For Anthropic-format
-/// callers (`proxy_handler`) it translates the request to OpenAI format and the
-/// response back (`translate = true`); for OpenAI-format callers
-/// (`openai_chat_handler`) it forwards directly (`translate = false`).
+/// Forward a request to a `Protocol::OpenAI` endpoint. Callers hand over the
+/// final wire body: `proxy_handler` pre-translates via
+/// `build_openai_fallback_body` and sets `translate = true` so the *response*
+/// is translated back to Anthropic format; `openai_chat_handler` passes the
+/// raw OpenAI-format bytes with `translate = false` (passthrough).
 ///
 /// Returns `ForwardOutcome` so the caller's retry loop applies the SAME
 /// round-gated policy as the Anthropic path (`apply_round_outcome`): a
@@ -8149,9 +8166,8 @@ fn build_openai_fallback_body(body_bytes: &[u8]) -> FallbackBody {
 #[allow(clippy::too_many_arguments)]
 async fn try_fallback_upstream(
     state: &AppState,
-    // Final wire body (already OpenAI-shaped): translated + serialized at
-    // most once by the caller and reused across rotations/retries (LAB-716).
-    // `Bytes` so the per-attempt body handoff is a refcount, not a copy.
+    // Final wire body (already OpenAI-shaped), serialized once by the
+    // caller; each attempt clones the refcounted `Bytes`.
     request_body: &bytes::Bytes,
     req_id: &str,
     client_id: &str,
@@ -8164,13 +8180,6 @@ async fn try_fallback_upstream(
     translate: bool, // true = upstream response needs OpenAI→Anthropic translation
     is_streaming: bool,
 ) -> ForwardOutcome {
-    // Non-transient rotation: skip this endpoint and try the next candidate.
-    // Pre-dates the ForwardOutcome return type as a bare `None`.
-    const ROTATE: ForwardOutcome = ForwardOutcome::Retry {
-        saw_529: false,
-        push_skip: true,
-        transient: false,
-    };
     let ep = &state.endpoints[endpoint_idx];
 
     info!(
@@ -11589,9 +11598,9 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
 }
 
 /// Forward one OpenAI-compat request to a single Anthropic-protocol `Endpoint`.
-/// The caller has already translated the OpenAI request into `anthropic_body`
-/// (plus the OAuth variant `oauth_anthropic_body`); this helper picks the right
-/// variant by token prefix, forwards to the endpoint, and translates the
+/// The caller has already translated the OpenAI request and serialized it once
+/// into `anthropic_body_bytes` (plus the OAuth variant); this helper picks the
+/// right variant by token prefix, forwards to the endpoint, and translates the
 /// Anthropic response back to OpenAI format. Structurally similar to
 /// `forward_anthropic`, but intentionally kept separate: it speaks OpenAI on
 /// both edges (request body already translated, response translated back).
@@ -11606,11 +11615,10 @@ async fn forward_openai_compat_anthropic(
     parts: &axum::http::request::Parts,
     ep: &Endpoint,
     endpoint_idx: usize,
-    // Translated Anthropic-shape bodies, serialized once by the caller and
-    // reused across rotations/retries (LAB-716). `Bytes` so the per-attempt
-    // body handoff is a refcount, not a re-serialization.
-    body_bytes: &bytes::Bytes,
-    oauth_body_bytes: &bytes::Bytes,
+    // Translated Anthropic-shape bodies, serialized once by the caller
+    // (LAB-716); each attempt clones the refcounted `Bytes`.
+    anthropic_body_bytes: &bytes::Bytes,
+    oauth_anthropic_body_bytes: &bytes::Bytes,
     req_id: &str,
     client_id: &str,
     client_ver: &str,
@@ -11660,9 +11668,9 @@ async fn forward_openai_compat_anthropic(
 
     // Use OAuth variant (with CC system prompt) for OAuth tokens
     let req_body = if token.starts_with("sk-ant-oat") {
-        oauth_body_bytes
+        oauth_anthropic_body_bytes
     } else {
-        body_bytes
+        anthropic_body_bytes
     };
     debug!(
         account = endpoint_name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7930,6 +7930,11 @@ async fn proxy_handler(
     // Upstream error from the most recent model-unsupported rejection —
     // returned verbatim if the pool exhausts on nothing but rejections.
     let mut model_unsupported_resp: Option<Response> = None;
+    // OpenAI-shape body, built lazily on the first OpenAI-endpoint attempt
+    // and reused across rotations/retries (LAB-716). Lazy so requests served
+    // entirely by Anthropic endpoints — the common case — never pay for the
+    // translation.
+    let mut openai_fallback_body: Option<FallbackBody> = None;
     for retry_round in 0..=MAX_529_RETRIES {
         if retry_round > 0 {
             let delay = round_backoff_delay(retry_round, last_saw_529);
@@ -7976,20 +7981,44 @@ async fn proxy_handler(
                                 (out, i)
                             }
                             Protocol::OpenAI => {
-                                let out = try_fallback_upstream(
-                                    &state,
-                                    &body_bytes,
-                                    &req_id,
-                                    &client_id,
-                                    &client_ip,
-                                    &agent_id,
-                                    &session_id,
-                                    &model,
-                                    i,
-                                    request_start,
-                                    true,
-                                )
-                                .await;
+                                let out = match openai_fallback_body
+                                    .get_or_insert_with(|| build_openai_fallback_body(&body_bytes))
+                                {
+                                    FallbackBody::Ready { body, is_streaming } => {
+                                        try_fallback_upstream(
+                                            &state,
+                                            body,
+                                            &req_id,
+                                            &client_id,
+                                            &client_ip,
+                                            &agent_id,
+                                            &session_id,
+                                            &model,
+                                            i,
+                                            request_start,
+                                            true,
+                                            *is_streaming,
+                                        )
+                                        .await
+                                    }
+                                    FallbackBody::Unparseable => ForwardOutcome::Retry {
+                                        saw_529: false,
+                                        push_skip: true,
+                                        transient: false,
+                                    },
+                                    FallbackBody::Untranslatable(msg) => {
+                                        warn!(
+                                            req_id,
+                                            upstream = ep.name,
+                                            error = %msg,
+                                            "fallback: request not representable in OpenAI format"
+                                        );
+                                        // Terminal, not a retry: the request itself
+                                        // is the problem, so rotating would fail the
+                                        // same way on every endpoint.
+                                        ForwardOutcome::Done(untranslatable_request_response(msg))
+                                    }
+                                };
                                 (out, i)
                             }
                         }
@@ -8058,6 +8087,48 @@ async fn proxy_handler(
 
 // ── Fallback upstream handler ────────────────────────────────────────
 
+/// Anthropic→OpenAI request body for `try_fallback_upstream`, built lazily by
+/// `proxy_handler` on the first OpenAI-endpoint attempt of a request and
+/// memoized across rotations/retries (LAB-716) — previously the parse +
+/// translate + serialize ran inside the retry loop, once per attempt, peaking
+/// exactly when the pool was retrying hardest.
+enum FallbackBody {
+    /// Translated + serialized once; `is_streaming` read from the same parse.
+    Ready {
+        body: bytes::Bytes,
+        is_streaming: bool,
+    },
+    /// Request JSON didn't parse (or couldn't re-serialize) — rotate past
+    /// OpenAI endpoints; Anthropic endpoints still forward the raw bytes and
+    /// let the upstream reject them.
+    Unparseable,
+    /// Parsed but not representable in OpenAI format — terminal for the
+    /// request: rotating would fail identically on every endpoint.
+    Untranslatable(String),
+}
+
+fn build_openai_fallback_body(body_bytes: &[u8]) -> FallbackBody {
+    let parsed: serde_json::Value = match serde_json::from_slice(body_bytes) {
+        Ok(v) => v,
+        Err(_) => return FallbackBody::Unparseable,
+    };
+    let is_streaming = parsed
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
+    let openai_body = match translate_anthropic_request_to_openai(&parsed) {
+        Ok(v) => v,
+        Err(msg) => return FallbackBody::Untranslatable(msg),
+    };
+    match serde_json::to_vec(&openai_body) {
+        Ok(b) => FallbackBody::Ready {
+            body: b.into(),
+            is_streaming,
+        },
+        Err(_) => FallbackBody::Unparseable,
+    }
+}
+
 /// Forward a request to a `Protocol::OpenAI` endpoint. For Anthropic-format
 /// callers (`proxy_handler`) it translates the request to OpenAI format and the
 /// response back (`translate = true`); for OpenAI-format callers
@@ -8078,7 +8149,10 @@ async fn proxy_handler(
 #[allow(clippy::too_many_arguments)]
 async fn try_fallback_upstream(
     state: &AppState,
-    body_bytes: &[u8],
+    // Final wire body (already OpenAI-shaped): translated + serialized at
+    // most once by the caller and reused across rotations/retries (LAB-716).
+    // `Bytes` so the per-attempt body handoff is a refcount, not a copy.
+    request_body: &bytes::Bytes,
     req_id: &str,
     client_id: &str,
     client_ip: &std::net::IpAddr,
@@ -8087,7 +8161,8 @@ async fn try_fallback_upstream(
     model: &str,
     endpoint_idx: usize,
     request_start: std::time::Instant,
-    translate: bool, // true = Anthropic↔OpenAI translation needed
+    translate: bool, // true = upstream response needs OpenAI→Anthropic translation
+    is_streaming: bool,
 ) -> ForwardOutcome {
     // Non-transient rotation: skip this endpoint and try the next candidate.
     // Pre-dates the ForwardOutcome return type as a bare `None`.
@@ -8109,40 +8184,6 @@ async fn try_fallback_upstream(
 
     ep.requests.fetch_add(1, Ordering::Relaxed);
 
-    // Parse once to extract streaming flag before potential translation
-    let parsed: serde_json::Value = match serde_json::from_slice(body_bytes) {
-        Ok(v) => v,
-        Err(_) => return ROTATE,
-    };
-    let is_streaming = parsed
-        .get("stream")
-        .and_then(|s| s.as_bool())
-        .unwrap_or(false);
-
-    // Build request body
-    let request_body = if translate {
-        let openai_body = match translate_anthropic_request_to_openai(&parsed) {
-            Ok(v) => v,
-            Err(msg) => {
-                warn!(
-                    req_id,
-                    upstream = ep.name,
-                    error = %msg,
-                    "fallback: request not representable in OpenAI format"
-                );
-                // Terminal, not a retry: the request itself is the problem, so
-                // rotating to another endpoint would just fail the same way.
-                return ForwardOutcome::Done(untranslatable_request_response(&msg));
-            }
-        };
-        match serde_json::to_vec(&openai_body) {
-            Ok(b) => b,
-            Err(_) => return ROTATE,
-        }
-    } else {
-        body_bytes.to_vec()
-    };
-
     let url = format!("{}/v1/chat/completions", ep.base_url);
 
     // Same non-streaming read_timeout exemption as forward_anthropic (LAB-718).
@@ -8155,7 +8196,7 @@ async fn try_fallback_upstream(
         .post(&url)
         .header("authorization", format!("Bearer {}", ep.token))
         .header("content-type", "application/json")
-        .body(request_body)
+        .body(request_body.clone())
         .send()
         .await
     {
@@ -10961,12 +11002,24 @@ fn anthropic_user_blocks_to_openai_content(
     })
 }
 
+// Test-only invocation counter for `translate_anthropic_request_to_openai`
+// (LAB-716 AC: translation must run at most once per request, not per retry
+// attempt). Thread-local: `#[tokio::test]` defaults to a current-thread
+// runtime on the test's own thread, so parallel tests can't cross-pollute.
+#[cfg(test)]
+thread_local! {
+    static TRANSLATE_A2O_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 /// Err (with a client-facing message) when a message contains an image this
 /// translator can't represent faithfully — the caller must surface a real
 /// error instead of silently forwarding a request with the image dropped.
 fn translate_anthropic_request_to_openai(
     body: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
+    #[cfg(test)]
+    TRANSLATE_A2O_CALLS.with(|c| c.set(c.get() + 1));
+
     let mut out = serde_json::Map::new();
 
     if let Some(model) = body.get("model") {
@@ -11553,8 +11606,11 @@ async fn forward_openai_compat_anthropic(
     parts: &axum::http::request::Parts,
     ep: &Endpoint,
     endpoint_idx: usize,
-    anthropic_body: &serde_json::Value,
-    oauth_anthropic_body: &serde_json::Value,
+    // Translated Anthropic-shape bodies, serialized once by the caller and
+    // reused across rotations/retries (LAB-716). `Bytes` so the per-attempt
+    // body handoff is a refcount, not a re-serialization.
+    body_bytes: &bytes::Bytes,
+    oauth_body_bytes: &bytes::Bytes,
     req_id: &str,
     client_id: &str,
     client_ver: &str,
@@ -11604,15 +11660,14 @@ async fn forward_openai_compat_anthropic(
 
     // Use OAuth variant (with CC system prompt) for OAuth tokens
     let req_body = if token.starts_with("sk-ant-oat") {
-        oauth_anthropic_body
+        oauth_body_bytes
     } else {
-        anthropic_body
+        body_bytes
     };
-    let body_str = req_body.to_string();
     debug!(
         account = endpoint_name,
         model = %model,
-        body_len = body_str.len(),
+        body_len = req_body.len(),
         "openai-compat: upstream request"
     );
 
@@ -11625,7 +11680,7 @@ async fn forward_openai_compat_anthropic(
     let upstream_req = http_client
         .request(reqwest::Method::POST, &url)
         .headers(headers)
-        .body(body_str);
+        .body(req_body.clone());
 
     let resp = match upstream_req.send().await {
         Ok(r) => r,
@@ -12113,6 +12168,26 @@ async fn openai_chat_handler(
     let mut oauth_anthropic_body = anthropic_body.clone();
     inject_oauth_system_prompt(&mut oauth_anthropic_body);
 
+    // Serialize both variants once (LAB-716): the forward helper used to
+    // `to_string()` the JSON on every retry attempt; now each attempt clones
+    // a refcounted `Bytes`. Serializing a `Value` can only fail on a
+    // non-string map key, which JSON input can't produce — the 500 arm is a
+    // formality.
+    let (anthropic_body_bytes, oauth_body_bytes) = match (
+        serde_json::to_vec(&anthropic_body),
+        serde_json::to_vec(&oauth_anthropic_body),
+    ) {
+        (Ok(a), Ok(o)) => (bytes::Bytes::from(a), bytes::Bytes::from(o)),
+        _ => {
+            error!(req_id, "failed to serialize translated request body");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "body serialization failed",
+            )
+                .into_response();
+        }
+    };
+
     let n = state.endpoints.len();
     let mut last_saw_529 = false;
     let mut last_saw_transient = false;
@@ -12148,8 +12223,8 @@ async fn openai_chat_handler(
                                     &parts,
                                     ep,
                                     i,
-                                    &anthropic_body,
-                                    &oauth_anthropic_body,
+                                    &anthropic_body_bytes,
+                                    &oauth_body_bytes,
                                     &req_id,
                                     &client_id,
                                     &client_ver,
@@ -12180,6 +12255,7 @@ async fn openai_chat_handler(
                                     i,
                                     request_start,
                                     false,
+                                    is_streaming,
                                 )
                                 .await;
                                 (out, i)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14137,10 +14137,11 @@ async fn try_fallback_upstream_rotates_on_429() {
     ep.base_url = format!("http://{}", addr);
     Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
 
-    let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+    let body =
+        bytes::Bytes::from_static(br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#);
     let result = try_fallback_upstream(
         &state,
-        body,
+        &body,
         "req-1",
         "client-1",
         &"127.0.0.1".parse().unwrap(),
@@ -14149,6 +14150,7 @@ async fn try_fallback_upstream_rotates_on_429() {
         "claude-opus-4-7",
         0,
         Instant::now(),
+        false,
         false,
     )
     .await;
@@ -14181,10 +14183,11 @@ async fn try_fallback_upstream_rotates_on_500() {
     ep.base_url = format!("http://{}", addr);
     Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
 
-    let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+    let body =
+        bytes::Bytes::from_static(br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#);
     let result = try_fallback_upstream(
         &state,
-        body,
+        &body,
         "req-1",
         "client-1",
         &"127.0.0.1".parse().unwrap(),
@@ -14193,6 +14196,7 @@ async fn try_fallback_upstream_rotates_on_500() {
         "claude-opus-4-7",
         0,
         Instant::now(),
+        false,
         false,
     )
     .await;
@@ -14220,10 +14224,11 @@ async fn try_fallback_upstream_transport_error_is_transient_and_counted() {
     ep.base_url = url;
     Arc::get_mut(&mut state).unwrap().endpoints.push(ep);
 
-    let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+    let body =
+        bytes::Bytes::from_static(br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#);
     let result = try_fallback_upstream(
         &state,
-        body,
+        &body,
         "req-1",
         "client-1",
         &"127.0.0.1".parse().unwrap(),
@@ -14232,6 +14237,7 @@ async fn try_fallback_upstream_transport_error_is_transient_and_counted() {
         "claude-opus-4-7",
         0,
         Instant::now(),
+        false,
         false,
     )
     .await;
@@ -14292,10 +14298,11 @@ async fn try_fallback_upstream_records_usage_and_budget() {
 
     assert!(state.check_budget("client-1").await.is_ok());
 
-    let body = br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#;
+    let body =
+        bytes::Bytes::from_static(br#"{"model":"claude-opus-4-7","messages":[],"max_tokens":1}"#);
     let result = try_fallback_upstream(
         &state,
-        body,
+        &body,
         "req-1",
         "client-1",
         &"127.0.0.1".parse().unwrap(),
@@ -14305,6 +14312,7 @@ async fn try_fallback_upstream_records_usage_and_budget() {
         0,
         Instant::now(),
         true,
+        false,
     )
     .await;
     assert!(matches!(result, ForwardOutcome::Done(_)));
@@ -14458,6 +14466,131 @@ async fn proxy_handler_translates_to_openai_endpoint() {
         "translated request must have OpenAI `messages` field"
     );
     assert_eq!(received["model"], "claude-opus-4-7");
+}
+
+/// LAB-716: request translation must run at most ONCE per request, not once
+/// per retry attempt. Two OpenAI endpoints; the preferred one 500s so the
+/// retry loop rotates to the second — both attempts must reuse one translated
+/// body (asserted byte-identical) with a single translate invocation.
+/// Relies on `#[tokio::test]`'s current-thread runtime: the handler runs on
+/// this test's thread, so the thread-local counter sees exactly this request.
+#[tokio::test]
+async fn proxy_handler_translates_once_across_endpoint_rotation() {
+    // Failing upstream: captures the raw body, then 500s → rotate.
+    let (bad_tx, mut bad_rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(1);
+    let bad_app = Router::new().fallback(any(move |req: Request<Body>| {
+        let tx = bad_tx.clone();
+        async move {
+            let bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let _ = tx.send(bytes).await;
+            (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response()
+        }
+    }));
+    let bad_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let bad_addr = bad_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(bad_listener, bad_app).await.unwrap();
+    });
+
+    // Healthy upstream: captures the raw body, returns an OpenAI response.
+    let (ok_tx, mut ok_rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(1);
+    let ok_app = Router::new().fallback(any(move |req: Request<Body>| {
+        let tx = ok_tx.clone();
+        async move {
+            let bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let _ = tx.send(bytes).await;
+            (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({
+                    "id": "chatcmpl-x",
+                    "object": "chat.completion",
+                    "model": "claude-opus-4-7",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "hi back"},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+                })),
+            )
+                .into_response()
+        }
+    }));
+    let ok_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let ok_addr = ok_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(ok_listener, ok_app).await.unwrap();
+    });
+
+    // Priority 0 = failing endpoint picked first; priority 100 = healthy
+    // rotation target (deterministic ordering, same trick as LAB-365).
+    let mut state = test_state_with(vec![]);
+    let mut bad_ep = make_endpoint("bad-gw", Protocol::OpenAI);
+    bad_ep.base_url = format!("http://{}", bad_addr);
+    let mut ok_ep = make_endpoint("ok-gw", Protocol::OpenAI);
+    ok_ep.base_url = format!("http://{}", ok_addr);
+    ok_ep.priority = 100;
+    {
+        let s = Arc::get_mut(&mut state).unwrap();
+        s.endpoints.push(bad_ep);
+        s.endpoints.push(ok_ep);
+    }
+
+    let proxy_app = Router::new().fallback(any(proxy_handler)).with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            proxy_app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let calls_before = TRANSLATE_A2O_CALLS.with(|c| c.get());
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{}/v1/messages", proxy_addr))
+        .json(&serde_json::json!({
+            "model": "claude-opus-4-7",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hi"}],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "rotation to the healthy endpoint must succeed"
+    );
+
+    let calls_after = TRANSLATE_A2O_CALLS.with(|c| c.get());
+    assert_eq!(
+        calls_after - calls_before,
+        1,
+        "translation must run exactly once for a 2-endpoint retry, not per attempt"
+    );
+
+    // Both attempts must send the SAME wire body (memoized Bytes reused).
+    let bad_body = bad_rx
+        .recv()
+        .await
+        .expect("failing endpoint got the request");
+    let ok_body = ok_rx
+        .recv()
+        .await
+        .expect("healthy endpoint got the rotation");
+    assert_eq!(
+        bad_body, ok_body,
+        "rotated attempt must reuse the identical serialized body"
+    );
 }
 
 // ── Connection resilience: synthetic SSE error on upstream disconnect ──


### PR DESCRIPTION
Fixes #100 / LAB-716.

## Problem
The OpenAI-path forward helpers redid request-shaping work inside the retry loop, once per endpoint attempt:

- `try_fallback_upstream` re-parsed the request JSON, re-ran `translate_anthropic_request_to_openai`, and re-serialized **per attempt** (even passthrough re-parsed just to read the `stream` flag) — O(attempts) full-body work that peaked exactly when the pool was retrying hardest.
- `forward_openai_compat_anthropic` called `req_body.to_string()` per attempt — a full re-serialization of a potentially large (auto-cached, OAuth-variant) body on every rotation.

## Change (perf-only; behaviour across rotations/retries unchanged)
- `try_fallback_upstream` now takes the final wire body as `Bytes` plus the pre-computed `is_streaming` flag; each attempt clones a refcounted buffer. `translate` now governs only response-direction translation.
- `proxy_handler` builds the translated body **lazily** (`FallbackBody` memo) on the first OpenAI-endpoint attempt — Anthropic-only requests never pay for translation. Unparseable JSON still rotates (now with a `warn!`); untranslatable requests still return the terminal 400.
- `openai_chat_handler` serializes the plain + OAuth Anthropic variants **once** before the retry loop and passes `Bytes` to `forward_openai_compat_anthropic` (params renamed to `anthropic_body_bytes`/`oauth_anthropic_body_bytes`).
- `ROTATE` hoisted to module scope next to `ForwardOutcome` (was duplicated).

## Acceptance criteria
- [x] Parse + translate at most once per request — new test `proxy_handler_translates_once_across_endpoint_rotation` asserts exactly one translate invocation across a 2-endpoint rotation (thread-local `#[cfg(test)]` counter; current-thread test runtime isolates it), plus byte-identical bodies received by both endpoints.
- [x] Serialization once per variant, passed as `Bytes`; no per-attempt `to_string()`.
- [x] Behaviour unchanged — all 643 existing tests pass unmodified in semantics (the 4 direct `try_fallback_upstream` tests only updated for the new signature).

## Behavioural footnote
For unparseable/untranslatable bodies the old code bumped `ep.requests` and logged "routing to unified OpenAI endpoint" before bailing; the memo now short-circuits before the helper, so doomed attempts that never sent a request no longer count. `ep.requests` feeds stats only, not routing.

## Review
Expert panel (bug-hunter, security, craftsman, catchphrase) run at high stakes: bug-hunter + security **NO FINDINGS** (bodies verified byte-identical, memo per-request local, no token/variant cross-wiring); craftsman's doc-drift + observability findings and catchphrase's comment-dedup all applied in the second commit.

Gates: `cargo fmt --check`, `clippy -Dwarnings --all-targets`, `cargo test` (613+18+12 pass) — all green locally.
