### PR TITLE
fix(LAB-1675): unbrick the release pipeline — rustls, vX.Y.Z tags, decoupled publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,12 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
+# Least privilege per job (LAB-1675 panel finding): validate/build execute
+# arbitrary dependency build.rs code via cargo — they must not inherit the
+# ability to mint an OIDC publish token or write to the repo. Each job
+# declares exactly what it needs below.
 permissions:
-  id-token: write
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -74,6 +77,9 @@ jobs:
     needs: validate
     runs-on: ${{ matrix.runner }}
     strategy:
+      # One exotic target failing must not cancel the siblings — we want the
+      # full failure picture in one run (LAB-1675/#132).
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -102,7 +108,7 @@ jobs:
       - name: Install cross-compilation tools
         if: matrix.cross
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross
+          cargo install cross --locked --version 0.2.5
           sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
 
       - name: Build
@@ -138,18 +144,20 @@ jobs:
             anthropic-lb-*.tar.gz
             anthropic-lb-*.tar.gz.sha256
 
-  release:
-    name: Release
-    needs: [validate, build]
+  # Publish gates on Validate only, NOT the binary matrix (LAB-1675/#132):
+  # with "require trusted publishing" ON this workflow is the only publish
+  # path, and a tag-triggered run can't be re-run against a fixed workflow —
+  # so an exotic cross-target failure must not permanently strand a version.
+  # Binaries are convenience artifacts; the source release is the product.
+  publish:
+    name: Publish to crates.io
+    needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          path: artifacts
-          merge-multiple: true
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
@@ -161,6 +169,23 @@ jobs:
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io.outputs.token }}
+
+  upload-artifacts:
+    name: Upload release artifacts
+    needs: [validate, build]
+    # Run even when a build leg failed (needs-semantics would otherwise skip
+    # this job entirely): upload whatever binaries DID build. All-legs-failed
+    # leaves download-artifact with nothing and fails the job — honest red.
+    if: ${{ !cancelled() && needs.validate.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: artifacts
+          merge-multiple: true
 
       # release-please already created the release for this tag with the
       # CHANGELOG section as its body — only upload artifacts here. Passing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,9 @@ which triggers `release.yml` (build + crates.io) and `docker.yml`.
   must keep `chore(main): release` in its Ignored Title Keywords (Kodus
   console → Settings → Code Review → General); there is no in-repo config
   for this unless the console's config-file override is enabled.
-- **crates.io requires trusted publishing** — a green `release.yml` publish
-  job is the only publish path; there is no manual token fallback. The
-  publish job deliberately gates on `validate` only, not the binary matrix.
+- **crates.io requires trusted publishing** — a green `release.yml` `publish`
+  job is the only publishing path; there is no manual token fallback. The
+  `publish` job deliberately gates on `validate` only, not the binary matrix.
 
 ## Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,15 @@ which triggers `release.yml` (build + crates.io) and `docker.yml`.
   `Release-As: 1.0.0` footer, then drop `bump-minor-pre-major` and
   `bump-patch-for-minor-pre-major` from `release-please-config.json`
   (`prerelease: true` is inert at major ≥ 1 and can stay).
+- **Release PR bodies are machine-parsed** — release-please reads its own
+  PR body on merge to create the tag; any bot that rewrites PR descriptions
+  breaks the release (LAB-1675/#132: Kody did exactly this to #126). Kody
+  must keep `chore(main): release` in its Ignored Title Keywords (Kodus
+  console → Settings → Code Review → General); there is no in-repo config
+  for this unless the console's config-file override is enabled.
+- **crates.io requires trusted publishing** — a green `release.yml` publish
+  job is the only publish path; there is no manual token fallback. The
+  publish job deliberately gates on `validate` only, not the binary matrix.
 
 ## Deployment
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,15 +580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,21 +623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,7 +650,7 @@ dependencies = [
  "rand 0.8.7",
  "redis-protocol",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "semver",
  "socket2 0.5.10",
  "tokio",
@@ -967,27 +953,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1008,11 +979,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1290,23 +1259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,47 +1324,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.115"
+name = "openssl-probe"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -1454,12 +1375,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polyval"
@@ -1714,7 +1629,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
@@ -1723,23 +1637,20 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -1826,11 +1737,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -1897,7 +1820,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2149,27 +2085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,16 +2183,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2591,12 +2496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,35 +2631,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,17 @@ categories = ["network-programming", "web-programming"]
 axum = "0.8"
 hyper = { version = "1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json", "stream"] }
+# rustls, not native-tls (LAB-1675/#132): openssl-sys can't build in the cross
+# container (aarch64 release leg), and fred/cachekit-rs already run on
+# rustls-ring. Defaults are off to drop it (this also drops system-proxy:
+# env-var HTTPS_PROXY still works everywhere, only macOS/Windows OS-level
+# proxy lookup is lost); http2 is required (the client builder sets
+# http2_keep_alive_*). native-roots keeps operator-added system CAs working
+# for openai-protocol upstreams — NOTE the effective trust store is the
+# UNION of system roots and the Mozilla webpki bundle, because cachekit-rs
+# enables reqwest/rustls-tls (webpki) and cargo features unify. rustls has
+# no CN fallback: upstream certs must carry SANs.
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "http2", "rustls-tls-native-roots"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
+  "include-component-in-tag": false,
   "bootstrap-sha": "f0ac4d93cf7da15452387781fdaaf24344911d64",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
Fixes the three independent defects that have made every tag→crates.io publish attempt fail (post-mortem in #132; Multica ticket LAB-1675). Closes #132.

## The fixes

**1. Tag format (defect 2, live-confirmed on 0.2.2):** `release-please-config.json` now sets `include-component-in-tag: false`. Release-please tagged `anthropic-lb-v0.2.2` on the [#131](https://github.com/27b-io/anthropic-lb/pull/131) merge, which matches neither `release.yml`'s `v[0-9]+.*` trigger nor `docker.yml`'s `v*` — the publish silently never fired. Next tags will be plain `vX.Y.Z`.

**2. aarch64/openssl (defect 3):** reqwest swaps `native-tls` → `rustls-tls-native-roots` with default features off. `openssl-sys` cannot build in the `cross` container ([run 31231128795](https://github.com/27b-io/anthropic-lb/actions/runs/31231128795)); fred and cachekit-rs were already on rustls-ring, so native-tls was a second, redundant TLS stack — `openssl-sys`, `native-tls`, `hyper-tls`, and `encoding_rs` all leave the tree (lockfile −130 lines). `http2` is kept explicitly (the client builder sets `http2_keep_alive_*`); `native-roots` preserves the system CA store behaviour native-tls had. Note for review: the effective trust store is the union of system roots and the Mozilla webpki bundle (cachekit-rs enables `reqwest/rustls-tls`; cargo features unify), and rustls has no CN fallback — upstream certs must carry SANs.

**3. Publish decoupled from the binary matrix:** with crates.io "require trusted publishing" ON, a green `release.yml` is the *only* publish path, and a tag-triggered run cannot be re-run against a fixed workflow — so one exotic cross-target failure permanently strands a version. The crates.io publish job now gates on `validate` only (fmt, clippy `-Dwarnings`, full test suite). The binary matrix gets `fail-fast: false`, and artifact upload now runs on partial matrix success instead of being skipped when any leg fails.

**Expert-panel hardening** (mandatory review gate for the TLS change — 4-agent panel, high stakes): per-job least-privilege `permissions` (validate/build execute arbitrary dependency `build.rs` code and no longer inherit `id-token: write` / `contents: write`); `cargo install cross` pinned to 0.2.5 (was floating git HEAD).

**Defect 1 (Kody rewriting release PR bodies)** is a Kodus console setting — no repo file can carry it by default. Documented in CLAUDE.md; the one-click for @ray is in the ticket.

## Verification

- 642 tests green, `cargo fmt --check` + `clippy -Dwarnings` clean.
- **aarch64 cross build reproduced green locally** via podman with `cross` 0.2.5 and this exact feature set (the previously failing leg): `Finished release [optimized]`, valid ARM aarch64 ELF produced.
- `cargo tree -i openssl-sys` / `-i native-tls` / `-i encoding_rs`: no matches, on both host and aarch64 target graphs.
- Workflow YAML validated.

## Recovery of 0.2.2 (recommended follow-up, Ray's call)

crates.io is still at 0.1.0 and there is no `v0.2.2` tag for release-please to anchor on (only `anthropic-lb-v0.2.2`), so the next release PR would double-count 0.2.2's commits. After this PR merges (squash commit = `M`, Cargo.toml still 0.2.2):

```
git tag v0.2.2 M && git push origin v0.2.2
```

That single tag push (a) runs the fixed workflow and publishes **0.2.2 as the first crates.io version** — the end-to-end proof this ticket demands, (b) gives release-please its anchor so the next release PR computes only post-0.2.2 commits. Optional cleanup first: delete the superseded `anthropic-lb-v0.2.2` GitHub release + tag (nothing consumes them) so 0.2.2 ends up with exactly one release carrying the artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Improved release publishing reliability with clearer validation and artifact-upload stages.
  * Builds can continue independently, allowing available release artifacts to be uploaded even if some builds fail.
  * Publishing now uses more secure, restricted permissions.
  * Added documentation for release preparation and trusted package publishing.

* **Configuration**
  * Improved HTTP client configuration for JSON, streaming, HTTP/2 and Rustls TLS support.
  * Release tags now use a simplified naming format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Dependency security evidence (SCA — Kody rule 78)

`reqwest 0.12` feature change (`native-tls` → `default-features = false` + `json, stream, http2, rustls-tls-native-roots`); `Cargo.lock` is updated in this PR (resolves `reqwest 0.12.28`, 299 crates).

`cargo audit` (RustSec advisory-db, 1190 advisories, 2026-08-08) against the updated lockfile: **0 vulnerabilities**. One informational warning, pre-existing and untouched by this PR: [RUSTSEC-2025-0134](https://rustsec.org/advisories/RUSTSEC-2025-0134) (`rustls-pemfile 2.2.0` unmaintained, pulled via `fred 9.4.0` → `rustls-native-certs 0.7.3` — not on the reqwest path).

Net SCA effect of the change is subtractive: `openssl`, `openssl-sys`, `native-tls`, and `encoding_rs` leave the dependency tree entirely (only the pure-Rust `openssl-probe` cert-path locator remains, via rustls-native-certs), removing the C OpenSSL surface from future advisories.
