### PR TITLE
fix: propagate in-band upstream SSE errors in OpenAI-compat translators (LAB-710)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11416,10 +11416,13 @@ fn openai_error_frame(message: &str) -> bytes::Bytes {
 /// Returns Vec because one OpenAI chunk may produce multiple Anthropic events.
 /// `raw` is the raw SSE data line (after stripping "data: " prefix).
 fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) -> Vec<String> {
-    // After an in-band upstream error the Anthropic error frame is the final
-    // frame; drop whatever else the upstream sends (a trailing [DONE] would
-    // otherwise emit a message_stop — a success terminator after an error).
-    if ctx.upstream_error {
+    // Both terminators are final. After an in-band upstream error the
+    // Anthropic error frame is the last frame; drop whatever else the
+    // upstream sends (a trailing [DONE] would otherwise emit a message_stop —
+    // a success terminator after an error). Symmetrically, after
+    // `message_stop` nothing may follow — an in-band error line or stray
+    // delta arriving post-completion would violate the protocol the same way.
+    if ctx.upstream_error || ctx.message_stopped {
         return vec![];
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8311,7 +8311,10 @@ async fn try_fallback_upstream(
                                         }
                                     }
                                 }
-                                if client_gone {
+                                if client_gone || ctx.upstream_error {
+                                    // upstream_error: the in-band error frame
+                                    // just sent is the stream's final frame —
+                                    // stop draining so nothing can follow it.
                                     break;
                                 }
                             }
@@ -8344,7 +8347,7 @@ async fn try_fallback_upstream(
                                 client_gone = true;
                             }
                         }
-                        if client_gone {
+                        if client_gone || ctx.upstream_error {
                             break;
                         }
                     }
@@ -8359,6 +8362,10 @@ async fn try_fallback_upstream(
                         // forwarded — emitting it would ship a second `[DONE]`.
                         let msg = format!("upstream stream interrupted: {e}");
                         let frame = if translate_response {
+                            // Error frame is terminal: mark the ctx so the
+                            // post-loop buffer flush translates to nothing
+                            // instead of emitting frames after the error.
+                            ctx.upstream_error = true;
                             Some(anthropic_error_frame(&msg))
                         } else if !sent_done {
                             Some(openai_error_frame(&msg))
@@ -8397,7 +8404,7 @@ async fn try_fallback_upstream(
                 warn!(
                     req_id,
                     upstream = upstream_name,
-                    "fallback: unified endpoint stream ended with in-band upstream error"
+                    "fallback: unified endpoint stream ended with upstream error frame"
                 );
             } else {
                 info!(
@@ -10894,6 +10901,11 @@ fn translate_sse_event(raw: &str, ctx: &mut StreamContext) -> Option<String> {
                 .pointer("/error/message")
                 .and_then(|v| v.as_str())
                 .unwrap_or("upstream error");
+            warn!(
+                error_type = err_type,
+                error_message = err_msg,
+                "Anthropic upstream emitted in-band error event mid-stream"
+            );
             Some(openai_error_sse(&format!("{err_type}: {err_msg}")))
         }
         _ => None, // ping
@@ -11323,10 +11335,11 @@ struct ReverseStreamContext {
     block_index: i64,
     in_text_block: bool,
     in_tool_use: bool,
-    /// Upstream emitted an in-band `{"error": {...}}` data line. The
-    /// translator has already surfaced it as an Anthropic `event: error`
-    /// frame; everything after it (including `[DONE]` → `message_stop`) is
-    /// suppressed so no success terminator follows an error.
+    /// An Anthropic `event: error` frame has been sent downstream — either
+    /// translated from an in-band `{"error": {...}}` data line, or by the
+    /// stream loop on a transport failure. That frame is terminal: the
+    /// translator emits nothing once this is set (including `[DONE]` →
+    /// `message_stop`), so no success terminator can follow an error.
     upstream_error: bool,
 }
 
@@ -11354,7 +11367,7 @@ fn make_anthropic_event(event_type: &str, data: &serde_json::Value) -> String {
 /// ("socket closed unexpectedly"). Emits a single `event: error` frame; the
 /// Anthropic SSE protocol has no terminator analogous to OpenAI's `[DONE]`,
 /// so the channel may close naturally after this frame.
-fn anthropic_error_frame(message: &str) -> bytes::Bytes {
+fn anthropic_error_sse(message: &str) -> String {
     // `error.type` must be one of Anthropic's documented values
     // (overloaded_error, api_error, invalid_request_error, ...). Using a
     // custom type like "upstream_error" risks the SDK rejecting the frame
@@ -11365,7 +11378,12 @@ fn anthropic_error_frame(message: &str) -> bytes::Bytes {
         "type": "error",
         "error": { "type": "api_error", "message": message }
     });
-    bytes::Bytes::from(make_anthropic_event("error", &body))
+    make_anthropic_event("error", &body)
+}
+
+/// `anthropic_error_sse` as Bytes, for the raw stream-loop send paths.
+fn anthropic_error_frame(message: &str) -> bytes::Bytes {
+    bytes::Bytes::from(anthropic_error_sse(message))
 }
 
 /// Final-frame OpenAI SSE error for downstream. Emits the error JSON
@@ -11424,15 +11442,12 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
             Some(m) => m.to_string(),
             None => err.to_string(),
         };
-        // "api_error" is Anthropic's documented catch-all type (see
-        // anthropic_error_frame); the upstream detail lives in message.
-        return vec![make_anthropic_event(
-            "error",
-            &serde_json::json!({
-                "type": "error",
-                "error": {"type": "api_error", "message": format!("{err_type}: {err_msg}")}
-            }),
-        )];
+        warn!(
+            error_type = err_type,
+            error_message = err_msg,
+            "OpenAI upstream emitted in-band error mid-stream"
+        );
+        return vec![anthropic_error_sse(&format!("{err_type}: {err_msg}"))];
     }
 
     let mut events: Vec<String> = Vec::new();
@@ -11924,7 +11939,10 @@ async fn forward_openai_compat_anthropic(
                             }
 
                             if let Some(translated) = translate_sse_event(&event, &mut ctx) {
-                                if translated.trim() == "data: [DONE]" {
+                                // ends_with, not equality: the json_mode flush
+                                // and the in-band error frame both append the
+                                // terminator to another frame in one string.
+                                if translated.ends_with("data: [DONE]\n\n") {
                                     sent_done = true;
                                 }
                                 if ctx.upstream_error {
@@ -11934,7 +11952,6 @@ async fn forward_openai_compat_anthropic(
                                     // skip the buffer flush and the clean-[DONE]
                                     // guard, and finalize as a failure.
                                     upstream_error = true;
-                                    sent_done = true;
                                 }
                                 if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {
                                     client_gone = true;
@@ -11977,16 +11994,14 @@ async fn forward_openai_compat_anthropic(
                 let remaining = String::from_utf8_lossy(&buffer).into_owned();
                 if !remaining.trim().is_empty() {
                     if let Some(translated) = translate_sse_event(&remaining, &mut ctx) {
-                        if translated.trim() == "data: [DONE]" {
+                        if translated.ends_with("data: [DONE]\n\n") {
                             sent_done = true;
                         }
                         if ctx.upstream_error {
-                            // Error event arrived in the trailing buffer
-                            // (stream closed without a final \n\n) — same
-                            // rules as in-loop: its frame has [DONE], the
-                            // guard below must not add a clean one.
+                            // Error event in the trailing buffer (stream
+                            // closed without a final \n\n) — same rules as
+                            // in-loop.
                             upstream_error = true;
-                            sent_done = true;
                         }
                         if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {
                             client_gone = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8279,8 +8279,8 @@ async fn try_fallback_upstream(
             // Passthrough-only: tracks whether upstream's `[DONE]` terminator
             // has been forwarded verbatim, so an error frame on the next read
             // doesn't ship a second `[DONE]` and break strict OpenAI parsers.
-            // Not needed in the translate branch — translation converts
-            // `[DONE]` to `message_stop`, which has no analogous terminator.
+            // The translate branch tracks its equivalent (`message_stop`
+            // emitted) as `ctx.message_stopped`, set inside the translator.
             let mut sent_done = false;
             // Carries any partial trailing SSE line between chunks so the
             // `[DONE]` terminator is detected across resp.chunk() boundaries.
@@ -8357,20 +8357,20 @@ async fn try_fallback_upstream(
                         // Downstream protocol depends on whether we're translating:
                         // translate_response=true → /v1/messages client expects
                         // Anthropic SSE; translate_response=false → /v1/chat/completions
-                        // passthrough, downstream is the OpenAI SSE format. Skip
-                        // the openai error frame when `[DONE]` was already
-                        // forwarded — emitting it would ship a second `[DONE]`.
+                        // passthrough, downstream is the OpenAI SSE format.
                         let msg = format!("upstream stream interrupted: {e}");
                         // Error frame is terminal: mark the ctx so the
                         // post-loop buffer flush translates to nothing, no
                         // frame follows the error, and finalization logs the
-                        // stream as failed on both protocols. When `[DONE]`
-                        // already went out the client saw a complete stream —
-                        // no frame is sent and the stream stays a success.
-                        let frame = if translate_response {
+                        // stream as failed on both protocols. When the
+                        // success terminator already went out (`message_stop`
+                        // translated, or `[DONE]` forwarded verbatim) the
+                        // client saw a complete stream — no frame is sent and
+                        // the stream stays a success.
+                        let frame = if translate_response && !ctx.message_stopped {
                             ctx.upstream_error = true;
                             Some(anthropic_error_frame(&msg))
-                        } else if !sent_done {
+                        } else if !translate_response && !sent_done {
                             ctx.upstream_error = true;
                             Some(openai_error_frame(&msg))
                         } else {
@@ -11345,6 +11345,12 @@ struct ReverseStreamContext {
     /// translator emits nothing once this is set (including `[DONE]` →
     /// `message_stop`), so no success terminator can follow an error.
     upstream_error: bool,
+    /// The Anthropic success terminator (`message_stop`) has been emitted —
+    /// from a finish_reason chunk or a bare upstream `[DONE]`. The stream is
+    /// complete from the client's view; a later transport failure must not
+    /// ship an error frame after it (mirror of the passthrough `sent_done`
+    /// guard, one protocol over).
+    message_stopped: bool,
 }
 
 impl Default for ReverseStreamContext {
@@ -11357,6 +11363,7 @@ impl Default for ReverseStreamContext {
             in_text_block: false,
             in_tool_use: false,
             upstream_error: false,
+            message_stopped: false,
         }
     }
 }
@@ -11420,6 +11427,7 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
     if trimmed == "[DONE]" {
         // Only emit message_stop if we started a message
         if ctx.message_started {
+            ctx.message_stopped = true;
             return vec![make_anthropic_event(
                 "message_stop",
                 &serde_json::json!({"type": "message_stop"}),
@@ -11624,6 +11632,7 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
             &serde_json::json!({"type": "message_stop"}),
         ));
         ctx.message_started = false; // prevent duplicate from [DONE]
+        ctx.message_stopped = true;
     }
 
     events

--- a/src/main.rs
+++ b/src/main.rs
@@ -8374,6 +8374,11 @@ async fn try_fallback_upstream(
                             ctx.upstream_error = true;
                             Some(openai_error_frame(&msg))
                         } else {
+                            debug!(
+                                req_id,
+                                "fallback: transport error after success \
+                                 terminator — error frame suppressed"
+                            );
                             None
                         };
                         if let Some(frame) = frame {
@@ -11634,7 +11639,8 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
             "message_stop",
             &serde_json::json!({"type": "message_stop"}),
         ));
-        ctx.message_started = false; // prevent duplicate from [DONE]
+        // message_stopped's early-return keeps a trailing [DONE] (or anything
+        // else) from emitting a duplicate message_stop.
         ctx.message_stopped = true;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8393,11 +8393,19 @@ async fn try_fallback_upstream(
             if client_gone {
                 debug!(req_id, "fallback: client disconnected during stream");
             }
-            info!(
-                req_id,
-                upstream = upstream_name,
-                "fallback: unified endpoint stream complete"
-            );
+            if ctx.upstream_error {
+                warn!(
+                    req_id,
+                    upstream = upstream_name,
+                    "fallback: unified endpoint stream ended with in-band upstream error"
+                );
+            } else {
+                info!(
+                    req_id,
+                    upstream = upstream_name,
+                    "fallback: unified endpoint stream complete"
+                );
+            }
         });
 
         return ForwardOutcome::Done(
@@ -10281,6 +10289,12 @@ struct StreamContext {
     /// Text content buffered while `json_mode` is set, flushed fence-stripped
     /// at end-of-message so streaming content matches the non-streaming strip.
     text_buffer: String,
+    /// Upstream emitted an in-band `event: error` frame. The translator has
+    /// already surfaced it as an OpenAI error frame (which carries its own
+    /// `[DONE]`); the stream loop must stop translating and must NOT emit a
+    /// clean `[DONE]` afterwards — that would fake a successful completion
+    /// after a truncation.
+    upstream_error: bool,
 }
 
 impl Default for StreamContext {
@@ -10294,6 +10308,7 @@ impl Default for StreamContext {
             current_tool_id: String::new(),
             json_mode: false,
             text_buffer: String::new(),
+            upstream_error: false,
         }
     }
 }
@@ -10863,6 +10878,24 @@ fn translate_sse_event(raw: &str, ctx: &mut StreamContext) -> Option<String> {
                 None => Some("data: [DONE]\n\n".to_string()),
             }
         }
+        "error" => {
+            // In-band upstream failure (e.g. overloaded_error mid-stream).
+            // Surface it in the client's protocol instead of dropping it —
+            // dropping it made the stream end with a clean [DONE] after a
+            // silent truncation. The frame carries its own [DONE];
+            // ctx.upstream_error tells the stream loop to stop and skip the
+            // ensure-[DONE] guard.
+            ctx.upstream_error = true;
+            let err_type = parsed
+                .pointer("/error/type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("api_error");
+            let err_msg = parsed
+                .pointer("/error/message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("upstream error");
+            Some(openai_error_sse(&format!("{err_type}: {err_msg}")))
+        }
         _ => None, // ping
     }
 }
@@ -11290,6 +11323,11 @@ struct ReverseStreamContext {
     block_index: i64,
     in_text_block: bool,
     in_tool_use: bool,
+    /// Upstream emitted an in-band `{"error": {...}}` data line. The
+    /// translator has already surfaced it as an Anthropic `event: error`
+    /// frame; everything after it (including `[DONE]` → `message_stop`) is
+    /// suppressed so no success terminator follows an error.
+    upstream_error: bool,
 }
 
 impl Default for ReverseStreamContext {
@@ -11301,6 +11339,7 @@ impl Default for ReverseStreamContext {
             block_index: -1,
             in_text_block: false,
             in_tool_use: false,
+            upstream_error: false,
         }
     }
 }
@@ -11332,17 +11371,29 @@ fn anthropic_error_frame(message: &str) -> bytes::Bytes {
 /// Final-frame OpenAI SSE error for downstream. Emits the error JSON
 /// followed by `data: [DONE]` (OpenAI's stream terminator) — callers MUST
 /// NOT emit an additional `[DONE]` after this frame.
-fn openai_error_frame(message: &str) -> bytes::Bytes {
+fn openai_error_sse(message: &str) -> String {
     let err = serde_json::json!({
         "error": { "message": message, "type": "upstream_error" }
     });
-    bytes::Bytes::from(format!("data: {err}\n\ndata: [DONE]\n\n"))
+    format!("data: {err}\n\ndata: [DONE]\n\n")
+}
+
+/// `openai_error_sse` as Bytes, for the raw stream-loop send paths.
+fn openai_error_frame(message: &str) -> bytes::Bytes {
+    bytes::Bytes::from(openai_error_sse(message))
 }
 
 /// Translate an OpenAI SSE chunk to Anthropic SSE events.
 /// Returns Vec because one OpenAI chunk may produce multiple Anthropic events.
 /// `raw` is the raw SSE data line (after stripping "data: " prefix).
 fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) -> Vec<String> {
+    // After an in-band upstream error the Anthropic error frame is the final
+    // frame; drop whatever else the upstream sends (a trailing [DONE] would
+    // otherwise emit a message_stop — a success terminator after an error).
+    if ctx.upstream_error {
+        return vec![];
+    }
+
     let trimmed = raw.trim();
     if trimmed == "[DONE]" {
         // Only emit message_stop if we started a message
@@ -11359,6 +11410,30 @@ fn translate_openai_sse_to_anthropic(raw: &str, ctx: &mut ReverseStreamContext) 
         Ok(v) => v,
         Err(_) => return vec![],
     };
+
+    // In-band upstream error ({"error": {...}} data line). Without this it
+    // would fall through the missing-choices early-return and vanish — a
+    // not-yet-started message then ends as a 200 with an empty SSE body.
+    if let Some(err) = parsed.get("error").filter(|e| !e.is_null()) {
+        ctx.upstream_error = true;
+        let err_type = err
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("upstream_error");
+        let err_msg = match err.get("message").and_then(|v| v.as_str()) {
+            Some(m) => m.to_string(),
+            None => err.to_string(),
+        };
+        // "api_error" is Anthropic's documented catch-all type (see
+        // anthropic_error_frame); the upstream detail lives in message.
+        return vec![make_anthropic_event(
+            "error",
+            &serde_json::json!({
+                "type": "error",
+                "error": {"type": "api_error", "message": format!("{err_type}: {err_msg}")}
+            }),
+        )];
+    }
 
     let mut events: Vec<String> = Vec::new();
 
@@ -11852,13 +11927,25 @@ async fn forward_openai_compat_anthropic(
                                 if translated.trim() == "data: [DONE]" {
                                     sent_done = true;
                                 }
+                                if ctx.upstream_error {
+                                    // In-band `event: error` — the frame just
+                                    // translated carries its own [DONE]. Treat
+                                    // like a transport error: stop translating,
+                                    // skip the buffer flush and the clean-[DONE]
+                                    // guard, and finalize as a failure.
+                                    upstream_error = true;
+                                    sent_done = true;
+                                }
                                 if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {
                                     client_gone = true;
                                     break;
                                 }
+                                if upstream_error {
+                                    break;
+                                }
                             }
                         }
-                        if client_gone {
+                        if client_gone || upstream_error {
                             break;
                         }
                     }
@@ -11891,6 +11978,14 @@ async fn forward_openai_compat_anthropic(
                 if !remaining.trim().is_empty() {
                     if let Some(translated) = translate_sse_event(&remaining, &mut ctx) {
                         if translated.trim() == "data: [DONE]" {
+                            sent_done = true;
+                        }
+                        if ctx.upstream_error {
+                            // Error event arrived in the trailing buffer
+                            // (stream closed without a final \n\n) — same
+                            // rules as in-loop: its frame has [DONE], the
+                            // guard below must not add a clean one.
+                            upstream_error = true;
                             sent_done = true;
                         }
                         if tx.send(Ok(bytes::Bytes::from(translated))).await.is_err() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8361,13 +8361,17 @@ async fn try_fallback_upstream(
                         // the openai error frame when `[DONE]` was already
                         // forwarded — emitting it would ship a second `[DONE]`.
                         let msg = format!("upstream stream interrupted: {e}");
+                        // Error frame is terminal: mark the ctx so the
+                        // post-loop buffer flush translates to nothing, no
+                        // frame follows the error, and finalization logs the
+                        // stream as failed on both protocols. When `[DONE]`
+                        // already went out the client saw a complete stream —
+                        // no frame is sent and the stream stays a success.
                         let frame = if translate_response {
-                            // Error frame is terminal: mark the ctx so the
-                            // post-loop buffer flush translates to nothing
-                            // instead of emitting frames after the error.
                             ctx.upstream_error = true;
                             Some(anthropic_error_frame(&msg))
                         } else if !sent_done {
+                            ctx.upstream_error = true;
                             Some(openai_error_frame(&msg))
                         } else {
                             None

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3404,6 +3404,31 @@ fn translate_sse_tool_use_stop_reason() {
 }
 
 #[test]
+fn translate_sse_inband_error_emits_openai_error_frame() {
+    // LAB-710: an Anthropic `event: error` mid-stream must reach the OpenAI
+    // client as an error frame, not vanish into the `_ => None` arm.
+    let mut ctx = StreamContext::default();
+    let raw = "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}";
+    let result = translate_sse_event(raw, &mut ctx).unwrap();
+
+    // Flag set → stream loop finalizes as failure and skips the clean [DONE]
+    // guard (the error frame carries its own terminator).
+    assert!(ctx.upstream_error);
+
+    // Exactly one [DONE], and it belongs to the error frame itself.
+    assert_eq!(result.matches("[DONE]").count(), 1);
+    assert!(result.ends_with("data: [DONE]\n\n"));
+
+    let first_event = result.split("\n\n").next().unwrap();
+    let chunk: serde_json::Value =
+        serde_json::from_str(first_event.strip_prefix("data: ").unwrap()).unwrap();
+    assert_eq!(chunk["error"]["type"], "upstream_error");
+    let msg = chunk["error"]["message"].as_str().unwrap();
+    assert!(msg.contains("overloaded_error"));
+    assert!(msg.contains("Overloaded"));
+}
+
+#[test]
 fn translate_sse_text_block_start_skipped() {
     let mut ctx = StreamContext::default();
     let raw = "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}";
@@ -3883,6 +3908,58 @@ fn reverse_sse_no_duplicate_message_stop() {
     assert!(
         done_events.is_empty(),
         "DONE after finish_reason should emit nothing (message_stop already sent)"
+    );
+}
+
+#[test]
+fn reverse_sse_inband_error_before_message_start() {
+    // LAB-710: an in-band OpenAI {"error": {...}} line before any content
+    // must emit an Anthropic `event: error` frame — previously it hit the
+    // missing-choices early-return and the client got 200 + empty SSE body.
+    let mut ctx = ReverseStreamContext::default();
+    let events = translate_openai_sse_to_anthropic(
+        "{\"error\":{\"message\":\"The server had an error\",\"type\":\"server_error\"}}",
+        &mut ctx,
+    );
+    assert!(ctx.upstream_error);
+    assert_eq!(events.len(), 1);
+    assert!(events[0].starts_with("event: error\n"));
+    let data_line = events[0].lines().nth(1).unwrap();
+    let body: serde_json::Value =
+        serde_json::from_str(data_line.strip_prefix("data: ").unwrap()).unwrap();
+    assert_eq!(body["type"], "error");
+    assert_eq!(body["error"]["type"], "api_error");
+    let msg = body["error"]["message"].as_str().unwrap();
+    assert!(msg.contains("server_error"));
+    assert!(msg.contains("The server had an error"));
+
+    // No fake success terminator: trailing [DONE] after the error emits nothing.
+    let after = translate_openai_sse_to_anthropic("[DONE]", &mut ctx);
+    assert!(after.is_empty());
+}
+
+#[test]
+fn reverse_sse_inband_error_mid_message_suppresses_message_stop() {
+    // Error arriving after content started: error frame is final — no
+    // message_stop may follow it, even if the upstream still sends [DONE].
+    let mut ctx = ReverseStreamContext::default();
+    translate_openai_sse_to_anthropic(
+        "{\"id\":\"chatcmpl-1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}",
+        &mut ctx,
+    );
+    assert!(ctx.message_started);
+
+    let err_events = translate_openai_sse_to_anthropic(
+        "{\"error\":{\"message\":\"overloaded\",\"type\":\"server_error\"}}",
+        &mut ctx,
+    );
+    assert_eq!(err_events.len(), 1);
+    assert!(err_events[0].starts_with("event: error\n"));
+
+    let done_events = translate_openai_sse_to_anthropic("[DONE]", &mut ctx);
+    assert!(
+        done_events.is_empty(),
+        "no message_stop may follow an in-band error frame"
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3933,6 +3933,18 @@ fn reverse_sse_message_stopped_set_by_both_terminator_paths() {
     );
     assert!(ctx.message_stopped, "finish_reason emitted message_stop");
 
+    // message_stop is terminal inside the translator too: an in-band error
+    // line (or stray delta) arriving post-completion must emit nothing.
+    let after = translate_openai_sse_to_anthropic(
+        "{\"error\":{\"message\":\"late\",\"type\":\"server_error\"}}",
+        &mut ctx,
+    );
+    assert!(
+        after.is_empty(),
+        "no frame may follow message_stop, got: {after:?}"
+    );
+    assert!(!ctx.upstream_error);
+
     let mut ctx = ReverseStreamContext::default();
     translate_openai_sse_to_anthropic(
         "{\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3916,6 +3916,34 @@ fn reverse_sse_no_duplicate_message_stop() {
 }
 
 #[test]
+fn reverse_sse_message_stopped_set_by_both_terminator_paths() {
+    // LAB-710: `ctx.message_stopped` gates the transport-error frame — once
+    // the client has its `message_stop`, a later read failure must not ship
+    // an error frame. Both emit sites must set it: finish_reason (the normal
+    // case) and a bare [DONE] with no finish_reason seen.
+    let mut ctx = ReverseStreamContext::default();
+    translate_openai_sse_to_anthropic(
+        "{\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}",
+        &mut ctx,
+    );
+    assert!(!ctx.message_stopped);
+    translate_openai_sse_to_anthropic(
+        "{\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}",
+        &mut ctx,
+    );
+    assert!(ctx.message_stopped, "finish_reason emitted message_stop");
+
+    let mut ctx = ReverseStreamContext::default();
+    translate_openai_sse_to_anthropic(
+        "{\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}",
+        &mut ctx,
+    );
+    let done_events = translate_openai_sse_to_anthropic("[DONE]", &mut ctx);
+    assert!(done_events[0].contains("message_stop"));
+    assert!(ctx.message_stopped, "bare [DONE] emitted message_stop");
+}
+
+#[test]
 fn reverse_sse_inband_error_before_message_start() {
     // LAB-710: an in-band OpenAI {"error": {...}} line before any content
     // must emit an Anthropic `event: error` frame — previously it hit the
@@ -14178,6 +14206,90 @@ async fn proxy_handler_fallback_streaming() {
     assert!(
         body.contains("message_stop"),
         "should have message_stop event"
+    );
+}
+
+#[tokio::test]
+async fn fallback_translated_stream_no_error_frame_after_message_stop() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // LAB-710: a transport read failure AFTER the upstream's `[DONE]` must
+    // not ship an Anthropic error frame — the translated `message_stop`
+    // already terminated the stream from the client's view. Mirror of the
+    // passthrough `sent_done` guard, one protocol over.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mock_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 8192];
+        let _ = stream.read(&mut buf).await;
+        let head = "HTTP/1.1 200 OK\r\n\
+             content-type: text/event-stream\r\n\
+             transfer-encoding: chunked\r\n\
+             \r\n";
+        let _ = stream.write_all(head.as_bytes()).await;
+        let body = concat!(
+            "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let chunk = format!("{:x}\r\n{}\r\n", body.len(), body);
+        let _ = stream.write_all(chunk.as_bytes()).await;
+        // Drop WITHOUT the 0-length chunked terminator: the proxy's next
+        // resp.chunk() errors after message_stop already went downstream.
+        let _ = stream.shutdown().await;
+    });
+
+    let mut openai = make_endpoint("fallback", Protocol::OpenAI);
+    openai.base_url = format!("http://{}", mock_addr);
+    openai.priority = 100;
+    let state = Arc::new(AppState {
+        endpoints: vec![mk_endpoint("acct-a", "sk-ant-api-a"), openai],
+        state_path: PathBuf::from("/tmp/anthropic-lb-done-then-err-test.state.json"),
+        auto_cache: false,
+        ..test_state_base()
+    });
+    {
+        let mut info = state.endpoints[0].rate_info.write().await;
+        info.hard_limited_until = Some(Instant::now() + Duration::from_secs(3600));
+    }
+
+    let app = Router::new()
+        .fallback(any(proxy_handler))
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let resp = Client::new()
+        .post(format!("http://{}/v1/messages", addr))
+        .header("content-type", "application/json")
+        .json(&serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1024,
+            "stream": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.text().await.unwrap();
+
+    assert!(
+        body.contains("message_stop"),
+        "stream completed — must carry the success terminator, got: {body:?}"
+    );
+    assert!(
+        !body.contains("event: error"),
+        "no error frame may follow message_stop, got: {body:?}"
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3641,6 +3641,10 @@ fn json_mode_stream_message_stop_safety_net_flushes_buffer() {
     let content: serde_json::Value = serde_json::from_str(frames.next().unwrap()).unwrap();
     assert_eq!(content["choices"][0]["delta"]["content"], r#"{"ok":true}"#);
     assert_eq!(frames.next(), Some("[DONE]"));
+    // The stream loop detects the terminator with ends_with("data: [DONE]\n\n")
+    // — a combined frame that failed this would earn a second [DONE] from the
+    // post-loop guard (LAB-710 panel finding).
+    assert!(output.ends_with("data: [DONE]\n\n"));
 }
 
 // ── Reverse translation: Anthropic → OpenAI ──────────────────────


### PR DESCRIPTION
Closes #94 / LAB-710.

Both OpenAI-compat SSE translators dropped **in-band upstream error events**, surfacing only transport-level failures (LAB-708 audit finding):

- **A→O** (`translate_sse_event`): an Anthropic `event: error` mid-stream fell into the catch-all `None` arm; the ensure-`[DONE]` guard then emitted a clean terminator after a silent truncation.
- **O→A** (`translate_openai_sse_to_anthropic`): an in-band OpenAI `{"error":{...}}` data line hit the missing-`choices/0/delta` early-return; a not-yet-started message ended as a 200 with an empty SSE body.

## Fix

- **A→O**: new `"error"` arm emits an OpenAI error frame via `openai_error_sse()` (carries its own `[DONE]`), sets `ctx.upstream_error`; the stream loop breaks, skips the buffer flush and the clean-`[DONE]` guard, and finalizes with `upstream_error=true` (AC 1, 3).
- **O→A**: top-level `{"error":...}` emits an Anthropic `event: error` frame (`api_error` catch-all, upstream detail in the message) via a new `anthropic_error_sse()` split; once the flag is set the translator emits nothing further, so a trailing `[DONE]` cannot produce a `message_stop` success terminator (AC 2).
- Regression tests per direction: error frame emitted, exactly one `[DONE]` / no `message_stop` after the error (AC 4).

## Expert-panel findings applied (high-stakes review: bug-hunter, security, craftsman, catchphrase)

- O→A loop now **breaks** after any error frame, and the transport-`Err` arm shares the flag — an upstream that RSTs after its in-band error line no longer yields a second `event: error`, and the post-loop flush can never emit frames after an error.
- `warn!` with error type/message at both translator error arms — an upstream `overloaded_error` is now operator-visible.
- Pre-existing bug in the same machinery: `sent_done` used trim-equality, missing the json_mode combined content+`[DONE]` frame → double `[DONE]` from the post-loop guard. Now `ends_with("data: [DONE]\n\n")`, pinned by test.
- Security: no findings — upstream strings pass through `serde_json` (SSE framing injection impossible); no new leak class vs the existing transport-error frames.

Out of scope per ticket: transport-level handling (already correct), incremental usage (LAB-717), 429/cooldown (LAB-713).

Tests: 645 passing, clippy + fmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming translations now report upstream errors as terminal, protocol-specific error messages.
  * Prevented misleading success termination messages after a streaming error.
  * Preserved error details across supported translation directions.
  * Improved handling of failed stream completions and transport errors after successful termination.

* **Tests**
  * Added coverage for in-stream errors in both translation directions, including correct termination and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->